### PR TITLE
Bug/last will delivery

### DIFF
--- a/application/src/main/java/org/thingsboard/mqtt/broker/actors/client/ClientActor.java
+++ b/application/src/main/java/org/thingsboard/mqtt/broker/actors/client/ClientActor.java
@@ -386,6 +386,8 @@ public class ClientActor extends ContextAwareActor {
 
         long delay = state.isClientIdGenerated() ? TimeUnit.SECONDS.toMillis(actorConfiguration.getWaitBeforeGeneratedActorStopSeconds())
                 : TimeUnit.SECONDS.toMillis(actorConfiguration.getWaitBeforeNamedActorStopSeconds());
+        log.debug("[{}][{}][{}] Scheduling actor stop command with {} delay", state.getClientId(), state.getCurrentSessionId(),
+                state.getCurrentSessionState(), delay);
         systemContext.scheduleMsgWithDelay(ctx, stopActorCommandMsg, delay);
     }
 

--- a/application/src/main/java/org/thingsboard/mqtt/broker/actors/config/ActorsConfiguration.java
+++ b/application/src/main/java/org/thingsboard/mqtt/broker/actors/config/ActorsConfiguration.java
@@ -25,6 +25,7 @@ import org.thingsboard.mqtt.broker.actors.TbActorSystemSettings;
 
 @Configuration
 public class ActorsConfiguration {
+
     @Value("${actors.system.throughput:5}")
     private int actorThroughput;
     @Value("${actors.system.max-actor-init-attempts:10}")

--- a/application/src/main/java/org/thingsboard/mqtt/broker/util/MqttPropertiesUtil.java
+++ b/application/src/main/java/org/thingsboard/mqtt/broker/util/MqttPropertiesUtil.java
@@ -16,10 +16,10 @@
 package org.thingsboard.mqtt.broker.util;
 
 import io.netty.handler.codec.mqtt.MqttProperties;
+import org.thingsboard.mqtt.broker.common.data.BrokerConstants;
 import org.thingsboard.mqtt.broker.common.data.DevicePublishMsg;
 import org.thingsboard.mqtt.broker.common.data.mqtt.MsgExpiryResult;
 import org.thingsboard.mqtt.broker.common.data.util.BytesUtil;
-import org.thingsboard.mqtt.broker.common.data.BrokerConstants;
 import org.thingsboard.mqtt.broker.queue.TbQueueMsgHeaders;
 import org.thingsboard.mqtt.broker.queue.common.DefaultTbQueueMsgHeaders;
 import org.thingsboard.mqtt.broker.service.mqtt.PublishMsg;
@@ -117,6 +117,10 @@ public class MqttPropertiesUtil {
     public static Integer getPayloadFormatIndicatorValue(MqttProperties mqttProperties) {
         MqttProperties.IntegerProperty payloadFormatProperty = getPayloadFormatIndicatorProperty(mqttProperties);
         return payloadFormatProperty == null ? null : payloadFormatProperty.value();
+    }
+
+    public static MqttProperties.IntegerProperty getWillDelayProperty(MqttProperties mqttProperties) {
+        return (MqttProperties.IntegerProperty) mqttProperties.getProperty(BrokerConstants.WILL_DELAY_INTERVAL_PROP_ID);
     }
 
     public static MqttProperties.StringProperty getContentTypeProperty(MqttProperties mqttProperties) {

--- a/application/src/test/java/org/thingsboard/mqtt/broker/service/mqtt/will/DefaultLastWillServiceTest.java
+++ b/application/src/test/java/org/thingsboard/mqtt/broker/service/mqtt/will/DefaultLastWillServiceTest.java
@@ -21,8 +21,8 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.mockito.verification.VerificationMode;
-import org.thingsboard.mqtt.broker.common.data.SessionInfo;
 import org.thingsboard.mqtt.broker.common.data.BrokerConstants;
+import org.thingsboard.mqtt.broker.common.data.SessionInfo;
 import org.thingsboard.mqtt.broker.service.mqtt.PublishMsg;
 import org.thingsboard.mqtt.broker.service.mqtt.retain.RetainedMsgProcessor;
 import org.thingsboard.mqtt.broker.service.processing.MsgDispatcherService;
@@ -65,7 +65,7 @@ public class DefaultLastWillServiceTest {
 
         ScheduledExecutorService scheduledExecutorService = mock(ScheduledExecutorService.class);
         lastWillService.setScheduler(scheduledExecutorService);
-        doNothing().when(lastWillService).scheduleLastWill(any(), any(), anyInt());
+        doNothing().when(lastWillService).scheduleLastWill(any(), anyInt());
     }
 
     @Test
@@ -96,7 +96,7 @@ public class DefaultLastWillServiceTest {
     }
 
     private void verifyPersistPublishMsg(VerificationMode mode) {
-        verify(lastWillService, mode).scheduleLastWill(any(), any(), anyInt());
+        verify(lastWillService, mode).scheduleLastWill(any(), anyInt());
     }
 
     private void saveLastWillMsg() {

--- a/common/actor/src/main/java/org/thingsboard/mqtt/broker/actors/DefaultTbActorSystem.java
+++ b/common/actor/src/main/java/org/thingsboard/mqtt/broker/actors/DefaultTbActorSystem.java
@@ -210,6 +210,7 @@ public class DefaultTbActorSystem implements TbActorSystem {
         return new HashSet<>(actors.keySet());
     }
 
+    @Override
     public void destroy() {
         log.info("Stopping actor system dispatchers...");
         dispatchers.values().forEach(d -> ThingsBoardExecutors.shutdownAndAwaitTermination(d.getExecutor(), d.getDispatcherId()));

--- a/common/actor/src/main/java/org/thingsboard/mqtt/broker/actors/DefaultTbActorSystem.java
+++ b/common/actor/src/main/java/org/thingsboard/mqtt/broker/actors/DefaultTbActorSystem.java
@@ -211,9 +211,10 @@ public class DefaultTbActorSystem implements TbActorSystem {
     }
 
     public void destroy() {
-        log.info("Stopping actor system.");
+        log.info("Stopping actor system dispatchers...");
         dispatchers.values().forEach(d -> ThingsBoardExecutors.shutdownAndAwaitTermination(d.getExecutor(), d.getDispatcherId()));
         if (scheduler != null) {
+            log.info("Stopping actor system scheduler...");
             ThingsBoardExecutors.shutdownAndAwaitTermination(scheduler, "Actor system scheduler");
         }
         actors.clear();

--- a/common/actor/src/main/java/org/thingsboard/mqtt/broker/actors/TbActorSystem.java
+++ b/common/actor/src/main/java/org/thingsboard/mqtt/broker/actors/TbActorSystem.java
@@ -52,4 +52,6 @@ public interface TbActorSystem {
     List<TbActorId> filterChildren(TbActorId parent, Predicate<TbActorId> childFilter);
 
     Set<TbActorId> getAllActorIds();
+
+    void destroy();
 }


### PR DESCRIPTION
## Pull Request description

During the TBMQ shutdown, this issue may occur when last will messages are attempted to be delivered, but the scheduler has already been stopped.
Resulting in:

```
java.util.concurrent.RejectedExecutionException: Task 
java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask@4c7825d8
[Not completed, task = java.util.concurrent.Executors$RunnableAdapter@25380416
[Wrapped task = org.thingsboard.mqtt.broker.service.mqtt.will.DefaultLastWillService$$Lambda$3299/0x00007fc82926e418@7b067819]]
rejected from java.util.concurrent.ScheduledThreadPoolExecutor@47e838a3
[Terminated, pool size = 0, active threads = 0, queued tasks = 0, completed tasks = 16]

	at java.base/java.util.concurrent.ThreadPoolExecutor$AbortPolicy.rejectedExecution(ThreadPoolExecutor.java:2065)
	at java.base/java.util.concurrent.ThreadPoolExecutor.reject(ThreadPoolExecutor.java:833)
	at java.base/java.util.concurrent.ScheduledThreadPoolExecutor.delayedExecute(ScheduledThreadPoolExecutor.java:340)
	at java.base/java.util.concurrent.ScheduledThreadPoolExecutor.schedule(ScheduledThreadPoolExecutor.java:562)
	at java.base/java.util.concurrent.Executors$DelegatedScheduledExecutorService.schedule(Executors.java:813)
	at org.thingsboard.mqtt.broker.service.mqtt.will.DefaultLastWillService.scheduleLastWill(DefaultLastWillService.java:121)
	at org.thingsboard.mqtt.broker.service.mqtt.will.DefaultLastWillService.removeAndExecuteLastWillIfNeeded(DefaultLastWillService.java:108)
	at org.thingsboard.mqtt.broker.actors.client.service.disconnect.DisconnectServiceImpl.clearClientSession(DisconnectServiceImpl.java:163)
	at org.thingsboard.mqtt.broker.actors.client.service.disconnect.DisconnectServiceImpl.disconnect(DisconnectServiceImpl.java:91)
	at org.thingsboard.mqtt.broker.actors.client.service.ActorProcessorImpl.disconnect(ActorProcessorImpl.java:336)
	at org.thingsboard.mqtt.broker.actors.client.service.ActorProcessorImpl.onDisconnect(ActorProcessorImpl.java:331)
	at org.thingsboard.mqtt.broker.actors.client.ClientActor.doProcess(ClientActor.java:129)
	at org.thingsboard.mqtt.broker.actors.service.ContextAwareActor.process(ContextAwareActor.java:44)
	at org.thingsboard.mqtt.broker.actors.TbActorMailbox.processMailbox(TbActorMailbox.java:145)
	at java.base/java.util.concurrent.ForkJoinTask$RunnableExecuteAction.exec(ForkJoinTask.java:1395)
	at java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:373)
	at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1182)
	at java.base/java.util.concurrent.ForkJoinPool.scan(ForkJoinPool.java:1655)
	at java.base/java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1622)
	at java.base/java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:165)

```

## General checklist

- [x] You have reviewed the guidelines [document](https://docs.google.com/document/d/1A4Vc3wrHsY_159b9RG5LOtCryoH6VPwgOhrFEzJKwbI/edit?usp=sharing).
- [x] [Labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels#about-labels) that classify your pull request have been added.
- [x] The [milestone](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones) is specified and corresponds to fix version.
- [x] Description references specific [issue](https://github.com/thingsboard/tbmq/issues).
- [x] Description contains human-readable scope of changes.
- [x] Description contains brief notes about what needs to be added to the documentation.
- [x] No merge conflicts, commented blocks of code, code formatting issues.
- [x] Changes are backward compatible or upgrade script is provided.

## Front-End feature checklist

- [x] Screenshots with affected component(s) are added. The best option is to provide 2 screens: before and after changes;
- [x] If you change the widget or other API, ensure it is backward-compatible or upgrade script is present.

## Back-End feature checklist

- [x] Added corresponding unit and/or integration test(s). Provide written explanation in the PR description if you have failed to add tests.
- [x] If new dependency was added: the dependency tree is checked for conflicts.

