### PR TITLE
Allow ; as a character in kafka configs

### DIFF
--- a/application/src/main/java/org/thingsboard/mqtt/broker/config/AbstractMsgsRateLimitsConfiguration.java
+++ b/application/src/main/java/org/thingsboard/mqtt/broker/config/AbstractMsgsRateLimitsConfiguration.java
@@ -22,7 +22,7 @@ import lombok.Data;
 import org.springframework.context.annotation.Condition;
 import org.springframework.context.annotation.ConditionContext;
 import org.springframework.core.type.AnnotatedTypeMetadata;
-import org.thingsboard.mqtt.broker.cache.CacheConstants;
+import org.thingsboard.mqtt.broker.common.data.BrokerConstants;
 
 import java.time.Duration;
 
@@ -34,8 +34,8 @@ public abstract class AbstractMsgsRateLimitsConfiguration {
 
     protected BucketConfiguration getBucketConfiguration() {
         ConfigurationBuilder builder = BucketConfiguration.builder();
-        for (String limitSrc : config.split(CacheConstants.COMMA)) {
-            String[] parts = limitSrc.split(CacheConstants.COLON);
+        for (String limitSrc : config.split(BrokerConstants.COMMA)) {
+            String[] parts = limitSrc.split(BrokerConstants.COLON);
             if (parts.length != 2) {
                 throw new IllegalArgumentException("Invalid limitSrc format: " + limitSrc);
             }

--- a/application/src/main/java/org/thingsboard/mqtt/broker/config/SwaggerConfiguration.java
+++ b/application/src/main/java/org/thingsboard/mqtt/broker/config/SwaggerConfiguration.java
@@ -55,9 +55,10 @@ import org.springframework.context.annotation.Primary;
 import org.springframework.core.MethodParameter;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.RequestParam;
-import org.thingsboard.mqtt.broker.common.data.util.StringUtils;
+import org.thingsboard.mqtt.broker.common.data.BrokerConstants;
 import org.thingsboard.mqtt.broker.common.data.exception.ThingsboardErrorCode;
 import org.thingsboard.mqtt.broker.common.data.security.Authority;
+import org.thingsboard.mqtt.broker.common.data.util.StringUtils;
 import org.thingsboard.mqtt.broker.common.util.JacksonUtil;
 import org.thingsboard.mqtt.broker.exception.ThingsboardCredentialsExpiredResponse;
 import org.thingsboard.mqtt.broker.exception.ThingsboardErrorResponse;
@@ -274,7 +275,7 @@ public class SwaggerConfiguration {
                 }
             }
             if (!requestParams.isEmpty()) {
-                var path = routerOperation.getPath() + "{?" + String.join(",", requestParams) + "}";
+                var path = routerOperation.getPath() + "{?" + String.join(BrokerConstants.COMMA, requestParams) + "}";
                 routerOperation.setPath(path);
             }
             return routerOperation;

--- a/application/src/main/java/org/thingsboard/mqtt/broker/controller/TimeseriesController.java
+++ b/application/src/main/java/org/thingsboard/mqtt/broker/controller/TimeseriesController.java
@@ -36,6 +36,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.context.request.async.DeferredResult;
+import org.thingsboard.mqtt.broker.common.data.BrokerConstants;
 import org.thingsboard.mqtt.broker.common.data.exception.ThingsboardException;
 import org.thingsboard.mqtt.broker.common.data.kv.Aggregation;
 import org.thingsboard.mqtt.broker.common.data.kv.BaseReadTsKvQuery;
@@ -310,7 +311,7 @@ public class TimeseriesController extends BaseController {
     private List<String> toKeysList(String keys) {
         List<String> keyList = null;
         if (!StringUtils.isEmpty(keys)) {
-            keyList = Arrays.asList(keys.split(","));
+            keyList = Arrays.asList(keys.split(BrokerConstants.COMMA));
         }
         return keyList;
     }

--- a/application/src/main/java/org/thingsboard/mqtt/broker/service/install/SqlDatabaseUpgradeService.java
+++ b/application/src/main/java/org/thingsboard/mqtt/broker/service/install/SqlDatabaseUpgradeService.java
@@ -21,6 +21,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Service;
+import org.thingsboard.mqtt.broker.common.data.BrokerConstants;
 import org.thingsboard.mqtt.broker.dao.messages.DeviceMsgService;
 
 import java.io.BufferedReader;
@@ -210,7 +211,7 @@ public class SqlDatabaseUpgradeService implements DatabaseEntitiesUpgradeService
                 if (additionalAction != null) {
                     additionalAction.accept(conn);
                 }
-                conn.createStatement().execute("UPDATE tb_schema_settings SET schema_version = " + newVersion + ";");
+                conn.createStatement().execute("UPDATE tb_schema_settings SET schema_version = " + newVersion + BrokerConstants.SEMICOLON);
                 log.info("Schema updated to version {}", newVersionStr);
             } else {
                 log.info("Skip schema re-update to version {}. Use env flag 'SKIP_SCHEMA_VERSION_CHECK' to force the re-update.", newVersionStr);

--- a/application/src/main/java/org/thingsboard/mqtt/broker/ssl/config/AbstractSslCredentials.java
+++ b/application/src/main/java/org/thingsboard/mqtt/broker/ssl/config/AbstractSslCredentials.java
@@ -15,6 +15,7 @@
  */
 package org.thingsboard.mqtt.broker.ssl.config;
 
+import org.thingsboard.mqtt.broker.common.data.BrokerConstants;
 import org.thingsboard.mqtt.broker.common.data.util.StringUtils;
 
 import javax.net.ssl.KeyManagerFactory;
@@ -131,7 +132,7 @@ public abstract class AbstractSslCredentials implements SslCredentials {
 
     @Override
     public String getValueFromSubjectNameByKey(String subjectName, String key) {
-        String[] dns = subjectName.split(",");
+        String[] dns = subjectName.split(BrokerConstants.COMMA);
         Optional<String> cn = (Arrays.stream(dns).filter(dn -> dn.contains(key + "="))).findFirst();
         String value = cn.isPresent() ? cn.get().replace(key + "=", "") : null;
         return StringUtils.isNotEmpty(value) ? value : null;

--- a/application/src/main/java/org/thingsboard/mqtt/broker/util/MiscUtils.java
+++ b/application/src/main/java/org/thingsboard/mqtt/broker/util/MiscUtils.java
@@ -18,6 +18,7 @@ package org.thingsboard.mqtt.broker.util;
 import com.google.common.hash.HashFunction;
 import com.google.common.hash.Hashing;
 import jakarta.servlet.http.HttpServletRequest;
+import org.thingsboard.mqtt.broker.common.data.BrokerConstants;
 
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
@@ -71,7 +72,7 @@ public class MiscUtils {
         String scheme = getScheme(request);
         int port = MiscUtils.getPort(request);
         if (needsPort(scheme, port)) {
-            domainName += ":" + port;
+            domainName += BrokerConstants.COLON + port;
         }
         return domainName;
     }

--- a/application/src/test/java/org/thingsboard/mqtt/broker/AbstractPubSubIntegrationTest.java
+++ b/application/src/test/java/org/thingsboard/mqtt/broker/AbstractPubSubIntegrationTest.java
@@ -45,6 +45,7 @@ import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.KafkaContainer;
 import org.testcontainers.containers.output.OutputFrame;
 import org.testcontainers.utility.DockerImageName;
+import org.thingsboard.mqtt.broker.common.data.BrokerConstants;
 import org.thingsboard.mqtt.broker.dao.client.MqttClientCredentialsService;
 import org.thingsboard.mqtt.broker.queue.kafka.settings.TbKafkaAdminSettings;
 import org.thingsboard.mqtt.broker.queue.kafka.settings.TbKafkaConsumerSettings;
@@ -63,7 +64,7 @@ public abstract class AbstractPubSubIntegrationTest {
 
     public static final int ONE_HOUR_MS = 3600000;
     public static final String LOCALHOST = "localhost";
-    public static final String SERVER_URI = "tcp://" + LOCALHOST + ":";
+    public static final String SERVER_URI = "tcp://" + LOCALHOST + BrokerConstants.COLON;
     public static final byte[] PAYLOAD = "testPayload".getBytes(StandardCharsets.UTF_8);
 
     public static final List<UserProperty> USER_PROPERTIES = List.of(

--- a/common/cache/src/main/java/org/thingsboard/mqtt/broker/cache/CacheConstants.java
+++ b/common/cache/src/main/java/org/thingsboard/mqtt/broker/cache/CacheConstants.java
@@ -33,6 +33,4 @@ public class CacheConstants {
     public static final String CLIENT_SESSIONS_LIMIT_CACHE_KEY = CacheConstants.CLIENT_SESSIONS_LIMIT_CACHE + COUNT_SUFFIX;
     public static final String APP_CLIENTS_LIMIT_CACHE_KEY = CacheConstants.APP_CLIENTS_LIMIT_CACHE + COUNT_SUFFIX;
 
-    public static final String COMMA = ",";
-    public static final String COLON = ":";
 }

--- a/common/cache/src/main/java/org/thingsboard/mqtt/broker/cache/JedisClusterNodesUtil.java
+++ b/common/cache/src/main/java/org/thingsboard/mqtt/broker/cache/JedisClusterNodesUtil.java
@@ -17,6 +17,7 @@ package org.thingsboard.mqtt.broker.cache;
 
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.connection.RedisNode;
+import org.thingsboard.mqtt.broker.common.data.BrokerConstants;
 
 @Slf4j
 public class JedisClusterNodesUtil {
@@ -31,7 +32,7 @@ public class JedisClusterNodesUtil {
             String id = parts[0];
 
             // Extract host and port from <ip:port@cport>
-            String[] hostPort = parts[1].split(":");
+            String[] hostPort = parts[1].split(BrokerConstants.COLON);
             String host = hostPort[0];
             int port = Integer.parseInt(hostPort[1].split("@")[0]);
 

--- a/common/cache/src/main/java/org/thingsboard/mqtt/broker/cache/TBRedisCacheConfiguration.java
+++ b/common/cache/src/main/java/org/thingsboard/mqtt/broker/cache/TBRedisCacheConfiguration.java
@@ -37,6 +37,7 @@ import org.springframework.data.redis.connection.lettuce.LettucePoolingClientCon
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 import org.springframework.format.support.DefaultFormattingConversionService;
+import org.thingsboard.mqtt.broker.common.data.BrokerConstants;
 import org.thingsboard.mqtt.broker.common.data.util.StringUtils;
 import redis.clients.jedis.ConnectionPoolConfig;
 import redis.clients.jedis.HostAndPort;
@@ -205,9 +206,9 @@ public abstract class TBRedisCacheConfiguration<C extends RedisConfiguration> {
             result = Collections.emptyList();
         } else {
             result = new ArrayList<>();
-            for (String hostPort : nodes.split(CacheConstants.COMMA)) {
-                String host = hostPort.split(CacheConstants.COLON)[0];
-                int port = Integer.parseInt(hostPort.split(CacheConstants.COLON)[1]);
+            for (String hostPort : nodes.split(BrokerConstants.COMMA)) {
+                String host = hostPort.split(BrokerConstants.COLON)[0];
+                int port = Integer.parseInt(hostPort.split(BrokerConstants.COLON)[1]);
                 result.add(new RedisNode(host, port));
             }
         }

--- a/common/data/src/main/java/org/thingsboard/mqtt/broker/common/data/BrokerConstants.java
+++ b/common/data/src/main/java/org/thingsboard/mqtt/broker/common/data/BrokerConstants.java
@@ -139,6 +139,7 @@ public class BrokerConstants {
 
     public static final String COMMA = ",";
     public static final String COLON = ":";
+    public static final String SEMICOLON = ";";
 
     //client session event constants
     public static final String REQUEST_ID_HEADER = "requestId";

--- a/common/data/src/main/java/org/thingsboard/mqtt/broker/common/data/util/StringUtils.java
+++ b/common/data/src/main/java/org/thingsboard/mqtt/broker/common/data/util/StringUtils.java
@@ -17,6 +17,7 @@ package org.thingsboard.mqtt.broker.common.data.util;
 
 import com.google.common.base.Splitter;
 import org.apache.commons.lang3.RandomStringUtils;
+import org.thingsboard.mqtt.broker.common.data.BrokerConstants;
 
 import java.security.SecureRandom;
 import java.util.Base64;
@@ -27,8 +28,6 @@ import static org.apache.commons.lang3.StringUtils.repeat;
 public class StringUtils {
 
     public static final SecureRandom RANDOM = new SecureRandom();
-
-    public static final String EMPTY = "";
 
     public static final int INDEX_NOT_FOUND = -1;
 
@@ -67,7 +66,7 @@ public class StringUtils {
             return str;
         }
         if (separator.isEmpty()) {
-            return EMPTY;
+            return BrokerConstants.EMPTY_STR;
         }
         final int pos = str.indexOf(separator);
         if (pos == INDEX_NOT_FOUND) {

--- a/common/queue/pom.xml
+++ b/common/queue/pom.xml
@@ -48,10 +48,6 @@
             <artifactId>kafka-clients</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.springframework</groupId>
-            <artifactId>spring-context-support</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-autoconfigure</artifactId>
         </dependency>
@@ -70,6 +66,16 @@
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.google.protobuf</groupId>

--- a/common/queue/src/main/java/org/thingsboard/mqtt/broker/queue/TbQueueAdmin.java
+++ b/common/queue/src/main/java/org/thingsboard/mqtt/broker/queue/TbQueueAdmin.java
@@ -15,6 +15,7 @@
  */
 package org.thingsboard.mqtt.broker.queue;
 
+import org.apache.kafka.clients.admin.ListConsumerGroupOffsetsResult;
 import org.thingsboard.mqtt.broker.common.data.BasicCallback;
 import org.thingsboard.mqtt.broker.common.data.page.PageData;
 import org.thingsboard.mqtt.broker.common.data.page.PageLink;
@@ -50,4 +51,5 @@ public interface TbQueueAdmin {
 
     void deleteOldConsumerGroups(String consumerGroupPrefix, String serviceId, long currentCgSuffix);
 
+    ListConsumerGroupOffsetsResult listConsumerGroupOffsets(String groupId);
 }

--- a/common/queue/src/main/java/org/thingsboard/mqtt/broker/queue/kafka/TbKafkaConsumerTemplate.java
+++ b/common/queue/src/main/java/org/thingsboard/mqtt/broker/queue/kafka/TbKafkaConsumerTemplate.java
@@ -129,7 +129,6 @@ public class TbKafkaConsumerTemplate<T extends TbQueueMsg> extends AbstractTbQue
             allTopicPartitions.add(newTopicPartition(topic, i));
         }
         consumer.assign(allTopicPartitions);
-
     }
 
     @Override

--- a/common/queue/src/main/java/org/thingsboard/mqtt/broker/queue/kafka/settings/StatsConsumerKafkaSettings.java
+++ b/common/queue/src/main/java/org/thingsboard/mqtt/broker/queue/kafka/settings/StatsConsumerKafkaSettings.java
@@ -22,6 +22,8 @@ import org.springframework.stereotype.Component;
 @Getter
 @Component
 public class StatsConsumerKafkaSettings {
+
     @Value("${queue.kafka.consumer-stats.consumer-config}")
     private String consumerProperties;
+
 }

--- a/common/queue/src/main/java/org/thingsboard/mqtt/broker/queue/kafka/settings/TbKafkaAdminSettings.java
+++ b/common/queue/src/main/java/org/thingsboard/mqtt/broker/queue/kafka/settings/TbKafkaAdminSettings.java
@@ -26,6 +26,7 @@ import java.util.Properties;
 @Setter
 @Component
 public class TbKafkaAdminSettings {
+
     @Value("${queue.kafka.bootstrap.servers}")
     private String servers;
 
@@ -36,7 +37,7 @@ public class TbKafkaAdminSettings {
         Properties props = new Properties();
         props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, servers);
         if (config != null) {
-            QueueUtil.getConfigs(config).forEach(props::put);
+            props.putAll(QueueUtil.getConfigs(config));
         }
         return props;
     }

--- a/common/queue/src/main/java/org/thingsboard/mqtt/broker/queue/kafka/settings/TbKafkaConsumerSettings.java
+++ b/common/queue/src/main/java/org/thingsboard/mqtt/broker/queue/kafka/settings/TbKafkaConsumerSettings.java
@@ -68,7 +68,7 @@ public class TbKafkaConsumerSettings {
         props.put(ConsumerConfig.MAX_PARTITION_FETCH_BYTES_CONFIG, maxPartitionFetchBytes);
         props.put(ConsumerConfig.FETCH_MAX_BYTES_CONFIG, fetchMaxBytes);
         if (customProperties != null) {
-            QueueUtil.getConfigs(customProperties).forEach(props::put);
+            props.putAll(QueueUtil.getConfigs(customProperties));
         }
         consumerPropertiesPerTopic
                 .getOrDefault(topic, Collections.emptyList())

--- a/common/queue/src/main/java/org/thingsboard/mqtt/broker/queue/kafka/settings/TbKafkaProducerSettings.java
+++ b/common/queue/src/main/java/org/thingsboard/mqtt/broker/queue/kafka/settings/TbKafkaProducerSettings.java
@@ -26,6 +26,7 @@ import java.util.Properties;
 @Setter
 @Component
 public class TbKafkaProducerSettings {
+
     @Value("${queue.kafka.bootstrap.servers}")
     private String servers;
 
@@ -57,7 +58,7 @@ public class TbKafkaProducerSettings {
         props.put(ProducerConfig.BUFFER_MEMORY_CONFIG, bufferMemory);
         props.put(ProducerConfig.COMPRESSION_TYPE_CONFIG, compressionType);
         if (customProperties != null) {
-            QueueUtil.getConfigs(customProperties).forEach(props::put);
+            props.putAll(QueueUtil.getConfigs(customProperties));
         }
         return props;
     }

--- a/common/queue/src/main/java/org/thingsboard/mqtt/broker/queue/kafka/stats/TbKafkaConsumerStatisticConfig.java
+++ b/common/queue/src/main/java/org/thingsboard/mqtt/broker/queue/kafka/stats/TbKafkaConsumerStatisticConfig.java
@@ -26,10 +26,12 @@ import org.springframework.stereotype.Component;
 @AllArgsConstructor
 @NoArgsConstructor
 public class TbKafkaConsumerStatisticConfig {
+
     @Value("${queue.kafka.consumer-stats.enabled:true}")
     private Boolean enabled;
     @Value("${queue.kafka.consumer-stats.print-interval-ms:60000}")
     private Long printIntervalMs;
     @Value("${queue.kafka.consumer-stats.kafka-response-timeout-ms:1000}")
     private Long kafkaResponseTimeoutMs;
+
 }

--- a/common/queue/src/main/java/org/thingsboard/mqtt/broker/queue/util/QueueUtil.java
+++ b/common/queue/src/main/java/org/thingsboard/mqtt/broker/queue/util/QueueUtil.java
@@ -16,6 +16,7 @@
 package org.thingsboard.mqtt.broker.queue.util;
 
 import lombok.extern.slf4j.Slf4j;
+import org.thingsboard.mqtt.broker.common.data.BrokerConstants;
 import org.thingsboard.mqtt.broker.common.data.util.StringUtils;
 
 import java.util.Collections;
@@ -26,15 +27,26 @@ import java.util.Properties;
 @Slf4j
 public class QueueUtil {
 
+    private static final String TBMQ_SEMICOLON_PLACEHOLDER = "{{TBMQ_SEMICOLON}}";
+
     public static Map<String, String> getConfigs(String properties) {
         if (StringUtils.isEmpty(properties)) {
             return Collections.emptyMap();
         }
+
+        String processedInput = properties.replace("\\;", TBMQ_SEMICOLON_PLACEHOLDER);
+
         Map<String, String> configs = new HashMap<>();
-        for (String property : properties.split(";")) {
-            int delimiterPosition = property.indexOf(":");
+        for (String property : processedInput.split(BrokerConstants.SEMICOLON)) {
+            int delimiterPosition = property.indexOf(BrokerConstants.COLON);
+
+            if (delimiterPosition == -1 || delimiterPosition == 0 || delimiterPosition == property.length() - 1) {
+                throw new IllegalArgumentException("Invalid property format: " + property);
+            }
+
             String key = property.substring(0, delimiterPosition);
-            String value = property.substring(delimiterPosition + 1);
+            String value = property.substring(delimiterPosition + 1).replace(TBMQ_SEMICOLON_PLACEHOLDER, BrokerConstants.SEMICOLON);
+
             configs.put(key, value);
         }
         return configs;

--- a/common/queue/src/test/java/org/thingsboard/mqtt/broker/queue/util/QueueUtilTest.java
+++ b/common/queue/src/test/java/org/thingsboard/mqtt/broker/queue/util/QueueUtilTest.java
@@ -1,0 +1,140 @@
+/**
+ * Copyright © 2016-2024 The Thingsboard Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.thingsboard.mqtt.broker.queue.util;
+
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Map;
+import java.util.Objects;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class QueueUtilTest {
+
+    @Test
+    void givenValidConfigString_whenParsed_thenReturnsCorrectConfigMap() {
+        String properties = "retention.ms:604800000;segment.bytes:26214400;retention.bytes:1048576000;partitions:12;replication.factor:1";
+
+        Map<String, String> configs = QueueUtil.getConfigs(properties);
+
+        assertThat(configs.size()).isEqualTo(5);
+        assertThat(configs.get("partitions")).isEqualTo("12");
+        assertThat(configs).containsKey("segment.bytes");
+    }
+
+    @Test
+    void givenConfigFile_whenParsed_thenReturnsCorrectConfigMap() throws Exception {
+        Path path = Paths.get(Objects.requireNonNull(getClass().getClassLoader().getResource("config.txt")).toURI());
+        String fileContent = Files.readString(path);
+
+        Map<String, String> result = QueueUtil.getConfigs(fileContent);
+
+        assertThat(result.size()).isEqualTo(4);
+        assertThat(result.get("security.protocol")).isEqualTo("SASL_PLAINTEXT");
+        assertThat(result.get("sasl.mechanism")).isEqualTo("OAUTHBEARER");
+        assertThat(result.get("sasl.jaas.config")).isEqualTo("org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required clientId=\"exampleClient\" clientSecret=\"supersecret\";");
+        assertThat(result.get("sasl.oauthbearer.token.endpoint.url")).isEqualTo("http://example.com/realms/Example/protocol/openid-connect/token");
+    }
+
+    @Test
+    void givenComplexConfigString_whenParsed_thenHandlesEscapedSemicolonCorrectly() throws Exception {
+        String fileContent = "security.protocol:SASL_PLAINTEXT;sasl.mechanism:OAUTHBEARER;sasl.jaas.config:org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required clientId=\"exampleClient\" clientSecret=\"supersecret\"\\;;sasl.oauthbearer.token.endpoint.url:http://example.com/realms/Example/protocol/openid-connect/token";
+
+        Map<String, String> result = QueueUtil.getConfigs(fileContent);
+
+        assertThat(result.size()).isEqualTo(4);
+        assertThat(result.get("security.protocol")).isEqualTo("SASL_PLAINTEXT");
+        assertThat(result.get("sasl.mechanism")).isEqualTo("OAUTHBEARER");
+        assertThat(result.get("sasl.jaas.config")).isEqualTo("org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required clientId=\"exampleClient\" clientSecret=\"supersecret\";");
+        assertThat(result.get("sasl.oauthbearer.token.endpoint.url")).isEqualTo("http://example.com/realms/Example/protocol/openid-connect/token");
+    }
+
+    @Test
+    void givenSimpleKeyValueString_whenParsed_thenReturnsCorrectKeyValuePairs() {
+        String config = "k1:v1;k2:v2;k3:v3";
+        Map<String, String> result = QueueUtil.getConfigs(config);
+
+        assertThat(result.size()).isEqualTo(3);
+        assertThat(result.get("k1")).isEqualTo("v1");
+        assertThat(result.get("k2")).isEqualTo("v2");
+        assertThat(result.get("k3")).isEqualTo("v3");
+    }
+
+    @Test
+    void givenConfigWithEscapedSemicolon_whenParsed_thenParsesCorrectly() {
+        String config = "k1:v1;k2:v2\\;;k3:v3";
+        Map<String, String> result = QueueUtil.getConfigs(config);
+
+        assertThat(result.size()).isEqualTo(3);
+        assertThat(result.get("k1")).isEqualTo("v1");
+        assertThat(result.get("k2")).isEqualTo("v2;");
+        assertThat(result.get("k3")).isEqualTo("v3");
+    }
+
+    @Test
+    void givenConfigWithMultipleEscapedSemicolons_whenParsed_thenParsesCorrectly() {
+        String config = "k1:v1\\;;k2:v2\\;v2b;k3:v3";
+        Map<String, String> result = QueueUtil.getConfigs(config);
+
+        assertThat(result.size()).isEqualTo(3);
+        assertThat(result.get("k1")).isEqualTo("v1;");
+        assertThat(result.get("k2")).isEqualTo("v2;v2b");
+        assertThat(result.get("k3")).isEqualTo("v3");
+    }
+
+    @Test
+    void givenEmptyConfigString_whenParsed_thenReturnsEmptyMap() {
+        String config = "";
+        Map<String, String> result = QueueUtil.getConfigs(config);
+
+        assertThat(result.size()).isZero();
+    }
+
+    @Test
+    void givenConfigWithOnlyEscapedSemicolons_whenParsed_thenHandlesEscapedCharacters() {
+        String config = "k1:v1\\;\\;\\;";
+        Map<String, String> result = QueueUtil.getConfigs(config);
+
+        assertThat(result.size()).isEqualTo(1);
+        assertThat(result.get("k1")).isEqualTo("v1;;;");
+    }
+
+    @Test
+    void givenConfigWithDelimiterAtStart_whenParsed_thenThrowsIllegalArgumentException() {
+        String config = ":k1v1";
+        assertThatThrownBy(() -> QueueUtil.getConfigs(config))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void givenConfigWithDelimiterAtEnd_whenParsed_thenThrowsIllegalArgumentException() {
+        String config = "k1v1:";
+        assertThatThrownBy(() -> QueueUtil.getConfigs(config))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void givenConfigWithMissingDelimiter_whenParsed_thenThrowsIllegalArgumentException() {
+        String config = "k1:v1;k2";
+        assertThatThrownBy(() -> QueueUtil.getConfigs(config))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+}

--- a/common/queue/src/test/resources/config.txt
+++ b/common/queue/src/test/resources/config.txt
@@ -1,0 +1,1 @@
+security.protocol:SASL_PLAINTEXT;sasl.mechanism:OAUTHBEARER;sasl.jaas.config:org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required clientId="exampleClient" clientSecret="supersecret"\;;sasl.oauthbearer.token.endpoint.url:http://example.com/realms/Example/protocol/openid-connect/token

--- a/common/queue/src/test/resources/logback.xml
+++ b/common/queue/src/test/resources/logback.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+
+<configuration>
+    <appender name="console" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{ISO8601} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <logger name="org.thingsboard.mqtt.broker.queue" level="INFO"/>
+
+    <root level="INFO">
+        <appender-ref ref="console"/>
+    </root>
+</configuration>

--- a/common/stats/src/main/java/org/thingsboard/mqtt/broker/common/stats/DefaultStatsFactory.java
+++ b/common/stats/src/main/java/org/thingsboard/mqtt/broker/common/stats/DefaultStatsFactory.java
@@ -22,6 +22,7 @@ import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
+import org.thingsboard.mqtt.broker.common.data.BrokerConstants;
 import org.thingsboard.mqtt.broker.common.data.util.StringUtils;
 
 import java.util.concurrent.atomic.AtomicInteger;
@@ -46,7 +47,7 @@ public class DefaultStatsFactory implements StatsFactory {
     @PostConstruct
     public void init() {
         if (!StringUtils.isEmpty(timerPercentilesStr)) {
-            String[] split = timerPercentilesStr.split(",");
+            String[] split = timerPercentilesStr.split(BrokerConstants.COMMA);
             timerPercentiles = new double[split.length];
             for (int i = 0; i < split.length; i++) {
                 timerPercentiles[i] = Double.parseDouble(split[i]);


### PR DESCRIPTION
## Pull Request description

#177 

We’ve added support for escaping the `;` character using the `\` character. To use this feature, you can set the following environment variable value:

```
k1:v1;k2:v2\;;k3:v3
```

This will be interpreted as:

```
k1:v1
k2:v2;
k3:v3
```

## General checklist

- [x] You have reviewed the guidelines [document](https://docs.google.com/document/d/1A4Vc3wrHsY_159b9RG5LOtCryoH6VPwgOhrFEzJKwbI/edit?usp=sharing).
- [x] [Labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels#about-labels) that classify your pull request have been added.
- [x] The [milestone](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones) is specified and corresponds to fix version.
- [x] Description references specific [issue](https://github.com/thingsboard/tbmq/issues).
- [x] Description contains human-readable scope of changes.
- [x] Description contains brief notes about what needs to be added to the documentation.
- [x] No merge conflicts, commented blocks of code, code formatting issues.
- [x] Changes are backward compatible or upgrade script is provided.

## Front-End feature checklist

- [x] Screenshots with affected component(s) are added. The best option is to provide 2 screens: before and after changes;
- [x] If you change the widget or other API, ensure it is backward-compatible or upgrade script is present.

## Back-End feature checklist

- [x] Added corresponding unit and/or integration test(s). Provide written explanation in the PR description if you have failed to add tests.
- [x] If new dependency was added: the dependency tree is checked for conflicts.

