### PR TITLE
Use sort order in aggregation queries

### DIFF
--- a/application/src/main/java/org/thingsboard/mqtt/broker/controller/TimeseriesController.java
+++ b/application/src/main/java/org/thingsboard/mqtt/broker/controller/TimeseriesController.java
@@ -150,7 +150,7 @@ public class TimeseriesController extends BaseController {
             @RequestParam(name = "interval", defaultValue = "0") Long interval,
             @RequestParam(name = "limit", defaultValue = "100") Integer limit,
             @RequestParam(name = "agg", defaultValue = "NONE") String aggStr,
-            @RequestParam(name = "orderBy", defaultValue = "DESC") String orderBy,
+            @RequestParam(name = "orderBy", defaultValue = BrokerConstants.DESC_ORDER) String orderBy,
             @RequestParam(name = "useStrictDataTypes", required = false, defaultValue = "true") Boolean useStrictDataTypes) throws ThingsboardException {
         try {
             checkParameter(ENTITY_ID, entityId);

--- a/common/data/src/main/java/org/thingsboard/mqtt/broker/common/data/BrokerConstants.java
+++ b/common/data/src/main/java/org/thingsboard/mqtt/broker/common/data/BrokerConstants.java
@@ -27,6 +27,9 @@ public class BrokerConstants {
     public static final String WS = "WS";
     public static final String WSS = "WSS";
 
+    private final String ASC_ORDER = "ASC";
+    private final String DESC_ORDER = "DESC";
+
     public static final String ENTITY_ID_TOTAL = "total";
     public static final String INCOMING_MSGS = "incomingMsgs";
     public static final String OUTGOING_MSGS = "outgoingMsgs";

--- a/common/data/src/main/java/org/thingsboard/mqtt/broker/common/data/BrokerConstants.java
+++ b/common/data/src/main/java/org/thingsboard/mqtt/broker/common/data/BrokerConstants.java
@@ -27,8 +27,8 @@ public class BrokerConstants {
     public static final String WS = "WS";
     public static final String WSS = "WSS";
 
-    private final String ASC_ORDER = "ASC";
-    private final String DESC_ORDER = "DESC";
+    public static final String ASC_ORDER = "ASC";
+    public static final String DESC_ORDER = "DESC";
 
     public static final String ENTITY_ID_TOTAL = "total";
     public static final String INCOMING_MSGS = "incomingMsgs";

--- a/common/data/src/main/java/org/thingsboard/mqtt/broker/common/data/kv/BaseReadTsKvQuery.java
+++ b/common/data/src/main/java/org/thingsboard/mqtt/broker/common/data/kv/BaseReadTsKvQuery.java
@@ -18,6 +18,8 @@ package org.thingsboard.mqtt.broker.common.data.kv;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 
+import static org.thingsboard.mqtt.broker.common.data.BrokerConstants.DESC_ORDER;
+
 @Data
 @EqualsAndHashCode(callSuper = true)
 public class BaseReadTsKvQuery extends BaseTsKvQuery implements ReadTsKvQuery {
@@ -28,7 +30,7 @@ public class BaseReadTsKvQuery extends BaseTsKvQuery implements ReadTsKvQuery {
     private final String order;
 
     public BaseReadTsKvQuery(String key, long startTs, long endTs, long interval, int limit, Aggregation aggregation) {
-        this(key, startTs, endTs, interval, limit, aggregation, "DESC");
+        this(key, startTs, endTs, interval, limit, aggregation, DESC_ORDER);
     }
 
     public BaseReadTsKvQuery(String key, long startTs, long endTs, long interval, int limit, Aggregation aggregation, String order) {
@@ -40,7 +42,7 @@ public class BaseReadTsKvQuery extends BaseTsKvQuery implements ReadTsKvQuery {
     }
 
     public BaseReadTsKvQuery(String key, long startTs, long endTs) {
-        this(key, startTs, endTs, endTs - startTs, 1, Aggregation.AVG, "DESC");
+        this(key, startTs, endTs, endTs - startTs, 1, Aggregation.AVG, DESC_ORDER);
     }
 
     public BaseReadTsKvQuery(String key, long startTs, long endTs, int limit, String order) {

--- a/dao/src/main/java/org/thingsboard/mqtt/broker/dao/sqlts/AbstractChunkedAggregationTimeseriesDao.java
+++ b/dao/src/main/java/org/thingsboard/mqtt/broker/dao/sqlts/AbstractChunkedAggregationTimeseriesDao.java
@@ -140,7 +140,7 @@ public abstract class AbstractChunkedAggregationTimeseriesDao extends BaseAbstra
                 futures.add(aggregateTsKvEntry);
                 startPeriod = endTs;
             }
-            return getTsKvEntriesFuture(Futures.allAsList(futures));
+            return getTsKvEntriesFuture(Futures.allAsList(futures), query.getOrder());
         }
     }
 

--- a/dao/src/main/java/org/thingsboard/mqtt/broker/dao/sqlts/BaseAbstractSqlTimeseriesDao.java
+++ b/dao/src/main/java/org/thingsboard/mqtt/broker/dao/sqlts/BaseAbstractSqlTimeseriesDao.java
@@ -15,11 +15,11 @@
  */
 package org.thingsboard.mqtt.broker.dao.sqlts;
 
-import com.google.common.base.Function;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
-import jakarta.annotation.Nullable;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.util.CollectionUtils;
+import org.thingsboard.mqtt.broker.common.data.BrokerConstants;
 import org.thingsboard.mqtt.broker.common.data.kv.TsKvEntry;
 import org.thingsboard.mqtt.broker.dao.DaoUtil;
 import org.thingsboard.mqtt.broker.dao.JpaAbstractDaoListeningExecutorService;
@@ -35,20 +35,29 @@ public abstract class BaseAbstractSqlTimeseriesDao extends JpaAbstractDaoListeni
 
     protected ListenableFuture<List<TsKvEntry>> getTsKvEntriesFuture(ListenableFuture<List<Optional<? extends AbstractTsKvEntity>>> future,
                                                                      String order) {
-        return Futures.transform(future, new Function<>() {
-            @Nullable
-            @Override
-            public List<TsKvEntry> apply(@Nullable List<Optional<? extends AbstractTsKvEntity>> results) {
-                if (results == null || results.isEmpty()) {
-                    return null;
-                }
-                List<? extends AbstractTsKvEntity> data = results.stream().filter(Optional::isPresent).map(Optional::get).collect(Collectors.toList());
-                if (order.equals("DESC")) {
-                    Collections.reverse(data);
-                }
-                return DaoUtil.convertDataList(data);
+        return Futures.transform(future, results -> {
+            if (CollectionUtils.isEmpty(results)) {
+                return null;
             }
+            return DaoUtil.convertDataList(collectWithOrder(results, order));
         }, service);
+    }
+
+    private List<? extends AbstractTsKvEntity> collectWithOrder(List<Optional<? extends AbstractTsKvEntity>> results,
+                                                                String order) {
+        List<? extends AbstractTsKvEntity> data = collectData(results);
+        if (BrokerConstants.DESC_ORDER.equals(order)) {
+            Collections.reverse(data);
+        }
+        return data;
+    }
+
+    private List<? extends AbstractTsKvEntity> collectData(List<Optional<? extends AbstractTsKvEntity>> results) {
+        return results
+                .stream()
+                .filter(Optional::isPresent)
+                .map(Optional::get)
+                .collect(Collectors.toList());
     }
 
 }

--- a/dao/src/main/java/org/thingsboard/mqtt/broker/dao/sqlts/BaseAbstractSqlTimeseriesDao.java
+++ b/dao/src/main/java/org/thingsboard/mqtt/broker/dao/sqlts/BaseAbstractSqlTimeseriesDao.java
@@ -25,6 +25,7 @@ import org.thingsboard.mqtt.broker.dao.DaoUtil;
 import org.thingsboard.mqtt.broker.dao.JpaAbstractDaoListeningExecutorService;
 import org.thingsboard.mqtt.broker.dao.model.sqlts.AbstractTsKvEntity;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -32,7 +33,8 @@ import java.util.stream.Collectors;
 @Slf4j
 public abstract class BaseAbstractSqlTimeseriesDao extends JpaAbstractDaoListeningExecutorService {
 
-    protected ListenableFuture<List<TsKvEntry>> getTsKvEntriesFuture(ListenableFuture<List<Optional<? extends AbstractTsKvEntity>>> future) {
+    protected ListenableFuture<List<TsKvEntry>> getTsKvEntriesFuture(ListenableFuture<List<Optional<? extends AbstractTsKvEntity>>> future,
+                                                                     String order) {
         return Futures.transform(future, new Function<>() {
             @Nullable
             @Override
@@ -41,6 +43,9 @@ public abstract class BaseAbstractSqlTimeseriesDao extends JpaAbstractDaoListeni
                     return null;
                 }
                 List<? extends AbstractTsKvEntity> data = results.stream().filter(Optional::isPresent).map(Optional::get).collect(Collectors.toList());
+                if (order.equals("DESC")) {
+                    Collections.reverse(data);
+                }
                 return DaoUtil.convertDataList(data);
             }
         }, service);

--- a/dao/src/main/java/org/thingsboard/mqtt/broker/dao/sqlts/SqlTimeseriesLatestDao.java
+++ b/dao/src/main/java/org/thingsboard/mqtt/broker/dao/sqlts/SqlTimeseriesLatestDao.java
@@ -56,12 +56,11 @@ import java.util.Optional;
 import java.util.function.Function;
 
 import static java.time.ZoneOffset.UTC;
+import static org.thingsboard.mqtt.broker.common.data.BrokerConstants.DESC_ORDER;
 
 @Slf4j
 @Component
 public class SqlTimeseriesLatestDao extends BaseAbstractSqlTimeseriesDao implements TimeseriesLatestDao {
-
-    private static final String DESC_ORDER = "DESC";
 
     @Autowired
     private TsKvLatestRepository tsKvLatestRepository;

--- a/dao/src/test/java/org/thingsboard/mqtt/broker/dao/service/TimeseriesServiceTest.java
+++ b/dao/src/test/java/org/thingsboard/mqtt/broker/dao/service/TimeseriesServiceTest.java
@@ -41,6 +41,8 @@ import java.util.concurrent.TimeoutException;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.thingsboard.mqtt.broker.common.data.BrokerConstants.ASC_ORDER;
+import static org.thingsboard.mqtt.broker.common.data.BrokerConstants.DESC_ORDER;
 
 @Slf4j
 @DaoSqlTest
@@ -51,7 +53,6 @@ public class TimeseriesServiceTest extends AbstractServiceTest {
     private final String LONG_KEY = "incomingMsgs";
 
     private final long TS = 42L;
-    private final String DESC_ORDER = "DESC";
 
     KvEntry longKvEntry = new LongDataEntry(LONG_KEY, Long.MAX_VALUE);
 
@@ -96,7 +97,7 @@ public class TimeseriesServiceTest extends AbstractServiceTest {
         saveEntries(entityId, TS - 1);
 
         List<ReadTsKvQuery> queries = new ArrayList<>();
-        queries.add(new BaseReadTsKvQuery(LONG_KEY, TS - 3, TS, 0, 1000, Aggregation.NONE, "ASC"));
+        queries.add(new BaseReadTsKvQuery(LONG_KEY, TS - 3, TS, 0, 1000, Aggregation.NONE, ASC_ORDER));
 
         List<TsKvEntry> entries = tsService.findAll(entityId, queries).get(MAX_TIMEOUT, TimeUnit.SECONDS);
         Assert.assertEquals(3, entries.size());
@@ -114,7 +115,7 @@ public class TimeseriesServiceTest extends AbstractServiceTest {
         saveEntries(entityId, TS - 1);
 
         List<ReadTsKvQuery> queries = new ArrayList<>();
-        queries.add(new BaseReadTsKvQuery(LONG_KEY, TS - 3, TS, 0, 1000, Aggregation.NONE, "DESC"));
+        queries.add(new BaseReadTsKvQuery(LONG_KEY, TS - 3, TS, 0, 1000, Aggregation.NONE, DESC_ORDER));
 
         List<TsKvEntry> entries = tsService.findAll(entityId, queries).get(MAX_TIMEOUT, TimeUnit.SECONDS);
         Assert.assertEquals(3, entries.size());
@@ -130,7 +131,7 @@ public class TimeseriesServiceTest extends AbstractServiceTest {
         saveEntries(entityId, TS);
         saveEntries(entityId, TS + 1L);
 
-        List<ReadTsKvQuery> queries = List.of(new BaseReadTsKvQuery(LONG_KEY, TS, TS, 1, 1, Aggregation.COUNT, "ASC"));
+        List<ReadTsKvQuery> queries = List.of(new BaseReadTsKvQuery(LONG_KEY, TS, TS, 1, 1, Aggregation.COUNT, ASC_ORDER));
 
         List<TsKvEntry> entries = tsService.findAll(entityId, queries).get();
         Assert.assertEquals(1, entries.size());
@@ -146,7 +147,7 @@ public class TimeseriesServiceTest extends AbstractServiceTest {
         }
         saveEntries(entityId, TS + 100L + 1L);
 
-        List<ReadTsKvQuery> queries = List.of(new BaseReadTsKvQuery(LONG_KEY, TS, TS + 100, 100, 1, Aggregation.COUNT, "ASC"));
+        List<ReadTsKvQuery> queries = List.of(new BaseReadTsKvQuery(LONG_KEY, TS, TS + 100, 100, 1, Aggregation.COUNT, ASC_ORDER));
 
         List<TsKvEntry> entries = tsService.findAll(entityId, queries).get();
         Assert.assertEquals(1, entries.size());
@@ -162,7 +163,7 @@ public class TimeseriesServiceTest extends AbstractServiceTest {
         }
         saveEntries(entityId, TS + 100000L + 1L);
 
-        List<ReadTsKvQuery> queries = List.of(new BaseReadTsKvQuery(LONG_KEY, TS, TS + 99999, 50000, 1, Aggregation.COUNT, "ASC"));
+        List<ReadTsKvQuery> queries = List.of(new BaseReadTsKvQuery(LONG_KEY, TS, TS + 99999, 50000, 1, Aggregation.COUNT, ASC_ORDER));
 
         List<TsKvEntry> entries = tsService.findAll(entityId, queries).get();
         Assert.assertEquals(2, entries.size());
@@ -179,7 +180,7 @@ public class TimeseriesServiceTest extends AbstractServiceTest {
         }
         saveEntries(entityId, TS + 80000L + 1L);
 
-        List<ReadTsKvQuery> queries = List.of(new BaseReadTsKvQuery(LONG_KEY, TS, TS + 80000, 50000, 1, Aggregation.COUNT, "ASC"));
+        List<ReadTsKvQuery> queries = List.of(new BaseReadTsKvQuery(LONG_KEY, TS, TS + 80000, 50000, 1, Aggregation.COUNT, ASC_ORDER));
 
         List<TsKvEntry> entries = tsService.findAll(entityId, queries).get();
         Assert.assertEquals(2, entries.size());
@@ -194,7 +195,7 @@ public class TimeseriesServiceTest extends AbstractServiceTest {
             saveEntries(entityId, i);
         }
 
-        List<ReadTsKvQuery> queries = List.of(new BaseReadTsKvQuery(LONG_KEY, TS, TS + 99999, 50000, 1, Aggregation.COUNT, "ASC"));
+        List<ReadTsKvQuery> queries = List.of(new BaseReadTsKvQuery(LONG_KEY, TS, TS + 99999, 50000, 1, Aggregation.COUNT, ASC_ORDER));
 
         List<TsKvEntry> entries = tsService.findAll(entityId, queries).get();
         Assert.assertEquals(2, entries.size());
@@ -209,7 +210,7 @@ public class TimeseriesServiceTest extends AbstractServiceTest {
             saveEntries(entityId, i);
         }
 
-        List<ReadTsKvQuery> queries = List.of(new BaseReadTsKvQuery(LONG_KEY, TS, TS + 80000, 50000, 1, Aggregation.COUNT, "ASC"));
+        List<ReadTsKvQuery> queries = List.of(new BaseReadTsKvQuery(LONG_KEY, TS, TS + 80000, 50000, 1, Aggregation.COUNT, ASC_ORDER));
 
         List<TsKvEntry> entries = tsService.findAll(entityId, queries).get();
         Assert.assertEquals(2, entries.size());
@@ -263,7 +264,7 @@ public class TimeseriesServiceTest extends AbstractServiceTest {
         assertEquals(Optional.of(400L), list.get(2).getLongValue());
 
         list = tsService.findAll(entityId, Collections.singletonList(new BaseReadTsKvQuery(LONG_KEY, 0,
-                60000, 20000, 3, Aggregation.AVG, "ASC"))).get(MAX_TIMEOUT, TimeUnit.SECONDS);
+                60000, 20000, 3, Aggregation.AVG, ASC_ORDER))).get(MAX_TIMEOUT, TimeUnit.SECONDS);
         assertEquals(3, list.size());
         assertEquals(10000, list.get(0).getTs());
         assertEquals(Optional.of(150.0), list.get(0).getDoubleValue());
@@ -275,7 +276,7 @@ public class TimeseriesServiceTest extends AbstractServiceTest {
         assertEquals(Optional.of(550.0), list.get(2).getDoubleValue());
 
         list = tsService.findAll(entityId, Collections.singletonList(new BaseReadTsKvQuery(LONG_KEY, 0,
-                60000, 20000, 3, Aggregation.SUM, "ASC"))).get(MAX_TIMEOUT, TimeUnit.SECONDS);
+                60000, 20000, 3, Aggregation.SUM, ASC_ORDER))).get(MAX_TIMEOUT, TimeUnit.SECONDS);
 
         assertEquals(3, list.size());
         assertEquals(10000, list.get(0).getTs());
@@ -288,7 +289,7 @@ public class TimeseriesServiceTest extends AbstractServiceTest {
         assertEquals(Optional.of(1100L), list.get(2).getLongValue());
 
         list = tsService.findAll(entityId, Collections.singletonList(new BaseReadTsKvQuery(LONG_KEY, 0,
-                60000, 20000, 3, Aggregation.MIN, "ASC"))).get(MAX_TIMEOUT, TimeUnit.SECONDS);
+                60000, 20000, 3, Aggregation.MIN, ASC_ORDER))).get(MAX_TIMEOUT, TimeUnit.SECONDS);
 
         assertEquals(3, list.size());
         assertEquals(10000, list.get(0).getTs());
@@ -301,7 +302,7 @@ public class TimeseriesServiceTest extends AbstractServiceTest {
         assertEquals(Optional.of(500L), list.get(2).getLongValue());
 
         list = tsService.findAll(entityId, Collections.singletonList(new BaseReadTsKvQuery(LONG_KEY, 0,
-                60000, 20000, 3, Aggregation.MAX, "ASC"))).get(MAX_TIMEOUT, TimeUnit.SECONDS);
+                60000, 20000, 3, Aggregation.MAX, ASC_ORDER))).get(MAX_TIMEOUT, TimeUnit.SECONDS);
 
         assertEquals(3, list.size());
         assertEquals(10000, list.get(0).getTs());
@@ -314,7 +315,7 @@ public class TimeseriesServiceTest extends AbstractServiceTest {
         assertEquals(Optional.of(600L), list.get(2).getLongValue());
 
         list = tsService.findAll(entityId, Collections.singletonList(new BaseReadTsKvQuery(LONG_KEY, 0,
-                60000, 20000, 3, Aggregation.COUNT, "ASC"))).get(MAX_TIMEOUT, TimeUnit.SECONDS);
+                60000, 20000, 3, Aggregation.COUNT, ASC_ORDER))).get(MAX_TIMEOUT, TimeUnit.SECONDS);
 
         assertEquals(3, list.size());
         assertEquals(10000, list.get(0).getTs());

--- a/dao/src/test/java/org/thingsboard/mqtt/broker/dao/service/TimeseriesServiceTest.java
+++ b/dao/src/test/java/org/thingsboard/mqtt/broker/dao/service/TimeseriesServiceTest.java
@@ -130,7 +130,7 @@ public class TimeseriesServiceTest extends AbstractServiceTest {
         saveEntries(entityId, TS);
         saveEntries(entityId, TS + 1L);
 
-        List<ReadTsKvQuery> queries = List.of(new BaseReadTsKvQuery(LONG_KEY, TS, TS, 1, 1, Aggregation.COUNT, DESC_ORDER));
+        List<ReadTsKvQuery> queries = List.of(new BaseReadTsKvQuery(LONG_KEY, TS, TS, 1, 1, Aggregation.COUNT, "ASC"));
 
         List<TsKvEntry> entries = tsService.findAll(entityId, queries).get();
         Assert.assertEquals(1, entries.size());
@@ -146,7 +146,7 @@ public class TimeseriesServiceTest extends AbstractServiceTest {
         }
         saveEntries(entityId, TS + 100L + 1L);
 
-        List<ReadTsKvQuery> queries = List.of(new BaseReadTsKvQuery(LONG_KEY, TS, TS + 100, 100, 1, Aggregation.COUNT, DESC_ORDER));
+        List<ReadTsKvQuery> queries = List.of(new BaseReadTsKvQuery(LONG_KEY, TS, TS + 100, 100, 1, Aggregation.COUNT, "ASC"));
 
         List<TsKvEntry> entries = tsService.findAll(entityId, queries).get();
         Assert.assertEquals(1, entries.size());
@@ -162,7 +162,7 @@ public class TimeseriesServiceTest extends AbstractServiceTest {
         }
         saveEntries(entityId, TS + 100000L + 1L);
 
-        List<ReadTsKvQuery> queries = List.of(new BaseReadTsKvQuery(LONG_KEY, TS, TS + 99999, 50000, 1, Aggregation.COUNT, DESC_ORDER));
+        List<ReadTsKvQuery> queries = List.of(new BaseReadTsKvQuery(LONG_KEY, TS, TS + 99999, 50000, 1, Aggregation.COUNT, "ASC"));
 
         List<TsKvEntry> entries = tsService.findAll(entityId, queries).get();
         Assert.assertEquals(2, entries.size());
@@ -179,7 +179,7 @@ public class TimeseriesServiceTest extends AbstractServiceTest {
         }
         saveEntries(entityId, TS + 80000L + 1L);
 
-        List<ReadTsKvQuery> queries = List.of(new BaseReadTsKvQuery(LONG_KEY, TS, TS + 80000, 50000, 1, Aggregation.COUNT, DESC_ORDER));
+        List<ReadTsKvQuery> queries = List.of(new BaseReadTsKvQuery(LONG_KEY, TS, TS + 80000, 50000, 1, Aggregation.COUNT, "ASC"));
 
         List<TsKvEntry> entries = tsService.findAll(entityId, queries).get();
         Assert.assertEquals(2, entries.size());
@@ -194,7 +194,7 @@ public class TimeseriesServiceTest extends AbstractServiceTest {
             saveEntries(entityId, i);
         }
 
-        List<ReadTsKvQuery> queries = List.of(new BaseReadTsKvQuery(LONG_KEY, TS, TS + 99999, 50000, 1, Aggregation.COUNT, DESC_ORDER));
+        List<ReadTsKvQuery> queries = List.of(new BaseReadTsKvQuery(LONG_KEY, TS, TS + 99999, 50000, 1, Aggregation.COUNT, "ASC"));
 
         List<TsKvEntry> entries = tsService.findAll(entityId, queries).get();
         Assert.assertEquals(2, entries.size());
@@ -209,7 +209,7 @@ public class TimeseriesServiceTest extends AbstractServiceTest {
             saveEntries(entityId, i);
         }
 
-        List<ReadTsKvQuery> queries = List.of(new BaseReadTsKvQuery(LONG_KEY, TS, TS + 80000, 50000, 1, Aggregation.COUNT, DESC_ORDER));
+        List<ReadTsKvQuery> queries = List.of(new BaseReadTsKvQuery(LONG_KEY, TS, TS + 80000, 50000, 1, Aggregation.COUNT, "ASC"));
 
         List<TsKvEntry> entries = tsService.findAll(entityId, queries).get();
         Assert.assertEquals(2, entries.size());
@@ -263,7 +263,7 @@ public class TimeseriesServiceTest extends AbstractServiceTest {
         assertEquals(Optional.of(400L), list.get(2).getLongValue());
 
         list = tsService.findAll(entityId, Collections.singletonList(new BaseReadTsKvQuery(LONG_KEY, 0,
-                60000, 20000, 3, Aggregation.AVG))).get(MAX_TIMEOUT, TimeUnit.SECONDS);
+                60000, 20000, 3, Aggregation.AVG, "ASC"))).get(MAX_TIMEOUT, TimeUnit.SECONDS);
         assertEquals(3, list.size());
         assertEquals(10000, list.get(0).getTs());
         assertEquals(Optional.of(150.0), list.get(0).getDoubleValue());
@@ -275,7 +275,7 @@ public class TimeseriesServiceTest extends AbstractServiceTest {
         assertEquals(Optional.of(550.0), list.get(2).getDoubleValue());
 
         list = tsService.findAll(entityId, Collections.singletonList(new BaseReadTsKvQuery(LONG_KEY, 0,
-                60000, 20000, 3, Aggregation.SUM))).get(MAX_TIMEOUT, TimeUnit.SECONDS);
+                60000, 20000, 3, Aggregation.SUM, "ASC"))).get(MAX_TIMEOUT, TimeUnit.SECONDS);
 
         assertEquals(3, list.size());
         assertEquals(10000, list.get(0).getTs());
@@ -288,7 +288,7 @@ public class TimeseriesServiceTest extends AbstractServiceTest {
         assertEquals(Optional.of(1100L), list.get(2).getLongValue());
 
         list = tsService.findAll(entityId, Collections.singletonList(new BaseReadTsKvQuery(LONG_KEY, 0,
-                60000, 20000, 3, Aggregation.MIN))).get(MAX_TIMEOUT, TimeUnit.SECONDS);
+                60000, 20000, 3, Aggregation.MIN, "ASC"))).get(MAX_TIMEOUT, TimeUnit.SECONDS);
 
         assertEquals(3, list.size());
         assertEquals(10000, list.get(0).getTs());
@@ -301,7 +301,7 @@ public class TimeseriesServiceTest extends AbstractServiceTest {
         assertEquals(Optional.of(500L), list.get(2).getLongValue());
 
         list = tsService.findAll(entityId, Collections.singletonList(new BaseReadTsKvQuery(LONG_KEY, 0,
-                60000, 20000, 3, Aggregation.MAX))).get(MAX_TIMEOUT, TimeUnit.SECONDS);
+                60000, 20000, 3, Aggregation.MAX, "ASC"))).get(MAX_TIMEOUT, TimeUnit.SECONDS);
 
         assertEquals(3, list.size());
         assertEquals(10000, list.get(0).getTs());
@@ -314,7 +314,7 @@ public class TimeseriesServiceTest extends AbstractServiceTest {
         assertEquals(Optional.of(600L), list.get(2).getLongValue());
 
         list = tsService.findAll(entityId, Collections.singletonList(new BaseReadTsKvQuery(LONG_KEY, 0,
-                60000, 20000, 3, Aggregation.COUNT))).get(MAX_TIMEOUT, TimeUnit.SECONDS);
+                60000, 20000, 3, Aggregation.COUNT, "ASC"))).get(MAX_TIMEOUT, TimeUnit.SECONDS);
 
         assertEquals(3, list.size());
         assertEquals(10000, list.get(0).getTs());


### PR DESCRIPTION
## Pull Request description

Implemented logic to correctly handle sorting order (ASC for ascending and DESC for descending) in aggregation queries. Previously, only ASC order was used by default, with no option for customization.

## General checklist

- [x] You have reviewed the guidelines [document](https://docs.google.com/document/d/1A4Vc3wrHsY_159b9RG5LOtCryoH6VPwgOhrFEzJKwbI/edit?usp=sharing).
- [x] [Labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels#about-labels) that classify your pull request have been added.
- [x] The [milestone](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones) is specified and corresponds to fix version.
- [x] Description references specific [issue](https://github.com/thingsboard/tbmq/issues).
- [x] Description contains human-readable scope of changes.
- [x] Description contains brief notes about what needs to be added to the documentation.
- [x] No merge conflicts, commented blocks of code, code formatting issues.
- [x] Changes are backward compatible or upgrade script is provided.

## Front-End feature checklist

- [x] Screenshots with affected component(s) are added. The best option is to provide 2 screens: before and after changes;
- [x] If you change the widget or other API, ensure it is backward-compatible or upgrade script is present.

## Back-End feature checklist

- [x] Added corresponding unit and/or integration test(s). Provide written explanation in the PR description if you have failed to add tests.
- [x] If new dependency was added: the dependency tree is checked for conflicts.

