### PR TITLE
Reset lastPersistedMsgSentPacketId counter on device disconnect to prevent skipped messages

### DIFF
--- a/application/src/main/java/org/thingsboard/mqtt/broker/actors/device/PersistedDeviceActorMessageProcessor.java
+++ b/application/src/main/java/org/thingsboard/mqtt/broker/actors/device/PersistedDeviceActorMessageProcessor.java
@@ -190,6 +190,7 @@ class PersistedDeviceActorMessageProcessor extends AbstractContextAwareMsgProces
 
     public void processDeviceDisconnect(TbActorCtx actorCtx) {
         this.sessionCtx = null;
+        this.lastPersistedMsgSentPacketId = 0L;
         long delayMs = TimeUnit.MINUTES.toMillis(deviceActorConfig.getWaitBeforeActorStopMinutes());
         this.stopActorCommandUUID = UUID.randomUUID();
         systemContext.scheduleMsgWithDelay(actorCtx, new StopDeviceActorCommandMsg(stopActorCommandUUID), delayMs);

--- a/application/src/test/java/org/thingsboard/mqtt/broker/actors/device/PersistedDeviceActorMessageProcessorTest.java
+++ b/application/src/test/java/org/thingsboard/mqtt/broker/actors/device/PersistedDeviceActorMessageProcessorTest.java
@@ -290,6 +290,7 @@ public class PersistedDeviceActorMessageProcessorTest {
         persistedDeviceActorMessageProcessor.processDeviceDisconnect(tbActorCtx);
 
         assertNull(persistedDeviceActorMessageProcessor.getSessionCtx());
+        assertEquals(0L, persistedDeviceActorMessageProcessor.getLastPersistedMsgSentPacketId());
         assertNotNull(persistedDeviceActorMessageProcessor.getStopActorCommandUUID());
     }
 


### PR DESCRIPTION
## Pull Request description

Fixed an issue where `lastPersistedMsgSentPacketId` was not reset to 0 on device disconnect, leading to skipped messages after reconnecting with `clean_session = false`.

Details:

The issue occurred only if the previous session was a clean session, but before the clean session, a persistent session existed. In this scenario, the actor retained an outdated `lastPersistedMsgSentPacketId`, leading to skipped messages during message delivery in the subsequent persisted session.

Steps to Reproduce (STR):
1. Connect a persistent DEVICE client and receive several messages (`clean_session = false`).
2. Disconnect the client.
3. Send additional messages while the client is offline.
4. Go online to receive additional messages and update `lastPersistedMsgSentPacketId`.
5. Reconnect with `clean_session = true` and the same client ID.
6. Disconnect and reconnect with `clean_session = false`.
7. Send more messages.

Observed Behavior:

Messages are skipped because `lastPersistedMsgSentPacketId` retains an outdated value from the previous persistent session.

Fix:

The `lastPersistedMsgSentPacketId` is now reset to 0 on device disconnect, ensuring proper state management for new sessions.

## General checklist

- [x] You have reviewed the guidelines [document](https://docs.google.com/document/d/1A4Vc3wrHsY_159b9RG5LOtCryoH6VPwgOhrFEzJKwbI/edit?usp=sharing).
- [x] [Labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels#about-labels) that classify your pull request have been added.
- [x] The [milestone](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones) is specified and corresponds to fix version.
- [x] Description references specific [issue](https://github.com/thingsboard/tbmq/issues).
- [x] Description contains human-readable scope of changes.
- [x] Description contains brief notes about what needs to be added to the documentation.
- [x] No merge conflicts, commented blocks of code, code formatting issues.
- [x] Changes are backward compatible or upgrade script is provided.

## Back-End feature checklist

- [x] Added corresponding unit and/or integration test(s). Provide written explanation in the PR description if you have failed to add tests.
- [x] If new dependency was added: the dependency tree is checked for conflicts.

