### PR TITLE
Fix MqttConnAckMessage incorrectly returns AuthMethod property even if no enhanced auth is used

### DIFF
--- a/application/src/main/java/org/thingsboard/mqtt/broker/service/mqtt/DefaultMqttMessageCreator.java
+++ b/application/src/main/java/org/thingsboard/mqtt/broker/service/mqtt/DefaultMqttMessageCreator.java
@@ -132,7 +132,11 @@ public class DefaultMqttMessageCreator implements MqttMessageGenerator {
             MqttPropertiesUtil.addResponseInfoToProps(properties, responseInfo);
         }
         MqttPropertiesUtil.addReceiveMaxToProps(properties, maxInFlightMessages);
-        MqttPropertiesUtil.addAuthMethodToProps(properties, MqttPropertiesUtil.getAuthenticationMethodValue(msg.getProperties()));
+
+        String authMethod = MqttPropertiesUtil.getAuthenticationMethodValue(msg.getProperties());
+        if (authMethod != null) {
+            MqttPropertiesUtil.addAuthMethodToProps(properties, authMethod);
+        }
         MqttConnAckVariableHeader mqttConnAckVariableHeader =
                 new MqttConnAckVariableHeader(CONNECTION_ACCEPTED, sessionPresent, properties);
         return new MqttConnAckMessage(mqttFixedHeader, mqttConnAckVariableHeader);


### PR DESCRIPTION
## Pull Request description
Resolves #204 

Fixes that MqttConnAckMessage returns an empty string for AuthMethod in CONNACK properties even if it was null.
While it is a very minor change i opted to target the main branch here as this is spec breaking and making some client libraries entirely unusable with tbmq. If this should be pushed back to the next release instead i can change the target branch.

(Not the unit test is kinda ugly with all the mocks but it works (i verified it afterwards as i had pushed the fix before even reading the pr guideline doc). Open to options how to do this better

## General checklist

- [x] You have reviewed the guidelines [document](https://docs.google.com/document/d/1A4Vc3wrHsY_159b9RG5LOtCryoH6VPwgOhrFEzJKwbI/edit?usp=sharing).
- [ ] [Labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels#about-labels) that classify your pull request have been added.
- [ ] The [milestone](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones) is specified and corresponds to fix version.
- [x] Description references specific [issue](https://github.com/thingsboard/tbmq/issues).
- [x] Description contains human-readable scope of changes.
- [x] Description contains brief notes about what needs to be added to the documentation.
- [x] No merge conflicts, commented blocks of code, code formatting issues.
- [X] Changes are backward compatible or upgrade script is provided.

## Back-End feature checklist

- [X] Added corresponding unit and/or integration test(s). Provide written explanation in the PR description if you have failed to add tests.
- [X] If new dependency was added: the dependency tree is checked for conflicts.

