### PR TITLE
Backpressure on data receiving

### DIFF
--- a/application/src/main/java/org/thingsboard/mqtt/broker/server/AbstractMqttServerBootstrap.java
+++ b/application/src/main/java/org/thingsboard/mqtt/broker/server/AbstractMqttServerBootstrap.java
@@ -42,6 +42,8 @@ public abstract class AbstractMqttServerBootstrap implements MqttServerBootstrap
     private int writeBufferHighWaterMark;
     @Value("#{${listener.write_buffer_low_water_mark:32} * 1024}")
     private int writeBufferLowWaterMark;
+    @Value("#{${listener.so_receive_buffer:0} * 1024}")
+    private int soReceiveBuffer;
 
     private Channel serverChannel;
     private EventLoopGroup bossGroup;
@@ -60,6 +62,9 @@ public abstract class AbstractMqttServerBootstrap implements MqttServerBootstrap
                 .childHandler(getChannelInitializer())
                 .childOption(ChannelOption.SO_KEEPALIVE, isKeepAlive())
                 .childOption(ChannelOption.WRITE_BUFFER_WATER_MARK, getWriteBufferWaterMark());
+        if (soReceiveBuffer > 0) {
+            b.childOption(ChannelOption.SO_RCVBUF, soReceiveBuffer);
+        }
 
         serverChannel = b.bind(getHost(), getPort()).sync().channel();
         log.info("[{}] Mqtt server started on port {}!", getServerName(), getPort());

--- a/application/src/main/resources/thingsboard-mqtt-broker.yml
+++ b/application/src/main/resources/thingsboard-mqtt-broker.yml
@@ -62,6 +62,9 @@ listener:
   write_buffer_high_water_mark: "${NETTY_WRITE_BUFFER_HIGH_WATER_MARK:64}"
   # The threshold (in KB) where Netty considers the channel writable again. When the limit reached, TBMQ starts delivering data to subscriber
   write_buffer_low_water_mark: "${NETTY_WRITE_BUFFER_LOW_WATER_MARK:32}"
+  # Socket receive buffer size for Netty in KB. If the buffer limit is reached, TCP will trigger backpressure and notify the sender to slow down.
+  # If set to 0 (default), the system's default buffer size will be used
+  so_receive_buffer: "${NETTY_SO_RECEIVE_BUFFER:0}"
   tcp:
     # Enable/disable MQTT TCP port listener
     enabled: "${LISTENER_TCP_ENABLED:true}"


### PR DESCRIPTION
## Pull Request description

Introduced a configurable setting for the Netty socket receive buffer size (`so_receive_buffer`) in the YAML configuration.

**Details:**
- The new setting allows specifying the socket receive buffer size in **KB**.
- The default value is `0`, which means the system's default buffer size will be used.
- This configuration can help fine-tune performance under high network load.
- If the buffer becomes full, TCP will apply backpressure and signal the sender to reduce the sending rate.

This change provides better control over buffer management, especially useful in environments with varying traffic patterns or resource constraints.

## General checklist

- [x] You have reviewed the guidelines [document](https://docs.google.com/document/d/1A4Vc3wrHsY_159b9RG5LOtCryoH6VPwgOhrFEzJKwbI/edit?usp=sharing).
- [x] [Labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels#about-labels) that classify your pull request have been added.
- [x] The [milestone](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones) is specified and corresponds to fix version.
- [x] Description references specific [issue](https://github.com/thingsboard/tbmq/issues).
- [x] Description contains human-readable scope of changes.
- [x] Description contains brief notes about what needs to be added to the documentation.
- [x] No merge conflicts, commented blocks of code, code formatting issues.
- [x] Changes are backward compatible or upgrade script is provided.

## Front-End feature checklist

- [x] Screenshots with affected component(s) are added. The best option is to provide 2 screens: before and after changes;
- [x] If you change the widget or other API, ensure it is backward-compatible or upgrade script is present.

## Back-End feature checklist

- [x] Added corresponding unit and/or integration test(s). Provide written explanation in the PR description if you have failed to add tests.
- [x] If new dependency was added: the dependency tree is checked for conflicts.

