### PR TITLE
Enable proxy protocol

### DIFF
--- a/application/src/main/java/org/thingsboard/mqtt/broker/server/AbstractMqttChannelInitializer.java
+++ b/application/src/main/java/org/thingsboard/mqtt/broker/server/AbstractMqttChannelInitializer.java
@@ -18,6 +18,7 @@ package org.thingsboard.mqtt.broker.server;
 import io.netty.channel.ChannelInitializer;
 import io.netty.channel.ChannelPipeline;
 import io.netty.channel.socket.SocketChannel;
+import io.netty.handler.codec.haproxy.HAProxyMessageDecoder;
 import io.netty.handler.codec.mqtt.MqttDecoder;
 import io.netty.handler.codec.mqtt.MqttEncoder;
 import io.netty.handler.ssl.SslHandler;
@@ -25,6 +26,7 @@ import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.thingsboard.mqtt.broker.server.ip.IpAddressHandler;
+import org.thingsboard.mqtt.broker.server.ip.ProxyIpFilter;
 import org.thingsboard.mqtt.broker.server.traffic.DuplexTrafficHandler;
 
 @Slf4j
@@ -35,6 +37,8 @@ public abstract class AbstractMqttChannelInitializer extends ChannelInitializer<
     private int maxClientIdLength;
     @Value("${historical-data-report.enabled:true}")
     private boolean historicalDataReportEnabled;
+    @Value("${listener.proxy_enabled:false}")
+    private boolean proxyProtocolEnabled;
 
     private final MqttHandlerFactory handlerFactory;
 
@@ -45,7 +49,13 @@ public abstract class AbstractMqttChannelInitializer extends ChannelInitializer<
     @Override
     public void initChannel(SocketChannel ch) {
         ChannelPipeline pipeline = ch.pipeline();
-        pipeline.addLast(new IpAddressHandler());
+
+        if (proxyProtocolEnabled) {
+            pipeline.addLast("proxy", new HAProxyMessageDecoder());
+            pipeline.addLast("ipFilter", new ProxyIpFilter());
+        } else {
+            pipeline.addLast("ipFilter", new IpAddressHandler());
+        }
 
         SslHandler sslHandler = getSslHandler();
         if (sslHandler != null) {

--- a/application/src/main/java/org/thingsboard/mqtt/broker/server/ip/ProxyIpFilter.java
+++ b/application/src/main/java/org/thingsboard/mqtt/broker/server/ip/ProxyIpFilter.java
@@ -1,0 +1,49 @@
+/**
+ * Copyright © 2016-2025 The Thingsboard Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.thingsboard.mqtt.broker.server.ip;
+
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.handler.codec.haproxy.HAProxyMessage;
+import lombok.extern.slf4j.Slf4j;
+import org.thingsboard.mqtt.broker.server.MqttSessionHandler;
+
+import java.net.InetSocketAddress;
+
+@Slf4j
+public class ProxyIpFilter extends ChannelInboundHandlerAdapter {
+
+    @Override
+    public void channelRead(ChannelHandlerContext ctx, Object msg) {
+        log.trace("[{}] Received msg: {}", ctx.channel().id(), msg);
+        if (msg instanceof HAProxyMessage proxyMsg) {
+            if (proxyMsg.sourceAddress() != null && proxyMsg.sourcePort() > 0) {
+                InetSocketAddress address = new InetSocketAddress(proxyMsg.sourceAddress(), proxyMsg.sourcePort());
+                log.trace("[{}] Setting address: {}", ctx.channel().id(), address);
+                ctx.channel().attr(MqttSessionHandler.ADDRESS).set(address);
+                // We no longer need this channel in the pipeline. Similar to HAProxyMessageDecoder
+                ctx.pipeline().remove(this);
+            } else {
+                log.trace("Received local health-check connection message: {}", proxyMsg);
+                ctx.close();
+            }
+        } else {
+            log.warn("[{}] Received unexpected msg, expected HAProxyMessage: {}", ctx.channel().id(), msg);
+            ctx.close();
+        }
+    }
+
+}

--- a/application/src/main/resources/thingsboard-mqtt-broker.yml
+++ b/application/src/main/resources/thingsboard-mqtt-broker.yml
@@ -55,6 +55,9 @@ server:
 
 # MQTT listeners parameters
 listener:
+  # Enable proxy protocol support. Disabled by default. If enabled, supports both v1 and v2.
+  # Useful to get the real IP address of the client in the logs, for session details info and unauthorized clients feature
+  proxy_enabled: "${MQTT_PROXY_PROTOCOL_ENABLED:false}"
   # Netty leak detector level: DISABLED, SIMPLE, ADVANCED, PARANOID. It is set globally for all listeners
   leak_detector_level: "${NETTY_LEAK_DETECTOR_LVL:DISABLED}"
   tcp:


### PR DESCRIPTION
## Pull Request description

#216 

This PR enables support for the PROXY protocol to correctly capture the real client IP address when traffic is forwarded through a load balancer (e.g., AWS NLB).

**Changes:**
- Added `HAProxyMessageDecoder` to the Netty pipeline when PROXY protocol is enabled.
- Introduced `ProxyIpFilter` to extract the client IP and port from the decoded `HAProxyMessage`.
- Conditionally fall back to default `IpAddressHandler` if PROXY protocol is not enabled.

**Why:**
When behind a load balancer, the application sees the LB IP instead of the real client IP. The PROXY protocol solves this by including client metadata in the initial TCP connection, which we now parse and use internally.

## General checklist

- [x] You have reviewed the guidelines [document](https://docs.google.com/document/d/1A4Vc3wrHsY_159b9RG5LOtCryoH6VPwgOhrFEzJKwbI/edit?usp=sharing).
- [x] [Labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels#about-labels) that classify your pull request have been added.
- [x] The [milestone](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones) is specified and corresponds to fix version.
- [x] Description references specific [issue](https://github.com/thingsboard/tbmq/issues).
- [x] Description contains human-readable scope of changes.
- [x] Description contains brief notes about what needs to be added to the documentation.
- [x] No merge conflicts, commented blocks of code, code formatting issues.
- [x] Changes are backward compatible or upgrade script is provided.

## Front-End feature checklist

- [x] Screenshots with affected component(s) are added. The best option is to provide 2 screens: before and after changes;
- [x] If you change the widget or other API, ensure it is backward-compatible or upgrade script is present.

## Back-End feature checklist

- [x] Added corresponding unit and/or integration test(s). Provide written explanation in the PR description if you have failed to add tests.
- [x] If new dependency was added: the dependency tree is checked for conflicts.

