### PR TITLE
Fix handling of QoS 0 publish messages for integration subscriptions

### DIFF
--- a/application/src/main/java/org/thingsboard/mqtt/broker/service/processing/data/PersistentMsgSubscriptions.java
+++ b/application/src/main/java/org/thingsboard/mqtt/broker/service/processing/data/PersistentMsgSubscriptions.java
@@ -62,21 +62,33 @@ public class PersistentMsgSubscriptions {
 
     public void addToDevices(Subscription subscription, int size) {
         if (deviceSubscriptions == null) {
-            deviceSubscriptions = initArrayList(size);
+            synchronized (this) {
+                if (deviceSubscriptions == null) {
+                    deviceSubscriptions = initArrayList(size);
+                }
+            }
         }
         deviceSubscriptions.add(subscription);
     }
 
     public void addToApplications(Subscription subscription, int size) {
         if (applicationSubscriptions == null) {
-            applicationSubscriptions = initArrayList(size);
+            synchronized (this) {
+                if (applicationSubscriptions == null) {
+                    applicationSubscriptions = initArrayList(size);
+                }
+            }
         }
         applicationSubscriptions.add(subscription);
     }
 
     public void addToIntegrations(Subscription subscription, int size) {
         if (integrationSubscriptions == null) {
-            integrationSubscriptions = initArrayList(size);
+            synchronized (this) {
+                if (integrationSubscriptions == null) {
+                    integrationSubscriptions = initArrayList(size);
+                }
+            }
         }
         integrationSubscriptions.add(subscription);
     }

--- a/application/src/test/java/org/thingsboard/mqtt/broker/service/processing/data/PersistentMsgSubscriptionsTest.java
+++ b/application/src/test/java/org/thingsboard/mqtt/broker/service/processing/data/PersistentMsgSubscriptionsTest.java
@@ -1,0 +1,171 @@
+/**
+ * Copyright © 2016-2025 The Thingsboard Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.thingsboard.mqtt.broker.service.processing.data;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.thingsboard.mqtt.broker.common.data.ClientSessionInfo;
+import org.thingsboard.mqtt.broker.common.data.ClientType;
+import org.thingsboard.mqtt.broker.common.data.MqttQoS;
+import org.thingsboard.mqtt.broker.gen.queue.PublishMsgProto;
+import org.thingsboard.mqtt.broker.service.processing.MsgProcessingCallback;
+import org.thingsboard.mqtt.broker.service.subscription.Subscription;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class PersistentMsgSubscriptionsTest {
+
+    private MsgProcessingCallback callback;
+    private PersistentMsgSubscriptions subscriptions;
+    private PublishMsgProto atMostOnceMsg;
+    private PublishMsgProto atLeastOnceMsg;
+
+    @BeforeEach
+    void setup() {
+        callback = mock(MsgProcessingCallback.class);
+        subscriptions = new PersistentMsgSubscriptions(false, null);
+
+        atMostOnceMsg = mock(PublishMsgProto.class);
+        when(atMostOnceMsg.getQos()).thenReturn(MqttQoS.AT_MOST_ONCE.value());
+
+        atLeastOnceMsg = mock(PublishMsgProto.class);
+        when(atLeastOnceMsg.getQos()).thenReturn(MqttQoS.AT_LEAST_ONCE.value());
+    }
+
+    private Subscription mockSub(ClientType type, boolean persistentSession, int qos) {
+        Subscription sub = mock(Subscription.class);
+        when(sub.getClientType()).thenReturn(type);
+        when(sub.getQos()).thenReturn(qos);
+
+        ClientSessionInfo sessionInfo = mock(ClientSessionInfo.class);
+        when(sessionInfo.isPersistent()).thenReturn(persistentSession);
+        when(sub.getClientSessionInfo()).thenReturn(sessionInfo);
+
+        return sub;
+    }
+
+    @Test
+    void givenIntegration_whenPubQos0_thenSubscriptionIsStoredAndNoImmediateCallback() {
+        Subscription sub = mockSub(ClientType.INTEGRATION, true, MqttQoS.AT_LEAST_ONCE.value());
+
+        subscriptions.processSubscriptions(List.of(sub), atMostOnceMsg, callback);
+
+        assertThat(subscriptions.getIntegrationSubscriptions().size()).isEqualTo(1);
+        verify(callback, never()).accept(sub);
+    }
+
+    @Test
+    void givenPersistentDev_whenPubQos0_thenTriggersCallbackDirectly() {
+        Subscription sub = mockSub(ClientType.DEVICE, true, MqttQoS.AT_LEAST_ONCE.value());
+
+        subscriptions.processSubscriptions(List.of(sub), atMostOnceMsg, callback);
+
+        verify(callback).accept(sub);
+        assertNull(subscriptions.getDeviceSubscriptions());
+    }
+
+    @Test
+    void givenPersistentApp_whenPubQos0_thenTriggersCallbackDirectly() {
+        Subscription sub = mockSub(ClientType.APPLICATION, true, MqttQoS.AT_LEAST_ONCE.value());
+
+        subscriptions.processSubscriptions(List.of(sub), atMostOnceMsg, callback);
+
+        verify(callback).accept(sub);
+        assertNull(subscriptions.getApplicationSubscriptions());
+    }
+
+    @Test
+    void givenPersistentSubAndDeviceQos1_whenPubQos1_thenSubscriptionIsStoredAndNoImmediateCallback() {
+        Subscription sub = mockSub(ClientType.DEVICE, true, MqttQoS.AT_LEAST_ONCE.value());
+
+        subscriptions.processSubscriptions(List.of(sub), atLeastOnceMsg, callback);
+
+        assertThat(subscriptions.getDeviceSubscriptions().size()).isEqualTo(1);
+        verify(callback, never()).accept(sub);
+    }
+
+    @Test
+    void givenPersistentSubAndAppQos1_whenPubQos1_thenSubscriptionIsStoredAndNoImmediateCallback() {
+        Subscription sub = mockSub(ClientType.APPLICATION, true, MqttQoS.AT_LEAST_ONCE.value());
+
+        subscriptions.processSubscriptions(List.of(sub), atLeastOnceMsg, callback);
+
+        assertThat(subscriptions.getApplicationSubscriptions().size()).isEqualTo(1);
+        verify(callback, never()).accept(sub);
+    }
+
+    @Test
+    void givenIntegrationSub_whenPubQos1_thenSubscriptionIsStoredAndNoImmediateCallback() {
+        Subscription sub = mockSub(ClientType.INTEGRATION, true, MqttQoS.AT_LEAST_ONCE.value());
+
+        subscriptions.processSubscriptions(List.of(sub), atLeastOnceMsg, callback);
+
+        assertThat(subscriptions.getIntegrationSubscriptions().size()).isEqualTo(1);
+        verify(callback, never()).accept(sub);
+    }
+
+    @Test
+    void givenPersistentSubAndAppQos0_whenPubQos1_thenTriggersCallbackDirectly() {
+        Subscription sub = mockSub(ClientType.APPLICATION, true, MqttQoS.AT_MOST_ONCE.value());
+
+        subscriptions.processSubscriptions(List.of(sub), atLeastOnceMsg, callback);
+
+        assertNull(subscriptions.getApplicationSubscriptions());
+        verify(callback).accept(sub);
+    }
+
+    @Test
+    void givenNonPersistentDevSession_whenQos1_thenTriggersCallbackDirectly() {
+        Subscription sub = mockSub(ClientType.DEVICE, false, MqttQoS.AT_LEAST_ONCE.value());
+
+        subscriptions.processSubscriptions(List.of(sub), atLeastOnceMsg, callback);
+
+        verify(callback).accept(sub);
+        assertNull(subscriptions.getDeviceSubscriptions());
+    }
+
+    @Test
+    void givenPersistentSub_whenApplicationQos2_thenSubscriptionIsStored() {
+        Subscription sub = mockSub(ClientType.APPLICATION, true, MqttQoS.EXACTLY_ONCE.value());
+
+        subscriptions.processSubscriptions(List.of(sub), atLeastOnceMsg, callback);
+
+        assertThat(subscriptions.getApplicationSubscriptions().size()).isEqualTo(1);
+        verify(callback, never()).accept(sub);
+    }
+
+    @Test
+    void givenParallelProcessingWithIntegrationAndDevQos0_whenPubQos0_thenTriggersCallbackAndStoreSubscription() {
+        PersistentMsgSubscriptions parallelSubs = new PersistentMsgSubscriptions(true, null);
+
+        Subscription sub1 = mockSub(ClientType.INTEGRATION, true, MqttQoS.AT_LEAST_ONCE.value());
+        Subscription sub2 = mockSub(ClientType.DEVICE, true, MqttQoS.AT_MOST_ONCE.value());
+
+        parallelSubs.processSubscriptions(List.of(sub1, sub2), atMostOnceMsg, callback);
+
+        verify(callback).accept(any());
+        assertThat(parallelSubs.getIntegrationSubscriptions().size()).isEqualTo(1);
+    }
+
+}


### PR DESCRIPTION
## Pull Request description


When processing `PUBLISH` messages with **QoS 0**, the broker incorrectly applied the delivery logic to all subscriptions.

In the case of **INTEGRATION** subscriptions, QoS 0 messages **should not be delivered immediately**, because these messages are routed to the **Integration Executor (IE)** microservice for processing—even at QoS 0. Attempting to deliver them directly from the broker node bypassed the intended processing path.

This caused:

* For **integration subscriptions**: the message was correctly forwarded to the IE for processing, **but was also mistakenly delivered directly to the integration client**, triggering unnecessary message processing. Since the integration session does not exist on the TBMQ node, the message was silently dropped, but it still resulted in avoidable overhead.
* For **non-integration subscriptions**: the message was correctly delivered to the client, **but was also incorrectly forwarded to the IE**, which is a bug and could lead to duplicate or unintended processing.

#### Fix

Refactored the QoS 0 processing logic to:

* Immediately deliver QoS 0 messages only to non-integration clients (e.g., device, application).
* Collect integration subscriptions for routing through the IE pipeline, **without invoking direct delivery logic on the broker node**.

This ensures correct and consistent behavior across client types and respects the architectural boundary for integration message handling.


## General checklist

- [x] You have reviewed the guidelines [document](https://docs.google.com/document/d/1A4Vc3wrHsY_159b9RG5LOtCryoH6VPwgOhrFEzJKwbI/edit?usp=sharing).
- [x] [Labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels#about-labels) that classify your pull request have been added.
- [x] The [milestone](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones) is specified and corresponds to fix version.
- [x] Description references specific [issue](https://github.com/thingsboard/tbmq/issues).
- [x] Description contains human-readable scope of changes.
- [x] Description contains brief notes about what needs to be added to the documentation.
- [x] No merge conflicts, commented blocks of code, code formatting issues.
- [x] Changes are backward compatible or upgrade script is provided.

## Front-End feature checklist

- [x] Screenshots with affected component(s) are added. The best option is to provide 2 screens: before and after changes;
- [x] If you change the widget or other API, ensure it is backward-compatible or upgrade script is present.

## Back-End feature checklist

- [x] Added corresponding unit and/or integration test(s). Provide written explanation in the PR description if you have failed to add tests.
- [x] If new dependency was added: the dependency tree is checked for conflicts.

