### PR TITLE
Control allowance of root multi-lvl wildcard subscription creation

### DIFF
--- a/application/src/main/java/org/thingsboard/mqtt/broker/actors/client/service/handlers/MqttSubscribeHandler.java
+++ b/application/src/main/java/org/thingsboard/mqtt/broker/actors/client/service/handlers/MqttSubscribeHandler.java
@@ -112,6 +112,12 @@ public class MqttSubscribeHandler {
         for (TopicSubscription subscription : topicSubscriptions) {
             var topic = subscription.getTopicFilter();
 
+            if (!authorizationRuleService.isAllowRootMultiLvlWildcardSub() && topic.equals(BrokerConstants.MULTI_LEVEL_WILDCARD)) {
+                log.warn("[{}] Not allowed to subscribe to the root multi level wildcard topic {}", ctx.getClientId(), topic);
+                codes.add(MqttReasonCodeResolver.implementationSpecificError(ctx));
+                continue;
+            }
+
             if (isSharedSubscriptionWithNoLocal(subscription)) {
                 log.warn("[{}] It is a Protocol Error to set the NoLocal option to true on a Shared Subscription.", ctx.getClientId());
                 disconnectClient(ctx);

--- a/application/src/main/java/org/thingsboard/mqtt/broker/service/auth/AuthorizationRuleService.java
+++ b/application/src/main/java/org/thingsboard/mqtt/broker/service/auth/AuthorizationRuleService.java
@@ -36,4 +36,7 @@ public interface AuthorizationRuleService {
     boolean isSubAuthorized(String topic, List<AuthRulePatterns> authRulePatterns);
 
     void evict(String clientId);
+
+    boolean isAllowRootMultiLvlWildcardSub();
+
 }

--- a/application/src/main/java/org/thingsboard/mqtt/broker/service/auth/DefaultAuthorizationRuleService.java
+++ b/application/src/main/java/org/thingsboard/mqtt/broker/service/auth/DefaultAuthorizationRuleService.java
@@ -17,6 +17,7 @@ package org.thingsboard.mqtt.broker.service.auth;
 
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.util.CollectionUtils;
 import org.thingsboard.mqtt.broker.common.data.client.credentials.ClientTypeSslMqttCredentials;
@@ -47,6 +48,9 @@ import static org.thingsboard.mqtt.broker.service.auth.providers.ssl.SslAuthFail
 public class DefaultAuthorizationRuleService implements AuthorizationRuleService {
 
     private final ConcurrentMap<String, ConcurrentMap<String, Boolean>> publishAuthMap = new ConcurrentHashMap<>();
+
+    @Value("${mqtt.subscription.allow-root-multi-level-wildcard:true}")
+    private boolean allowRootMultiLvlWildcardSub;
 
     @Override
     public List<AuthRulePatterns> parseSslAuthorizationRule(ClientTypeSslMqttCredentials clientTypeSslMqttCredentials, String clientCommonName) throws AuthenticationException {

--- a/application/src/main/resources/thingsboard-mqtt-broker.yml
+++ b/application/src/main/resources/thingsboard-mqtt-broker.yml
@@ -902,6 +902,16 @@ mqtt:
     # Minimal required topic name length that Broker publishes to the client that can be replaced with topic alias
     # (e.g., if the topic has more than 50 chars - it can be replaced with alias)
     min-length-for-alias-replacement: "${MQTT_TOPIC_MIN_LENGTH_FOR_ALIAS_REPLACEMENT:50}"
+  subscription:
+    # Controls whether clients are permitted to subscribe to the root multi-level wildcard "#".
+    # If set to 'true' (default):
+    #   Clients can subscribe to "#", receiving a copy of EVERY message published to the broker.
+    #   This is useful for debugging or firehose-style monitoring services.
+    # If set to 'false':
+    #   Clients are explicitly denied permission to subscribe to the exact topic "#".
+    #   They can still subscribe to specific paths (e.g., "sensors/#") or individual topics.
+    #   Recommended for production to prevent accidental or malicious data leakage
+    allow-root-multi-level-wildcard: "${MQTT_SUBSCRIPTION_ROOT_MULTI_LVL_WILDCARD:true}"
   shared-subscriptions:
     # Processing strategy type - how messages are split between clients in a shared subscription. Supported types: ROUND_ROBIN
     processing-type: "${MQTT_SHARED_SUBSCRIPTIONS_PROCESSING_TYPE:ROUND_ROBIN}"

--- a/application/src/test/java/org/thingsboard/mqtt/broker/actors/client/service/handlers/MqttSubscribeHandlerTest.java
+++ b/application/src/test/java/org/thingsboard/mqtt/broker/actors/client/service/handlers/MqttSubscribeHandlerTest.java
@@ -403,6 +403,18 @@ public class MqttSubscribeHandlerTest {
     }
 
     @Test
+    public void givenMultiLvlRootSub_whenCollectMqttReasonCodes_thenReturnExpectedResult() {
+        when(ctx.getMqttVersion()).thenReturn(MqttVersion.MQTT_5);
+        when(authorizationRuleService.isAllowRootMultiLvlWildcardSub()).thenReturn(false);
+
+        List<TopicSubscription> topicSubscriptions = List.of(getTopicSubscription(BrokerConstants.MULTI_LEVEL_WILDCARD, 1));
+        MqttSubscribeMsg msg = new MqttSubscribeMsg(UUID.randomUUID(), 1, topicSubscriptions);
+        List<MqttReasonCodes.SubAck> reasonCodes = mqttSubscribeHandler.collectMqttReasonCodes(ctx, msg);
+
+        assertEquals(List.of(MqttReasonCodes.SubAck.IMPLEMENTATION_SPECIFIC_ERROR), reasonCodes);
+    }
+
+    @Test
     public void givenMqttSubscribeMsg_whenCollectMqttReasonCodes_thenReturnExpectedResult() {
         when(ctx.getMqttVersion()).thenReturn(MqttVersion.MQTT_5);
         doThrow(DataValidationException.class).when(topicValidationService).validateTopicFilter(eq("topic1"));


### PR DESCRIPTION
## Pull Request description

Controls whether clients are permitted to subscribe to the root multi-level wildcard "#".
* If set to `true` (default):
  Clients can subscribe to "#", receiving a copy of EVERY message published to the broker.
  This is useful for debugging or firehose-style monitoring services.
* If set to `false`:
   Clients are explicitly denied permission to subscribe to the exact topic "#".
   They can still subscribe to specific paths (e.g., "sensors/#") or individual topics.
   Recommended for production to prevent accidental or malicious data leakage

## General checklist

- [x] You have reviewed the guidelines [document](https://docs.google.com/document/d/1A4Vc3wrHsY_159b9RG5LOtCryoH6VPwgOhrFEzJKwbI/edit?usp=sharing).
- [x] [Labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels#about-labels) that classify your pull request have been added.
- [x] The [milestone](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones) is specified and corresponds to fix version.
- [x] Description references specific [issue](https://github.com/thingsboard/tbmq/issues).
- [x] Description contains human-readable scope of changes.
- [x] Description contains brief notes about what needs to be added to the documentation.
- [x] No merge conflicts, commented blocks of code, code formatting issues.
- [x] Changes are backward compatible or upgrade script is provided.

## Front-End feature checklist

- [x] Screenshots with affected component(s) are added. The best option is to provide 2 screens: before and after changes;
- [x] If you change the widget or other API, ensure it is backward-compatible or upgrade script is present.

## Back-End feature checklist

- [x] Added corresponding unit and/or integration test(s). Provide written explanation in the PR description if you have failed to add tests.
- [x] If new dependency was added: the dependency tree is checked for conflicts.

