### PR TITLE
fix(actors): keep client-initiated DISCONNECT in FIFO with pending PUBLISH

### DIFF
--- a/application/src/main/java/org/thingsboard/mqtt/broker/session/ClientMqttActorManagerImpl.java
+++ b/application/src/main/java/org/thingsboard/mqtt/broker/session/ClientMqttActorManagerImpl.java
@@ -84,6 +84,13 @@ public class ClientMqttActorManagerImpl implements ClientMqttActorManager {
         TbActorRef clientActorRef = getActor(clientId);
         if (clientActorRef == null) {
             log.debug("[{}] Cannot find client actor for disconnect, sessionId - {}.", clientId, disconnectMsg.getSessionId());
+            return;
+        }
+        // Client-initiated disconnects (DISCONNECT packet, TCP close) must preserve FIFO order
+        // with previously received MQTT messages so that e.g. a QoS 0 PUBLISH sent right before
+        // DISCONNECT is not dropped by the high-priority queue.
+        if (disconnectMsg.getReason().getType().preservesInFlightMessages()) {
+            clientActorRef.tell(disconnectMsg);
         } else {
             clientActorRef.tellWithHighPriority(disconnectMsg);
         }

--- a/application/src/main/java/org/thingsboard/mqtt/broker/session/DisconnectReasonType.java
+++ b/application/src/main/java/org/thingsboard/mqtt/broker/session/DisconnectReasonType.java
@@ -56,8 +56,21 @@ public enum DisconnectReasonType {
     public static final Set<DisconnectReasonType> SERVER_DISCONNECT_EXCLUSIONS =
             EnumSet.of(ON_DISCONNECT_MSG, ON_CHANNEL_CLOSED, ON_CONNECTION_FAILURE);
 
+    /**
+     * Reasons that arrive from the client's own byte stream — a client-sent DISCONNECT packet or the
+     * TCP close that follows it. Disconnects with these reasons must be enqueued in FIFO order with
+     * previously received MQTT messages so that, for example, a QoS 0 PUBLISH sent right before a
+     * DISCONNECT (as `mosquitto_pub` does) is not skipped by the high-priority queue.
+     */
+    public static final Set<DisconnectReasonType> CLIENT_INITIATED_IN_STREAM =
+            EnumSet.of(ON_DISCONNECT_MSG, ON_DISCONNECT_AND_WILL_MSG, ON_CHANNEL_CLOSED);
+
     public boolean allowsServerDisconnect() {
         return !SERVER_DISCONNECT_EXCLUSIONS.contains(this);
+    }
+
+    public boolean preservesInFlightMessages() {
+        return CLIENT_INITIATED_IN_STREAM.contains(this);
     }
 
     public boolean allowsLastWillOnDisconnect() {

--- a/application/src/test/java/org/thingsboard/mqtt/broker/service/testing/integration/Qos0PublishDisconnectRaceIntegrationTestCase.java
+++ b/application/src/test/java/org/thingsboard/mqtt/broker/service/testing/integration/Qos0PublishDisconnectRaceIntegrationTestCase.java
@@ -1,0 +1,200 @@
+/**
+ * Copyright © 2016-2026 The Thingsboard Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.thingsboard.mqtt.broker.service.testing.integration;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.embedded.EmbeddedChannel;
+import io.netty.handler.codec.mqtt.MqttConnectReturnCode;
+import io.netty.handler.codec.mqtt.MqttEncoder;
+import io.netty.handler.codec.mqtt.MqttMessage;
+import io.netty.handler.codec.mqtt.MqttMessageBuilders;
+import io.netty.handler.codec.mqtt.MqttQoS;
+import io.netty.handler.codec.mqtt.MqttVersion;
+import lombok.extern.slf4j.Slf4j;
+import org.eclipse.paho.mqttv5.client.IMqttMessageListener;
+import org.eclipse.paho.mqttv5.client.MqttClient;
+import org.eclipse.paho.mqttv5.client.persist.MemoryPersistence;
+import org.eclipse.paho.mqttv5.common.MqttSubscription;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootContextLoader;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.thingsboard.mqtt.broker.AbstractPubSubIntegrationTest;
+import org.thingsboard.mqtt.broker.common.data.security.MqttClientCredentials;
+import org.thingsboard.mqtt.broker.dao.DaoSqlTest;
+import org.thingsboard.mqtt.broker.dao.client.MqttClientCredentialsService;
+import org.thingsboard.mqtt.broker.service.test.util.TestUtils;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.Socket;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Reproduces the QoS 0 publish-then-immediate-disconnect race that caused mosquitto_pub to lose
+ * messages. Each publisher uses a raw TCP socket so the PUBLISH and DISCONNECT bytes are written
+ * in a single OS-level write, guaranteeing both arrive in the same Netty channelRead and get
+ * enqueued on the actor mailbox before the dispatcher starts draining. Before the fix in
+ * {@code ClientMqttActorManagerImpl#disconnect}, the DISCONNECT was placed on the high-priority
+ * queue and processed before the still-pending PUBLISH, causing the subscriber to miss messages.
+ */
+@Slf4j
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@ContextConfiguration(classes = Qos0PublishDisconnectRaceIntegrationTestCase.class, loader = SpringBootContextLoader.class)
+@DaoSqlTest
+@RunWith(SpringRunner.class)
+public class Qos0PublishDisconnectRaceIntegrationTestCase extends AbstractPubSubIntegrationTest {
+
+    private static final int ITERATIONS = 20;
+    private static final String SUB_CLIENT_ID = "qos0RaceSubClient";
+    private static final String PUB_CLIENT_ID_PREFIX = "qos0RacePubClient-";
+    private static final String TEST_TOPIC = "qos0/race/topic";
+
+    @Autowired
+    private MqttClientCredentialsService credentialsService;
+
+    private MqttClientCredentials subCredentials;
+    private final List<MqttClientCredentials> pubCredentialsList = new ArrayList<>(ITERATIONS);
+
+    @Before
+    public void beforeTest() throws Exception {
+        subCredentials = credentialsService.saveCredentials(
+                TestUtils.createDeviceClientCredentialsWithAuth(SUB_CLIENT_ID, List.of(TEST_TOPIC)));
+        for (int i = 0; i < ITERATIONS; i++) {
+            pubCredentialsList.add(credentialsService.saveCredentials(
+                    TestUtils.createDeviceClientCredentialsWithAuth(PUB_CLIENT_ID_PREFIX + i, List.of(TEST_TOPIC))));
+        }
+        enableBasicProvider();
+    }
+
+    @After
+    public void clear() {
+        credentialsService.deleteCredentials(subCredentials.getId());
+        pubCredentialsList.forEach(c -> credentialsService.deleteCredentials(c.getId()));
+        pubCredentialsList.clear();
+    }
+
+    @Test
+    public void givenSubscribedClient_whenPublishersSendQos0AndImmediatelyDisconnect_thenAllMessagesAreDelivered() throws Throwable {
+        CountDownLatch latch = new CountDownLatch(ITERATIONS);
+        AtomicInteger received = new AtomicInteger();
+
+        MqttClient subClient = new MqttClient(SERVER_URI + mqttPort, SUB_CLIENT_ID, new MemoryPersistence());
+        subClient.connect();
+        MqttSubscription[] subscriptions = {new MqttSubscription(TEST_TOPIC, 0)};
+        IMqttMessageListener[] listeners = {(topic, message) -> {
+            received.incrementAndGet();
+            latch.countDown();
+        }};
+        subClient.subscribe(subscriptions, listeners);
+
+        try {
+            for (int i = 0; i < ITERATIONS; i++) {
+                publishQos0ThenDisconnect(PUB_CLIENT_ID_PREFIX + i, "msg-" + i);
+            }
+
+            boolean allReceived = latch.await(15, TimeUnit.SECONDS);
+            Assert.assertTrue(
+                    "Expected " + ITERATIONS + " messages, got " + received.get(),
+                    allReceived);
+            Assert.assertEquals(ITERATIONS, received.get());
+        } finally {
+            TestUtils.disconnectAndCloseClient(subClient);
+        }
+    }
+
+    /**
+     * Opens a raw TCP socket, sends CONNECT, waits for CONNACK, then writes PUBLISH and DISCONNECT
+     * in a single {@code write()} call so they land in the broker's channelRead together. The
+     * socket is then closed which triggers an additional ON_CHANNEL_CLOSED disconnect path on the
+     * broker.
+     */
+    private void publishQos0ThenDisconnect(String clientId, String payload) throws IOException {
+        byte[] connectBytes = encode(MqttMessageBuilders.connect()
+                .clientId(clientId)
+                .protocolVersion(MqttVersion.MQTT_3_1_1)
+                .cleanSession(true)
+                .keepAlive(60)
+                .build());
+        byte[] publishBytes = encode(MqttMessageBuilders.publish()
+                .topicName(TEST_TOPIC)
+                .qos(MqttQoS.AT_MOST_ONCE)
+                .retained(false)
+                .payload(Unpooled.wrappedBuffer(payload.getBytes(StandardCharsets.UTF_8)))
+                .build());
+        byte[] disconnectBytes = encode(MqttMessageBuilders.disconnect().build());
+
+        try (Socket socket = new Socket(LOCALHOST, mqttPort)) {
+            socket.setTcpNoDelay(true);
+            OutputStream out = socket.getOutputStream();
+            InputStream in = socket.getInputStream();
+
+            out.write(connectBytes);
+            out.flush();
+            awaitConnAckAccepted(in);
+
+            byte[] combined = new byte[publishBytes.length + disconnectBytes.length];
+            System.arraycopy(publishBytes, 0, combined, 0, publishBytes.length);
+            System.arraycopy(disconnectBytes, 0, combined, publishBytes.length, disconnectBytes.length);
+            out.write(combined);
+            out.flush();
+            // try-with-resources closes the socket → broker observes TCP FIN as ON_CHANNEL_CLOSED.
+        }
+    }
+
+    private void awaitConnAckAccepted(InputStream in) throws IOException {
+        int b0 = in.read();
+        Assert.assertEquals("Expected CONNACK fixed header (0x20)", 0x20, b0);
+        int remaining = in.read();
+        Assert.assertEquals("Expected CONNACK remaining length 2", 2, remaining);
+        in.read(); // session-present flags
+        int returnCode = in.read();
+        Assert.assertEquals(
+                "Expected CONNACK with CONNECTION_ACCEPTED",
+                MqttConnectReturnCode.CONNECTION_ACCEPTED.byteValue() & 0xff,
+                returnCode);
+    }
+
+    private byte[] encode(MqttMessage message) {
+        EmbeddedChannel channel = new EmbeddedChannel(MqttEncoder.INSTANCE);
+        try {
+            channel.writeOutbound(message);
+            ByteBuf encoded = channel.readOutbound();
+            try {
+                byte[] bytes = new byte[encoded.readableBytes()];
+                encoded.readBytes(bytes);
+                return bytes;
+            } finally {
+                encoded.release();
+            }
+        } finally {
+            channel.finishAndReleaseAll();
+        }
+    }
+}

--- a/application/src/test/java/org/thingsboard/mqtt/broker/session/ClientMqttActorManagerImplTest.java
+++ b/application/src/test/java/org/thingsboard/mqtt/broker/session/ClientMqttActorManagerImplTest.java
@@ -1,0 +1,96 @@
+/**
+ * Copyright © 2016-2026 The Thingsboard Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.thingsboard.mqtt.broker.session;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.thingsboard.mqtt.broker.actors.ActorSystemContext;
+import org.thingsboard.mqtt.broker.actors.TbActorId;
+import org.thingsboard.mqtt.broker.actors.TbActorRef;
+import org.thingsboard.mqtt.broker.actors.TbActorSystem;
+import org.thingsboard.mqtt.broker.actors.client.messages.mqtt.MqttDisconnectMsg;
+
+import java.util.Arrays;
+import java.util.EnumSet;
+import java.util.Set;
+import java.util.UUID;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class ClientMqttActorManagerImplTest {
+
+    private static final String CLIENT_ID = "testClient";
+
+    private TbActorRef actorRef;
+    private TbActorSystem actorSystem;
+    private ClientMqttActorManagerImpl manager;
+
+    @Before
+    public void setUp() {
+        actorRef = mock(TbActorRef.class);
+        actorSystem = mock(TbActorSystem.class);
+        when(actorSystem.getActor(any(TbActorId.class))).thenReturn(actorRef);
+        manager = new ClientMqttActorManagerImpl(mock(ActorSystemContext.class), actorSystem);
+    }
+
+    @Test
+    public void givenClientInitiatedDisconnectReasons_whenDisconnect_thenRoutedToNormalPriorityQueue() {
+        for (DisconnectReasonType type : DisconnectReasonType.CLIENT_INITIATED_IN_STREAM) {
+            reset(actorRef);
+            MqttDisconnectMsg msg = new MqttDisconnectMsg(UUID.randomUUID(), new DisconnectReason(type));
+
+            manager.disconnect(CLIENT_ID, msg);
+
+            verify(actorRef).tell(msg);
+            verify(actorRef, never()).tellWithHighPriority(any());
+        }
+    }
+
+    @Test
+    public void givenServerInitiatedDisconnectReasons_whenDisconnect_thenRoutedToHighPriorityQueue() {
+        Set<DisconnectReasonType> serverInitiated = EnumSet.allOf(DisconnectReasonType.class);
+        serverInitiated.removeAll(DisconnectReasonType.CLIENT_INITIATED_IN_STREAM);
+
+        for (DisconnectReasonType type : serverInitiated) {
+            reset(actorRef);
+            MqttDisconnectMsg msg = new MqttDisconnectMsg(UUID.randomUUID(), new DisconnectReason(type));
+
+            manager.disconnect(CLIENT_ID, msg);
+
+            verify(actorRef).tellWithHighPriority(msg);
+            verify(actorRef, never()).tell(any());
+        }
+    }
+
+    @Test
+    public void givenMissingActor_whenDisconnect_thenNoInteractions() {
+        when(actorSystem.getActor(any(TbActorId.class))).thenReturn(null);
+        for (DisconnectReasonType type : Arrays.asList(
+                DisconnectReasonType.ON_DISCONNECT_MSG,
+                DisconnectReasonType.ON_ERROR,
+                DisconnectReasonType.ON_CHANNEL_CLOSED)) {
+            MqttDisconnectMsg msg = new MqttDisconnectMsg(UUID.randomUUID(), new DisconnectReason(type));
+            manager.disconnect(CLIENT_ID, msg);
+        }
+        verify(actorRef, never()).tell(any());
+        verify(actorRef, never()).tellWithHighPriority(any());
+    }
+}


### PR DESCRIPTION
## Pull Request description

The client actor's mailbox in `TbActorMailbox` always drains its high-priority queue before the normal one. Client DISCONNECT and channel-close events were enqueued via `tellWithHighPriority`, so they could preempt in-flight PUBLISH messages that arrived on the same TCP stream just before them. QoS 0 publishers that send PUBLISH and DISCONNECT back-to-back without waiting for an ack (the canonical example is `mosquitto_pub`) hit this race regularly: the broker processed the DISCONNECT first, flipped session state to `DISCONNECTED`, and then released the still-queued PUBLISH instead of forwarding it to subscribers.

### Fix

Route disconnects whose reason originates from the client's own byte stream through the **normal** mailbox so FIFO order with preceding client messages is preserved:

- `ON_DISCONNECT_MSG` (client sent a DISCONNECT packet)
- `ON_DISCONNECT_AND_WILL_MSG` (MQTT 5 DISCONNECT with `DISCONNECT_WITH_WILL_MESSAGE` reason)
- `ON_CHANNEL_CLOSED` (TCP FIN/RST observed after the client's bytes)

Server-initiated disconnects — errors, protocol violations, conflicting sessions, rate limits, keep-alive timeout, admin kick, etc. — keep the high-priority path so misbehaving clients are still terminated immediately. The classification is exposed as `DisconnectReasonType#preservesInFlightMessages()` and the routing decision lives in `ClientMqttActorManagerImpl#disconnect`.

### Tests

- `ClientMqttActorManagerImplTest` — unit test covering the routing for every `DisconnectReasonType` (in-stream → `tell`, everything else → `tellWithHighPriority`, missing actor → no-op).
- `Qos0PublishDisconnectRaceIntegrationTestCase` — integration test using a raw TCP socket plus Netty's `MqttEncoder` to write PUBLISH and DISCONNECT bytes in a single `write()` call so both land in the broker's `channelRead` together. This deterministically reproduces the race: the test fails on `develop/2.4` without the fix (subscriber drops one or more messages out of 20) and passes with the fix.

## General checklist

- [x] You have reviewed the guidelines [document](https://docs.google.com/document/d/1A4Vc3wrHsY_159b9RG5LOtCryoH6VPwgOhrFEzJKwbI/edit?usp=sharing).
- [x] [Labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels#about-labels) that classify your pull request have been added.
- [x] The [milestone](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones) is specified and corresponds to fix version.
- [ ] Description references specific [issue](https://github.com/thingsboard/tbmq/issues).
- [x] Description contains human-readable scope of changes.
- [x] Description contains brief notes about what needs to be added to the documentation. _No docs changes required — internal mailbox routing behaviour, no public API or configuration change._
- [x] No merge conflicts, commented blocks of code, code formatting issues.
- [x] Changes are backward compatible or upgrade script is provided.

## Front-End feature checklist

- [ ] Screenshots with affected component(s) are added. The best option is to provide 2 screens: before and after changes;
- [ ] If you change the widget or other API, ensure it is backward-compatible or upgrade script is present.

_No front-end changes._

## Back-End feature checklist

- [x] Added corresponding unit and/or integration test(s). Provide written explanation in the PR description if you have failed to add tests.
- [x] If new dependency was added: the dependency tree is checked for conflicts. _No new dependencies._