### PR TITLE
feat(sparkplug): make TBMQ a Sparkplug 3.0 Compliant + Aware MQTT Server

### DIFF
--- a/application/src/main/java/org/thingsboard/mqtt/broker/actors/client/service/handlers/MqttPublishHandler.java
+++ b/application/src/main/java/org/thingsboard/mqtt/broker/actors/client/service/handlers/MqttPublishHandler.java
@@ -44,6 +44,7 @@ import org.thingsboard.mqtt.broker.service.historical.stats.TbMessageStatsReport
 import org.thingsboard.mqtt.broker.service.mqtt.MqttMessageGenerator;
 import org.thingsboard.mqtt.broker.service.mqtt.PublishMsg;
 import org.thingsboard.mqtt.broker.service.mqtt.retain.RetainedMsgProcessor;
+import org.thingsboard.mqtt.broker.service.mqtt.sparkplug.SparkplugCertificateRepublisher;
 import org.thingsboard.mqtt.broker.service.mqtt.validation.PublishMsgValidationService;
 import org.thingsboard.mqtt.broker.service.processing.MsgDispatcherService;
 import org.thingsboard.mqtt.broker.session.AwaitingPubRelPacketsCtx;
@@ -72,6 +73,7 @@ public class MqttPublishHandler {
     private final RetainedMsgProcessor retainedMsgProcessor;
     private final PublishMsgValidationService publishMsgValidationService;
     private final TbMessageStatsReportClient tbMessageStatsReportClient;
+    private final SparkplugCertificateRepublisher sparkplugCertificateRepublisher;
 
     private final boolean isTraceEnabled = log.isTraceEnabled();
 
@@ -134,6 +136,8 @@ public class MqttPublishHandler {
             }
             publishMsg = retainedMsgProcessor.process(publishMsg);
         }
+
+        sparkplugCertificateRepublisher.maybeRepublish(ctx.getSessionInfo(), publishMsg, ctx.getClientCertCn());
 
         clientLogger.logEventWithDetails(ctx.getClientId(), getClass(), logCtx -> logCtx
                 .msg("Persisting PUBLISH in queue")

--- a/application/src/main/java/org/thingsboard/mqtt/broker/service/mqtt/sparkplug/SparkplugCertificateRepublisher.java
+++ b/application/src/main/java/org/thingsboard/mqtt/broker/service/mqtt/sparkplug/SparkplugCertificateRepublisher.java
@@ -1,0 +1,38 @@
+/**
+ * Copyright © 2016-2026 The Thingsboard Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.thingsboard.mqtt.broker.service.mqtt.sparkplug;
+
+import org.thingsboard.mqtt.broker.common.data.SessionInfo;
+import org.thingsboard.mqtt.broker.service.mqtt.PublishMsg;
+
+/**
+ * Sparkplug 3.0 §10.1.4 — Sparkplug Aware MQTT Server. When an Edge Node publishes an
+ * NBIRTH or DBIRTH on the standard {@code spBv1.0/...} namespace (with retain=false per
+ * spec), the broker must additionally make the same payload available on the
+ * {@code $sparkplug/certificates/...} topic with retain=true so that consumers can read
+ * the latest birth certificate at any time.
+ */
+public interface SparkplugCertificateRepublisher {
+
+    /**
+     * If {@code publishMsg} is a Sparkplug B v1.0 NBIRTH or DBIRTH, asynchronously
+     * publish a copy on the corresponding {@code $sparkplug/certificates/...} topic
+     * with retain=true. For any other topic shape this is a no-op. The original
+     * publish is not modified — the caller continues to dispatch it through the
+     * normal publish path.
+     */
+    void maybeRepublish(SessionInfo sessionInfo, PublishMsg publishMsg, String clientCertCn);
+}

--- a/application/src/main/java/org/thingsboard/mqtt/broker/service/mqtt/sparkplug/SparkplugCertificateRepublisher.java
+++ b/application/src/main/java/org/thingsboard/mqtt/broker/service/mqtt/sparkplug/SparkplugCertificateRepublisher.java
@@ -28,11 +28,14 @@ import org.thingsboard.mqtt.broker.service.mqtt.PublishMsg;
 public interface SparkplugCertificateRepublisher {
 
     /**
-     * If {@code publishMsg} is a Sparkplug B v1.0 NBIRTH or DBIRTH, asynchronously
-     * publish a copy on the corresponding {@code $sparkplug/certificates/...} topic
-     * with retain=true. For any other topic shape this is a no-op. The original
-     * publish is not modified — the caller continues to dispatch it through the
-     * normal publish path.
+     * If {@code publishMsg} is a Sparkplug B v1.0 NBIRTH or DBIRTH, synchronously
+     * stores a copy of the payload on the corresponding {@code $sparkplug/certificates/...}
+     * topic in the retained-message store, then asynchronously dispatches it through the
+     * standard Kafka pipeline so live subscribers receive it. For any other topic shape
+     * this is a no-op. The original publish is not modified — the caller continues to
+     * dispatch it through the normal publish path. Any exception raised during the
+     * republish is logged and swallowed so the primary publish path is never
+     * compromised.
      */
     void maybeRepublish(SessionInfo sessionInfo, PublishMsg publishMsg, String clientCertCn);
 }

--- a/application/src/main/java/org/thingsboard/mqtt/broker/service/mqtt/sparkplug/SparkplugCertificateRepublisherImpl.java
+++ b/application/src/main/java/org/thingsboard/mqtt/broker/service/mqtt/sparkplug/SparkplugCertificateRepublisherImpl.java
@@ -1,0 +1,58 @@
+/**
+ * Copyright © 2016-2026 The Thingsboard Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.thingsboard.mqtt.broker.service.mqtt.sparkplug;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.thingsboard.mqtt.broker.common.data.SessionInfo;
+import org.thingsboard.mqtt.broker.queue.TbQueueCallback;
+import org.thingsboard.mqtt.broker.queue.TbQueueMsgMetadata;
+import org.thingsboard.mqtt.broker.service.mqtt.PublishMsg;
+import org.thingsboard.mqtt.broker.service.processing.MsgDispatcherService;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class SparkplugCertificateRepublisherImpl implements SparkplugCertificateRepublisher {
+
+    private final MsgDispatcherService msgDispatcherService;
+
+    @Override
+    public void maybeRepublish(SessionInfo sessionInfo, PublishMsg publishMsg, String clientCertCn) {
+        String certTopic = SparkplugTopicUtil.toCertificateTopic(publishMsg.getTopicName());
+        if (certTopic == null) {
+            return;
+        }
+        PublishMsg republished = publishMsg.toBuilder()
+                .topicName(certTopic)
+                .isRetained(true)
+                .build();
+        msgDispatcherService.persistPublishMsg(sessionInfo, republished, clientCertCn, new TbQueueCallback() {
+            @Override
+            public void onSuccess(TbQueueMsgMetadata metadata) {
+                if (log.isTraceEnabled()) {
+                    log.trace("Republished Sparkplug certificate on topic {}", certTopic);
+                }
+            }
+
+            @Override
+            public void onFailure(Throwable t) {
+                log.warn("Failed to republish Sparkplug certificate on topic {}", certTopic, t);
+            }
+        });
+    }
+}

--- a/application/src/main/java/org/thingsboard/mqtt/broker/service/mqtt/sparkplug/SparkplugCertificateRepublisherImpl.java
+++ b/application/src/main/java/org/thingsboard/mqtt/broker/service/mqtt/sparkplug/SparkplugCertificateRepublisherImpl.java
@@ -22,6 +22,7 @@ import org.thingsboard.mqtt.broker.common.data.SessionInfo;
 import org.thingsboard.mqtt.broker.queue.TbQueueCallback;
 import org.thingsboard.mqtt.broker.queue.TbQueueMsgMetadata;
 import org.thingsboard.mqtt.broker.service.mqtt.PublishMsg;
+import org.thingsboard.mqtt.broker.service.mqtt.retain.RetainedMsgProcessor;
 import org.thingsboard.mqtt.broker.service.processing.MsgDispatcherService;
 
 @Service
@@ -30,6 +31,7 @@ import org.thingsboard.mqtt.broker.service.processing.MsgDispatcherService;
 public class SparkplugCertificateRepublisherImpl implements SparkplugCertificateRepublisher {
 
     private final MsgDispatcherService msgDispatcherService;
+    private final RetainedMsgProcessor retainedMsgProcessor;
 
     @Override
     public void maybeRepublish(SessionInfo sessionInfo, PublishMsg publishMsg, String clientCertCn) {
@@ -41,6 +43,10 @@ public class SparkplugCertificateRepublisherImpl implements SparkplugCertificate
                 .topicName(certTopic)
                 .isRetained(true)
                 .build();
+        // Store as retained first (same order as MqttPublishHandler.process for client-originated
+        // retained publishes), then dispatch through the standard Kafka pipeline so live subscribers
+        // receive it. Without the retained-store step the fresh-subscribe path would see nothing.
+        republished = retainedMsgProcessor.process(republished);
         msgDispatcherService.persistPublishMsg(sessionInfo, republished, clientCertCn, new TbQueueCallback() {
             @Override
             public void onSuccess(TbQueueMsgMetadata metadata) {

--- a/application/src/main/java/org/thingsboard/mqtt/broker/service/mqtt/sparkplug/SparkplugCertificateRepublisherImpl.java
+++ b/application/src/main/java/org/thingsboard/mqtt/broker/service/mqtt/sparkplug/SparkplugCertificateRepublisherImpl.java
@@ -39,26 +39,30 @@ public class SparkplugCertificateRepublisherImpl implements SparkplugCertificate
         if (certTopic == null) {
             return;
         }
-        PublishMsg republished = publishMsg.toBuilder()
-                .topicName(certTopic)
-                .isRetained(true)
-                .build();
-        // Store as retained first (same order as MqttPublishHandler.process for client-originated
-        // retained publishes), then dispatch through the standard Kafka pipeline so live subscribers
-        // receive it. Without the retained-store step the fresh-subscribe path would see nothing.
-        republished = retainedMsgProcessor.process(republished);
-        msgDispatcherService.persistPublishMsg(sessionInfo, republished, clientCertCn, new TbQueueCallback() {
-            @Override
-            public void onSuccess(TbQueueMsgMetadata metadata) {
-                if (log.isTraceEnabled()) {
-                    log.trace("Republished Sparkplug certificate on topic {}", certTopic);
+        try {
+            PublishMsg republished = publishMsg.toBuilder()
+                    .topicName(certTopic)
+                    .isRetained(true)
+                    .build();
+            // Store as retained first (same order as MqttPublishHandler.process for client-originated
+            // retained publishes), then dispatch through the standard Kafka pipeline so live subscribers
+            // receive it. Without the retained-store step the fresh-subscribe path would see nothing.
+            republished = retainedMsgProcessor.process(republished);
+            msgDispatcherService.persistPublishMsg(sessionInfo, republished, clientCertCn, new TbQueueCallback() {
+                @Override
+                public void onSuccess(TbQueueMsgMetadata metadata) {
+                    if (log.isTraceEnabled()) {
+                        log.trace("Republished Sparkplug certificate on topic {}", certTopic);
+                    }
                 }
-            }
 
-            @Override
-            public void onFailure(Throwable t) {
-                log.warn("Failed to republish Sparkplug certificate on topic {}", certTopic, t);
-            }
-        });
+                @Override
+                public void onFailure(Throwable t) {
+                    log.warn("Failed to republish Sparkplug certificate on topic {}", certTopic, t);
+                }
+            });
+        } catch (Exception e) {
+            log.warn("Failed to republish Sparkplug certificate on topic {}", certTopic, e);
+        }
     }
 }

--- a/application/src/main/java/org/thingsboard/mqtt/broker/service/mqtt/sparkplug/SparkplugTopicUtil.java
+++ b/application/src/main/java/org/thingsboard/mqtt/broker/service/mqtt/sparkplug/SparkplugTopicUtil.java
@@ -1,0 +1,74 @@
+/**
+ * Copyright © 2016-2026 The Thingsboard Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.thingsboard.mqtt.broker.service.mqtt.sparkplug;
+
+public final class SparkplugTopicUtil {
+
+    public static final String CERTIFICATE_TOPIC_PREFIX = "$sparkplug/certificates/";
+
+    private static final String SP_BV_1_0_NAMESPACE = "spBv1.0";
+    private static final String NBIRTH = "NBIRTH";
+    private static final String DBIRTH = "DBIRTH";
+
+    private SparkplugTopicUtil() {
+    }
+
+    /**
+     * If the given topic is a Sparkplug B v1.0 NBIRTH or DBIRTH topic, returns the
+     * corresponding {@code $sparkplug/certificates/...} topic that a Sparkplug Aware
+     * MQTT Server must republish the message on with retain=true. Otherwise returns null.
+     *
+     * <p>Recognizes only the {@code spBv1.0} namespace, and only the NBIRTH/DBIRTH
+     * message types. NDATA/NCMD/NDEATH/DDATA/DCMD/DDEATH/STATE return null — they are
+     * not retained-republished per Sparkplug 3.0 §10.1.4.
+     */
+    public static String toCertificateTopic(String topic) {
+        if (!isNbirth(topic) && !isDbirth(topic)) {
+            return null;
+        }
+        return CERTIFICATE_TOPIC_PREFIX + topic;
+    }
+
+    private static boolean isNbirth(String topic) {
+        return matchesBirth(topic, NBIRTH, 4);
+    }
+
+    private static boolean isDbirth(String topic) {
+        return matchesBirth(topic, DBIRTH, 5);
+    }
+
+    private static boolean matchesBirth(String topic, String messageType, int expectedSegments) {
+        if (topic == null || topic.isEmpty()) {
+            return false;
+        }
+        String[] parts = topic.split("/", -1);
+        if (parts.length != expectedSegments) {
+            return false;
+        }
+        if (!SP_BV_1_0_NAMESPACE.equals(parts[0])) {
+            return false;
+        }
+        if (!messageType.equals(parts[2])) {
+            return false;
+        }
+        for (String part : parts) {
+            if (part.isEmpty() || part.indexOf('+') >= 0 || part.indexOf('#') >= 0) {
+                return false;
+            }
+        }
+        return true;
+    }
+}

--- a/application/src/main/java/org/thingsboard/mqtt/broker/service/mqtt/sparkplug/SparkplugTopicUtil.java
+++ b/application/src/main/java/org/thingsboard/mqtt/broker/service/mqtt/sparkplug/SparkplugTopicUtil.java
@@ -20,6 +20,7 @@ public final class SparkplugTopicUtil {
     public static final String CERTIFICATE_TOPIC_PREFIX = "$sparkplug/certificates/";
 
     private static final String SP_BV_1_0_NAMESPACE = "spBv1.0";
+    private static final String SP_BV_1_0_PREFIX = SP_BV_1_0_NAMESPACE + "/";
     private static final String NBIRTH = "NBIRTH";
     private static final String DBIRTH = "DBIRTH";
 
@@ -36,6 +37,11 @@ public final class SparkplugTopicUtil {
      * not retained-republished per Sparkplug 3.0 §10.1.4.
      */
     public static String toCertificateTopic(String topic) {
+        // Fast-path: cheap prefix check short-circuits the 99% of publishes that aren't
+        // Sparkplug, avoiding String.split allocation on the publish hot path.
+        if (topic == null || !topic.startsWith(SP_BV_1_0_PREFIX)) {
+            return null;
+        }
         if (!isNbirth(topic) && !isDbirth(topic)) {
             return null;
         }

--- a/application/src/test/java/org/thingsboard/mqtt/broker/actors/client/service/handlers/MqttPublishHandlerTest.java
+++ b/application/src/test/java/org/thingsboard/mqtt/broker/actors/client/service/handlers/MqttPublishHandlerTest.java
@@ -33,6 +33,7 @@ import org.thingsboard.mqtt.broker.actors.client.messages.mqtt.MqttDisconnectMsg
 import org.thingsboard.mqtt.broker.actors.client.messages.mqtt.MqttPublishMsg;
 import org.thingsboard.mqtt.broker.actors.client.state.MqttMsgWrapper;
 import org.thingsboard.mqtt.broker.actors.client.state.PubResponseProcessingCtx;
+import org.thingsboard.mqtt.broker.common.data.SessionInfo;
 import org.thingsboard.mqtt.broker.exception.DataValidationException;
 import org.thingsboard.mqtt.broker.exception.MqttException;
 import org.thingsboard.mqtt.broker.service.analysis.ClientLogger;
@@ -40,6 +41,7 @@ import org.thingsboard.mqtt.broker.service.historical.stats.TbMessageStatsReport
 import org.thingsboard.mqtt.broker.service.mqtt.MqttMessageGenerator;
 import org.thingsboard.mqtt.broker.service.mqtt.PublishMsg;
 import org.thingsboard.mqtt.broker.service.mqtt.retain.RetainedMsgProcessor;
+import org.thingsboard.mqtt.broker.service.mqtt.sparkplug.SparkplugCertificateRepublisher;
 import org.thingsboard.mqtt.broker.service.mqtt.validation.PublishMsgValidationService;
 import org.thingsboard.mqtt.broker.service.processing.MsgDispatcherService;
 import org.thingsboard.mqtt.broker.session.AwaitingPubRelPacketsCtx;
@@ -81,6 +83,8 @@ public class MqttPublishHandlerTest {
     PublishMsgValidationService publishMsgValidationService;
     @MockitoBean
     TbMessageStatsReportClient tbMessageStatsReportClient;
+    @MockitoBean
+    SparkplugCertificateRepublisher sparkplugCertificateRepublisher;
 
     @MockitoSpyBean
     MqttPublishHandler mqttPublishHandler;
@@ -392,6 +396,50 @@ public class MqttPublishHandlerTest {
 
         verify(mqttPublishHandler, times(1)).persistPubMsg(eq(ctx), any(), eq(actorRef), any());
         verify(retainedMsgProcessor, times(1)).process(eq(publishMsg));
+    }
+
+    @Test
+    public void givenAcceptedPubMsg_whenProcessPubMsg_thenInvokesSparkplugCertificateRepublisher() {
+        when(publishMsgValidationService.validatePubMsg(any(), any())).thenReturn(true);
+        SessionInfo sessionInfo = mock(SessionInfo.class);
+        when(ctx.getSessionInfo()).thenReturn(sessionInfo);
+        when(ctx.getClientCertCn()).thenReturn("cn-edge");
+
+        PublishMsg publishMsg = getPublishMsg(1, "spBv1.0/G1/NBIRTH/E1", 0);
+
+        mqttPublishHandler.process(ctx, createMqttPubMsg(publishMsg), actorRef);
+
+        verify(sparkplugCertificateRepublisher, times(1))
+                .maybeRepublish(eq(sessionInfo), eq(publishMsg), eq("cn-edge"));
+    }
+
+    @Test
+    public void givenRejectedPubMsg_whenProcessPubMsg_thenSparkplugCertificateRepublisherNotInvoked() {
+        when(publishMsgValidationService.validatePubMsg(any(), any())).thenReturn(false);
+        when(ctx.getMqttVersion()).thenReturn(MqttVersion.MQTT_5);
+
+        PublishMsg publishMsg = getPublishMsg(1, "spBv1.0/G1/NBIRTH/E1", 0);
+
+        mqttPublishHandler.process(ctx, createMqttPubMsg(publishMsg), actorRef);
+
+        verify(sparkplugCertificateRepublisher, never())
+                .maybeRepublish(any(), any(), any());
+    }
+
+    @Test
+    public void givenNbirthPubMsg_whenProcessPubMsg_thenOriginalPersistedAndCertificateRepublishHookInvoked() {
+        when(publishMsgValidationService.validatePubMsg(any(), any())).thenReturn(true);
+        when(ctx.getSessionInfo()).thenReturn(mock(SessionInfo.class));
+
+        PublishMsg publishMsg = getPublishMsg(1, "spBv1.0/G1/NBIRTH/E1", 0);
+
+        mqttPublishHandler.process(ctx, createMqttPubMsg(publishMsg), actorRef);
+
+        // original publish still flows through the standard persistence path
+        verify(mqttPublishHandler, times(1)).persistPubMsg(eq(ctx), eq(publishMsg), eq(actorRef), any());
+        // certificate republish hook invoked exactly once
+        verify(sparkplugCertificateRepublisher, times(1))
+                .maybeRepublish(any(), eq(publishMsg), any());
     }
 
     private MqttPublishMsg createMqttPubMsg(PublishMsg publishMsg) {

--- a/application/src/test/java/org/thingsboard/mqtt/broker/service/mqtt/sparkplug/SparkplugCertificateRepublisherImplTest.java
+++ b/application/src/test/java/org/thingsboard/mqtt/broker/service/mqtt/sparkplug/SparkplugCertificateRepublisherImplTest.java
@@ -18,20 +18,25 @@ package org.thingsboard.mqtt.broker.service.mqtt.sparkplug;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
+import org.mockito.InOrder;
 import org.thingsboard.mqtt.broker.common.data.SessionInfo;
 import org.thingsboard.mqtt.broker.service.mqtt.PublishMsg;
+import org.thingsboard.mqtt.broker.service.mqtt.retain.RetainedMsgProcessor;
 import org.thingsboard.mqtt.broker.service.processing.MsgDispatcherService;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 public class SparkplugCertificateRepublisherImplTest {
 
     private MsgDispatcherService msgDispatcherService;
+    private RetainedMsgProcessor retainedMsgProcessor;
     private SparkplugCertificateRepublisherImpl republisher;
     private SessionInfo sessionInfo;
     private final String clientCertCn = "cn-edge";
@@ -39,8 +44,10 @@ public class SparkplugCertificateRepublisherImplTest {
     @Before
     public void setUp() {
         msgDispatcherService = mock(MsgDispatcherService.class);
+        retainedMsgProcessor = mock(RetainedMsgProcessor.class);
+        when(retainedMsgProcessor.process(any())).thenAnswer(inv -> inv.getArgument(0));
         sessionInfo = mock(SessionInfo.class);
-        republisher = new SparkplugCertificateRepublisherImpl(msgDispatcherService);
+        republisher = new SparkplugCertificateRepublisherImpl(msgDispatcherService, retainedMsgProcessor);
     }
 
     @Test
@@ -148,5 +155,68 @@ public class SparkplugCertificateRepublisherImplTest {
         ArgumentCaptor<PublishMsg> captor = ArgumentCaptor.forClass(PublishMsg.class);
         verify(msgDispatcherService).persistPublishMsg(eq(sessionInfo), captor.capture(), eq(clientCertCn), any());
         assertThat(captor.getValue().getQos()).isEqualTo(2);
+    }
+
+    @Test
+    public void givenNbirthPublish_whenMaybeRepublish_thenStoresRetainedBeforeDispatch() {
+        byte[] payload = new byte[]{42};
+        PublishMsg original = PublishMsg.builder()
+                .topicName("spBv1.0/G1/NBIRTH/E1")
+                .payload(payload)
+                .qos(1)
+                .isRetained(false)
+                .isDup(false)
+                .build();
+
+        republisher.maybeRepublish(sessionInfo, original, clientCertCn);
+
+        InOrder order = inOrder(retainedMsgProcessor, msgDispatcherService);
+        ArgumentCaptor<PublishMsg> retainedCaptor = ArgumentCaptor.forClass(PublishMsg.class);
+        order.verify(retainedMsgProcessor).process(retainedCaptor.capture());
+        order.verify(msgDispatcherService).persistPublishMsg(eq(sessionInfo), any(), eq(clientCertCn), any());
+
+        PublishMsg storedAsRetained = retainedCaptor.getValue();
+        assertThat(storedAsRetained.getTopicName()).isEqualTo("$sparkplug/certificates/spBv1.0/G1/NBIRTH/E1");
+        assertThat(storedAsRetained.isRetained()).isTrue();
+        assertThat(storedAsRetained.getPayload()).isSameAs(payload);
+    }
+
+    @Test
+    public void givenDbirthPublish_whenMaybeRepublish_thenStoresRetainedBeforeDispatch() {
+        byte[] payload = new byte[]{7};
+        PublishMsg original = PublishMsg.builder()
+                .topicName("spBv1.0/G1/DBIRTH/E1/D1")
+                .payload(payload)
+                .qos(0)
+                .isRetained(false)
+                .isDup(false)
+                .build();
+
+        republisher.maybeRepublish(sessionInfo, original, clientCertCn);
+
+        InOrder order = inOrder(retainedMsgProcessor, msgDispatcherService);
+        ArgumentCaptor<PublishMsg> retainedCaptor = ArgumentCaptor.forClass(PublishMsg.class);
+        order.verify(retainedMsgProcessor).process(retainedCaptor.capture());
+        order.verify(msgDispatcherService).persistPublishMsg(eq(sessionInfo), any(), eq(clientCertCn), any());
+
+        PublishMsg storedAsRetained = retainedCaptor.getValue();
+        assertThat(storedAsRetained.getTopicName()).isEqualTo("$sparkplug/certificates/spBv1.0/G1/DBIRTH/E1/D1");
+        assertThat(storedAsRetained.isRetained()).isTrue();
+        assertThat(storedAsRetained.getPayload()).isSameAs(payload);
+    }
+
+    @Test
+    public void givenNonSparkplugPublish_whenMaybeRepublish_thenDoesNotStoreRetained() {
+        PublishMsg original = PublishMsg.builder()
+                .topicName("sensors/temperature")
+                .payload(new byte[]{1})
+                .qos(0)
+                .isRetained(false)
+                .isDup(false)
+                .build();
+
+        republisher.maybeRepublish(sessionInfo, original, clientCertCn);
+
+        verify(retainedMsgProcessor, never()).process(any());
     }
 }

--- a/application/src/test/java/org/thingsboard/mqtt/broker/service/mqtt/sparkplug/SparkplugCertificateRepublisherImplTest.java
+++ b/application/src/test/java/org/thingsboard/mqtt/broker/service/mqtt/sparkplug/SparkplugCertificateRepublisherImplTest.java
@@ -1,0 +1,152 @@
+/**
+ * Copyright © 2016-2026 The Thingsboard Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.thingsboard.mqtt.broker.service.mqtt.sparkplug;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.thingsboard.mqtt.broker.common.data.SessionInfo;
+import org.thingsboard.mqtt.broker.service.mqtt.PublishMsg;
+import org.thingsboard.mqtt.broker.service.processing.MsgDispatcherService;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+public class SparkplugCertificateRepublisherImplTest {
+
+    private MsgDispatcherService msgDispatcherService;
+    private SparkplugCertificateRepublisherImpl republisher;
+    private SessionInfo sessionInfo;
+    private final String clientCertCn = "cn-edge";
+
+    @Before
+    public void setUp() {
+        msgDispatcherService = mock(MsgDispatcherService.class);
+        sessionInfo = mock(SessionInfo.class);
+        republisher = new SparkplugCertificateRepublisherImpl(msgDispatcherService);
+    }
+
+    @Test
+    public void givenNbirthPublish_whenMaybeRepublish_thenDispatchesCertificateTopicWithRetainTrueAndSamePayload() {
+        byte[] payload = new byte[]{1, 2, 3, 4, 5};
+        PublishMsg original = PublishMsg.builder()
+                .packetId(42)
+                .topicName("spBv1.0/G1/NBIRTH/E1")
+                .payload(payload)
+                .qos(0)
+                .isRetained(false)
+                .isDup(false)
+                .build();
+
+        republisher.maybeRepublish(sessionInfo, original, clientCertCn);
+
+        ArgumentCaptor<PublishMsg> captor = ArgumentCaptor.forClass(PublishMsg.class);
+        verify(msgDispatcherService).persistPublishMsg(eq(sessionInfo), captor.capture(), eq(clientCertCn), any());
+        PublishMsg sent = captor.getValue();
+        assertThat(sent.getTopicName()).isEqualTo("$sparkplug/certificates/spBv1.0/G1/NBIRTH/E1");
+        assertThat(sent.isRetained()).isTrue();
+        assertThat(sent.getPayload()).isSameAs(payload);
+        assertThat(sent.getQos()).isEqualTo(0);
+    }
+
+    @Test
+    public void givenDbirthPublish_whenMaybeRepublish_thenDispatchesCertificateTopicWithRetainTrueAndSamePayload() {
+        byte[] payload = new byte[]{9, 8, 7};
+        PublishMsg original = PublishMsg.builder()
+                .topicName("spBv1.0/G1/DBIRTH/E1/D1")
+                .payload(payload)
+                .qos(1)
+                .isRetained(false)
+                .isDup(false)
+                .build();
+
+        republisher.maybeRepublish(sessionInfo, original, clientCertCn);
+
+        ArgumentCaptor<PublishMsg> captor = ArgumentCaptor.forClass(PublishMsg.class);
+        verify(msgDispatcherService).persistPublishMsg(eq(sessionInfo), captor.capture(), eq(clientCertCn), any());
+        PublishMsg sent = captor.getValue();
+        assertThat(sent.getTopicName()).isEqualTo("$sparkplug/certificates/spBv1.0/G1/DBIRTH/E1/D1");
+        assertThat(sent.isRetained()).isTrue();
+        assertThat(sent.getPayload()).isSameAs(payload);
+        assertThat(sent.getQos()).isEqualTo(1);
+    }
+
+    @Test
+    public void givenNdataPublish_whenMaybeRepublish_thenDoesNotDispatch() {
+        PublishMsg original = PublishMsg.builder()
+                .topicName("spBv1.0/G1/NDATA/E1")
+                .payload(new byte[]{1})
+                .qos(0)
+                .isRetained(false)
+                .isDup(false)
+                .build();
+
+        republisher.maybeRepublish(sessionInfo, original, clientCertCn);
+
+        verify(msgDispatcherService, never()).persistPublishMsg(any(), any(), any(), any());
+    }
+
+    @Test
+    public void givenNonSparkplugPublish_whenMaybeRepublish_thenDoesNotDispatch() {
+        PublishMsg original = PublishMsg.builder()
+                .topicName("sensors/temperature")
+                .payload(new byte[]{1})
+                .qos(0)
+                .isRetained(false)
+                .isDup(false)
+                .build();
+
+        republisher.maybeRepublish(sessionInfo, original, clientCertCn);
+
+        verify(msgDispatcherService, never()).persistPublishMsg(any(), any(), any(), any());
+    }
+
+    @Test
+    public void givenAlreadyCertificatePublish_whenMaybeRepublish_thenDoesNotDispatchToPreventLoop() {
+        PublishMsg original = PublishMsg.builder()
+                .topicName("$sparkplug/certificates/spBv1.0/G1/NBIRTH/E1")
+                .payload(new byte[]{1})
+                .qos(0)
+                .isRetained(true)
+                .isDup(false)
+                .build();
+
+        republisher.maybeRepublish(sessionInfo, original, clientCertCn);
+
+        verify(msgDispatcherService, never()).persistPublishMsg(any(), any(), any(), any());
+    }
+
+    @Test
+    public void givenNbirthPublishWithQos2_whenMaybeRepublish_thenPreservesQosOnCertificate() {
+        PublishMsg original = PublishMsg.builder()
+                .topicName("spBv1.0/G1/NBIRTH/E1")
+                .payload(new byte[]{1})
+                .qos(2)
+                .isRetained(false)
+                .isDup(false)
+                .build();
+
+        republisher.maybeRepublish(sessionInfo, original, clientCertCn);
+
+        ArgumentCaptor<PublishMsg> captor = ArgumentCaptor.forClass(PublishMsg.class);
+        verify(msgDispatcherService).persistPublishMsg(eq(sessionInfo), captor.capture(), eq(clientCertCn), any());
+        assertThat(captor.getValue().getQos()).isEqualTo(2);
+    }
+}

--- a/application/src/test/java/org/thingsboard/mqtt/broker/service/mqtt/sparkplug/SparkplugCertificateRepublisherImplTest.java
+++ b/application/src/test/java/org/thingsboard/mqtt/broker/service/mqtt/sparkplug/SparkplugCertificateRepublisherImplTest.java
@@ -27,10 +27,12 @@ import org.thingsboard.mqtt.broker.service.processing.MsgDispatcherService;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 public class SparkplugCertificateRepublisherImplTest {
@@ -218,5 +220,41 @@ public class SparkplugCertificateRepublisherImplTest {
         republisher.maybeRepublish(sessionInfo, original, clientCertCn);
 
         verify(retainedMsgProcessor, never()).process(any());
+    }
+
+    @Test
+    public void givenRetainedMsgProcessorThrows_whenMaybeRepublish_thenSwallowsExceptionAndDoesNotDispatch() {
+        PublishMsg original = PublishMsg.builder()
+                .topicName("spBv1.0/G1/NBIRTH/E1")
+                .payload(new byte[]{1})
+                .qos(1)
+                .isRetained(false)
+                .isDup(false)
+                .build();
+        when(retainedMsgProcessor.process(any())).thenThrow(new RuntimeException("retain store down"));
+
+        // Must not propagate — the §10.1.4 hook must never break the primary publish path.
+        republisher.maybeRepublish(sessionInfo, original, clientCertCn);
+
+        verifyNoInteractions(msgDispatcherService);
+    }
+
+    @Test
+    public void givenMsgDispatcherThrows_whenMaybeRepublish_thenSwallowsException() {
+        PublishMsg original = PublishMsg.builder()
+                .topicName("spBv1.0/G1/DBIRTH/E1/D1")
+                .payload(new byte[]{1})
+                .qos(1)
+                .isRetained(false)
+                .isDup(false)
+                .build();
+        doThrow(new RuntimeException("kafka down"))
+                .when(msgDispatcherService).persistPublishMsg(any(), any(), any(), any());
+
+        // Must not propagate — the §10.1.4 hook must never break the primary publish path.
+        republisher.maybeRepublish(sessionInfo, original, clientCertCn);
+
+        // retain-store was still attempted before the dispatch failure
+        verify(retainedMsgProcessor).process(any());
     }
 }

--- a/application/src/test/java/org/thingsboard/mqtt/broker/service/mqtt/sparkplug/SparkplugTopicUtilTest.java
+++ b/application/src/test/java/org/thingsboard/mqtt/broker/service/mqtt/sparkplug/SparkplugTopicUtilTest.java
@@ -1,0 +1,122 @@
+/**
+ * Copyright © 2016-2026 The Thingsboard Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.thingsboard.mqtt.broker.service.mqtt.sparkplug;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class SparkplugTopicUtilTest {
+
+    @Test
+    public void givenNbirthTopic_whenToCertificateTopic_thenReturnsCertificateTopic() {
+        String result = SparkplugTopicUtil.toCertificateTopic("spBv1.0/G1/NBIRTH/E1");
+
+        assertThat(result).isEqualTo("$sparkplug/certificates/spBv1.0/G1/NBIRTH/E1");
+    }
+
+    @Test
+    public void givenDbirthTopic_whenToCertificateTopic_thenReturnsCertificateTopic() {
+        String result = SparkplugTopicUtil.toCertificateTopic("spBv1.0/G1/DBIRTH/E1/D1");
+
+        assertThat(result).isEqualTo("$sparkplug/certificates/spBv1.0/G1/DBIRTH/E1/D1");
+    }
+
+    @Test
+    public void givenNdataTopic_whenToCertificateTopic_thenReturnsNull() {
+        assertThat(SparkplugTopicUtil.toCertificateTopic("spBv1.0/G1/NDATA/E1")).isNull();
+    }
+
+    @Test
+    public void givenDdataTopic_whenToCertificateTopic_thenReturnsNull() {
+        assertThat(SparkplugTopicUtil.toCertificateTopic("spBv1.0/G1/DDATA/E1/D1")).isNull();
+    }
+
+    @Test
+    public void givenNcmdTopic_whenToCertificateTopic_thenReturnsNull() {
+        assertThat(SparkplugTopicUtil.toCertificateTopic("spBv1.0/G1/NCMD/E1")).isNull();
+    }
+
+    @Test
+    public void givenDcmdTopic_whenToCertificateTopic_thenReturnsNull() {
+        assertThat(SparkplugTopicUtil.toCertificateTopic("spBv1.0/G1/DCMD/E1/D1")).isNull();
+    }
+
+    @Test
+    public void givenNdeathTopic_whenToCertificateTopic_thenReturnsNull() {
+        assertThat(SparkplugTopicUtil.toCertificateTopic("spBv1.0/G1/NDEATH/E1")).isNull();
+    }
+
+    @Test
+    public void givenDdeathTopic_whenToCertificateTopic_thenReturnsNull() {
+        assertThat(SparkplugTopicUtil.toCertificateTopic("spBv1.0/G1/DDEATH/E1/D1")).isNull();
+    }
+
+    @Test
+    public void givenStateTopic_whenToCertificateTopic_thenReturnsNull() {
+        assertThat(SparkplugTopicUtil.toCertificateTopic("spBv1.0/STATE/my_primary_host")).isNull();
+    }
+
+    @Test
+    public void givenNonSparkplugTopic_whenToCertificateTopic_thenReturnsNull() {
+        assertThat(SparkplugTopicUtil.toCertificateTopic("sensors/temperature")).isNull();
+        assertThat(SparkplugTopicUtil.toCertificateTopic("my/G1/NBIRTH/E1")).isNull();
+    }
+
+    @Test
+    public void givenAlreadyCertificateNbirthTopic_whenToCertificateTopic_thenReturnsNullToPreventLoop() {
+        assertThat(SparkplugTopicUtil.toCertificateTopic("$sparkplug/certificates/spBv1.0/G1/NBIRTH/E1")).isNull();
+    }
+
+    @Test
+    public void givenAlreadyCertificateDbirthTopic_whenToCertificateTopic_thenReturnsNullToPreventLoop() {
+        assertThat(SparkplugTopicUtil.toCertificateTopic("$sparkplug/certificates/spBv1.0/G1/DBIRTH/E1/D1")).isNull();
+    }
+
+    @Test
+    public void givenNbirthTopicWithWildcard_whenToCertificateTopic_thenReturnsNull() {
+        assertThat(SparkplugTopicUtil.toCertificateTopic("spBv1.0/+/NBIRTH/E1")).isNull();
+        assertThat(SparkplugTopicUtil.toCertificateTopic("spBv1.0/G1/NBIRTH/#")).isNull();
+    }
+
+    @Test
+    public void givenNbirthTopicWithMissingSegments_whenToCertificateTopic_thenReturnsNull() {
+        assertThat(SparkplugTopicUtil.toCertificateTopic("spBv1.0/G1/NBIRTH")).isNull();
+        assertThat(SparkplugTopicUtil.toCertificateTopic("spBv1.0/G1/NBIRTH/E1/extra")).isNull();
+    }
+
+    @Test
+    public void givenDbirthTopicWithMissingSegments_whenToCertificateTopic_thenReturnsNull() {
+        assertThat(SparkplugTopicUtil.toCertificateTopic("spBv1.0/G1/DBIRTH/E1")).isNull();
+        assertThat(SparkplugTopicUtil.toCertificateTopic("spBv1.0/G1/DBIRTH/E1/D1/extra")).isNull();
+    }
+
+    @Test
+    public void givenNbirthTopicWithEmptySegment_whenToCertificateTopic_thenReturnsNull() {
+        assertThat(SparkplugTopicUtil.toCertificateTopic("spBv1.0//NBIRTH/E1")).isNull();
+        assertThat(SparkplugTopicUtil.toCertificateTopic("spBv1.0/G1/NBIRTH/")).isNull();
+    }
+
+    @Test
+    public void givenNullTopic_whenToCertificateTopic_thenReturnsNull() {
+        assertThat(SparkplugTopicUtil.toCertificateTopic(null)).isNull();
+    }
+
+    @Test
+    public void givenEmptyTopic_whenToCertificateTopic_thenReturnsNull() {
+        assertThat(SparkplugTopicUtil.toCertificateTopic("")).isNull();
+    }
+}


### PR DESCRIPTION
## Pull Request description

Implements the Sparkplug-Aware MQTT Server behavior defined in §10.1.4 of the Eclipse Sparkplug 3.0 specification, so TBMQ qualifies as both a *Compliant* and an *Aware* MQTT Server per the Eclipse Sparkplug TCK 3.0.0.

The Compliant profile (§10.1.3 — MQTT QoS 0/1, retained messages, will messages) was already met out of the box. This PR adds the Aware-profile behavior: when an edge node publishes `NBIRTH` (`spBv1.0/<group>/NBIRTH/<edge>`) or `DBIRTH` (`spBv1.0/<group>/DBIRTH/<edge>/<device>`), the broker MUST also publish those same payload bytes on the parallel `$sparkplug/certificates/...` topic with `retain=true`, so any subscriber joining later receives the latest birth certificates immediately.

### Scope of changes

- **`SparkplugTopicUtil`** (new, in `service/mqtt/sparkplug/`): pure function `toCertificateTopic(String)` that maps an `spBv1.0/<group>/NBIRTH/<edge>` topic to `$sparkplug/certificates/spBv1.0/<group>/NBIRTH/<edge>` (and the corresponding DBIRTH variant). Returns `null` for anything that isn't NBIRTH/DBIRTH on the canonical namespace, including topics that already start with `$sparkplug/certificates/` (idempotency), wildcards, empty segments, and wrong segment counts.
- **`SparkplugCertificateRepublisher` (interface) + `SparkplugCertificateRepublisherImpl`** (new): the hook that produces the cert republish. For matching topics it:
  1. Builds a new `PublishMsg` on the cert topic with `isRetained = true`.
  2. Calls `RetainedMsgProcessor.process(...)` so the message lands in TBMQ's in-memory retained-message trie and the persisted retained-msg log. This is what lets *new* subscribers receive the cert with `retain=1` immediately on subscribe (per MQTT 3.1.1 §3.3.1.3).
  3. Calls `MsgDispatcherService.persistPublishMsg(...)` so the republish also reaches currently-subscribed clients via the normal Kafka pipeline.
- **`MqttPublishHandler`** (modified): one-line hook that calls `sparkplugCertificateRepublisher.maybeRepublish(...)` after retain processing and before `persistPubMsg`, so the original publish flow is unchanged for non-Sparkplug topics.

### Why the retain-store call (commit `439ef81f7`)

The first cut of the republisher only persisted via `MsgDispatcherService.persistPublishMsg`, which delivers to *currently-subscribed* clients via Kafka. End-to-end testing against the TCK revealed that **fresh** subscribers (the case the §10.1.4 store/retain assertions actually check) received nothing, because nothing had landed in the retain trie. Folding in `RetainedMsgProcessor.process(...)` *before* the Kafka dispatch fixes it. `SparkplugCertificateRepublisherImplTest` locks this ordering in via `InOrder` verification.

### Backward compatibility

- Non-Sparkplug topics see no behaviour change; the hook returns immediately for any topic that isn't a valid Sparkplug B NBIRTH/DBIRTH.
- No new configuration keys, no schema changes, no new external dependencies.

### Documentation notes

No user-facing docs changes are required — the new behaviour is the literal spec requirement (§10.1.4) and is invisible to anyone not using the Sparkplug B namespace. The Sparkplug compatibility status can be added to product marketing once the formal Eclipse listing is approved (separate org-level paperwork track, out of scope for this PR).

### TCK verification

Eclipse Sparkplug TCK 3.0.0 (the HiveMQ-extension version published at `download.eclipse.org/sparkplug/3.0.0/`), Broker profile, run against this branch:

```
Summary Test Results for Broker Sparkplug Compliant   — OVERALL: PASS
  conformance-mqtt-qos0                                PASS
  conformance-mqtt-qos1                                PASS
  conformance-mqtt-retained                            PASS
  conformance-mqtt-will-messages                       PASS

Summary Test Results for Broker Sparkplug Aware       — OVERALL: PASS
  conformance-mqtt-aware-basic                         PASS
  conformance-mqtt-aware-store                         PASS
  conformance-mqtt-aware-nbirth-mqtt-topic             PASS
  conformance-mqtt-aware-nbirth-mqtt-retain            PASS
  conformance-mqtt-aware-dbirth-mqtt-topic             PASS
  conformance-mqtt-aware-dbirth-mqtt-retain            PASS
  conformance-mqtt-aware-ndeath-timestamp              PASS
```

11/11 assertions PASS. Same TCK version that NanoMQ, Cirrus Link Chariot, and SIOTH are currently listed under at https://sparkplug.eclipse.org/compatibility/compatible-software/.

## General checklist

- [x] You have reviewed the guidelines [document](https://docs.google.com/document/d/1A4Vc3wrHsY_159b9RG5LOtCryoH6VPwgOhrFEzJKwbI/edit?usp=sharing).
- [x] [Labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels#about-labels) that classify your pull request have been added.
- [x] The [milestone](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones) is specified and corresponds to fix version.
- [ ] Description references specific [issue](https://github.com/thingsboard/tbmq/issues).
- [x] Description contains human-readable scope of changes.
- [x] Description contains brief notes about what needs to be added to the documentation.
- [x] No merge conflicts, commented blocks of code, code formatting issues.
- [x] Changes are backward compatible or upgrade script is provided.

## Front-End feature checklist

- [ ] Screenshots with affected component(s) are added. The best option is to provide 2 screens: before and after changes;
- [ ] If you change the widget or other API, ensure it is backward-compatible or upgrade script is present.

_No front-end changes._

## Back-End feature checklist

- [x] Added corresponding unit and/or integration test(s). Provide written explanation in the PR description if you have failed to add tests.
- [x] If new dependency was added: the dependency tree is checked for conflicts. _(No new dependencies.)_

**Tests added:**
- `SparkplugTopicUtilTest` — 18 cases covering NBIRTH/DBIRTH segment-count rules, namespace validation, wildcards (`+`/`#`), empty segments, idempotency on already-`$sparkplug/certificates/...` topics, and other malformed-topic rejections.
- `SparkplugCertificateRepublisherImplTest` — 9 cases including `InOrder` verification that `RetainedMsgProcessor.process(...)` runs **before** `MsgDispatcherService.persistPublishMsg(...)` (locks in the fix from `439ef81f7`).
- `MqttPublishHandlerTest` — 3 new cases asserting the hook is invoked with the right `(SessionInfo, PublishMsg, clientCertCn)` arguments on the publish path.