### PR TITLE
feat(metrics): expose dropped messages count as the droppedMsgs Prometheus counter

### DIFF
--- a/application/src/main/java/org/thingsboard/mqtt/broker/actors/client/ClientActor.java
+++ b/application/src/main/java/org/thingsboard/mqtt/broker/actors/client/ClientActor.java
@@ -63,7 +63,6 @@ import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
 import static org.thingsboard.mqtt.broker.actors.client.state.SessionState.MQTT_PROCESSABLE_STATES;
-import static org.thingsboard.mqtt.broker.common.data.BrokerConstants.DROPPED_MSGS;
 
 @Slf4j
 public class ClientActor extends ContextAwareActor {
@@ -316,7 +315,7 @@ public class ClientActor extends ContextAwareActor {
         } catch (FullMsgQueueException e) {
             log.debug("[{}][{}] Too many messages in the pre-connect queue", state.getClientId(), state.getCurrentSessionId());
             release(msg);
-            tbMessageStatsReportClient.reportStats(DROPPED_MSGS, state.getQueuedMessages().getPublishMsgCountAndClear());
+            tbMessageStatsReportClient.reportDroppedMsgs(state.getQueuedMessages().getPublishMsgCountAndClear());
             ctx.tellWithHighPriority(new MqttDisconnectMsg(state.getCurrentSessionId(), new DisconnectReason(DisconnectReasonType.ON_QUOTA_EXCEEDED,
                     "Too many messages in the pre-connect queue")));
         }

--- a/application/src/main/java/org/thingsboard/mqtt/broker/actors/client/service/handlers/MqttPublishHandler.java
+++ b/application/src/main/java/org/thingsboard/mqtt/broker/actors/client/service/handlers/MqttPublishHandler.java
@@ -240,7 +240,7 @@ public class MqttPublishHandler {
             public void onFailure(Throwable t) {
                 callbackProcessor.submit(() -> {
                     log.warn("[{}][{}] Failed to publish msg: {}", ctx.getClientId(), ctx.getSessionId(), publishMsg.getPacketId(), t);
-                    tbMessageStatsReportClient.reportDroppedMsgs(1);
+                    tbMessageStatsReportClient.reportDroppedMsgs();
                     handleMsgPersistenceFailure(ctx, publishMsg);
                 });
             }

--- a/application/src/main/java/org/thingsboard/mqtt/broker/actors/client/service/handlers/MqttPublishHandler.java
+++ b/application/src/main/java/org/thingsboard/mqtt/broker/actors/client/service/handlers/MqttPublishHandler.java
@@ -59,8 +59,6 @@ import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.ExecutorService;
 
-import static org.thingsboard.mqtt.broker.common.data.BrokerConstants.DROPPED_MSGS;
-
 @Service
 @RequiredArgsConstructor
 @Slf4j
@@ -242,7 +240,7 @@ public class MqttPublishHandler {
             public void onFailure(Throwable t) {
                 callbackProcessor.submit(() -> {
                     log.warn("[{}][{}] Failed to publish msg: {}", ctx.getClientId(), ctx.getSessionId(), publishMsg.getPacketId(), t);
-                    tbMessageStatsReportClient.reportStats(DROPPED_MSGS);
+                    tbMessageStatsReportClient.reportDroppedMsgs(1);
                     handleMsgPersistenceFailure(ctx, publishMsg);
                 });
             }

--- a/application/src/main/java/org/thingsboard/mqtt/broker/server/MqttSessionHandler.java
+++ b/application/src/main/java/org/thingsboard/mqtt/broker/server/MqttSessionHandler.java
@@ -72,7 +72,6 @@ import java.net.InetSocketAddress;
 import java.util.UUID;
 
 import static org.thingsboard.mqtt.broker.common.data.BrokerConstants.CLIENT_INCOMING_MESSAGES_RATE_LIMITS_DETECTED;
-import static org.thingsboard.mqtt.broker.common.data.BrokerConstants.DROPPED_MSGS;
 import static org.thingsboard.mqtt.broker.common.data.BrokerConstants.TOTAL_RATE_LIMITS_DETECTED;
 
 @Slf4j
@@ -228,7 +227,7 @@ public class MqttSessionHandler extends ChannelInboundHandlerAdapter implements 
         MqttPublishMessage publishMsg = (MqttPublishMessage) msg;
 
         if (!checkClientLimits(publishMsg)) {
-            tbMessageStatsReportClient.reportStats(DROPPED_MSGS);
+            tbMessageStatsReportClient.reportDroppedMsgs(1);
             processMsgOnRateLimits(
                     publishMsg.variableHeader().packetId(),
                     publishMsg.fixedHeader().qosLevel().value(),
@@ -248,7 +247,7 @@ public class MqttSessionHandler extends ChannelInboundHandlerAdapter implements 
                 mqttPublishMsg,
                 msgToProcess -> clientMqttActorManager.processMqttMsg(clientId, msgToProcess),
                 msgToDrop -> {
-                    tbMessageStatsReportClient.reportStats(DROPPED_MSGS);
+                    tbMessageStatsReportClient.reportDroppedMsgs(1);
                     processMsgOnRateLimits(
                             msgToDrop.getPublishMsg().getPacketId(),
                             msgToDrop.getPublishMsg().getQos(),

--- a/application/src/main/java/org/thingsboard/mqtt/broker/server/MqttSessionHandler.java
+++ b/application/src/main/java/org/thingsboard/mqtt/broker/server/MqttSessionHandler.java
@@ -227,7 +227,7 @@ public class MqttSessionHandler extends ChannelInboundHandlerAdapter implements 
         MqttPublishMessage publishMsg = (MqttPublishMessage) msg;
 
         if (!checkClientLimits(publishMsg)) {
-            tbMessageStatsReportClient.reportDroppedMsgs(1);
+            tbMessageStatsReportClient.reportDroppedMsgs();
             processMsgOnRateLimits(
                     publishMsg.variableHeader().packetId(),
                     publishMsg.fixedHeader().qosLevel().value(),
@@ -247,7 +247,7 @@ public class MqttSessionHandler extends ChannelInboundHandlerAdapter implements 
                 mqttPublishMsg,
                 msgToProcess -> clientMqttActorManager.processMqttMsg(clientId, msgToProcess),
                 msgToDrop -> {
-                    tbMessageStatsReportClient.reportDroppedMsgs(1);
+                    tbMessageStatsReportClient.reportDroppedMsgs();
                     processMsgOnRateLimits(
                             msgToDrop.getPublishMsg().getPacketId(),
                             msgToDrop.getPublishMsg().getQos(),

--- a/application/src/main/java/org/thingsboard/mqtt/broker/server/traffic/DuplexTrafficHandler.java
+++ b/application/src/main/java/org/thingsboard/mqtt/broker/server/traffic/DuplexTrafficHandler.java
@@ -72,7 +72,7 @@ public class DuplexTrafficHandler extends ChannelDuplexHandler {
         DecoderResult decoderResult = mqttMessage.decoderResult();
         if (decoderResult.isFailure() && decoderResult.cause() instanceof TooLongFrameException) {
             tbMessageStatsReportClient.reportStats(INCOMING_MSGS);
-            tbMessageStatsReportClient.reportDroppedMsgs(1);
+            tbMessageStatsReportClient.reportDroppedMsgs();
         }
     }
 

--- a/application/src/main/java/org/thingsboard/mqtt/broker/server/traffic/DuplexTrafficHandler.java
+++ b/application/src/main/java/org/thingsboard/mqtt/broker/server/traffic/DuplexTrafficHandler.java
@@ -29,7 +29,6 @@ import org.thingsboard.mqtt.broker.adaptor.NettyMqttConverter;
 import org.thingsboard.mqtt.broker.common.data.util.BytesUtil;
 import org.thingsboard.mqtt.broker.service.historical.stats.TbMessageStatsReportClient;
 
-import static org.thingsboard.mqtt.broker.common.data.BrokerConstants.DROPPED_MSGS;
 import static org.thingsboard.mqtt.broker.common.data.BrokerConstants.INCOMING_MSGS;
 import static org.thingsboard.mqtt.broker.common.data.BrokerConstants.OUTGOING_MSGS;
 import static org.thingsboard.mqtt.broker.server.MqttSessionHandler.CLIENT_ID_ATTR;
@@ -73,7 +72,7 @@ public class DuplexTrafficHandler extends ChannelDuplexHandler {
         DecoderResult decoderResult = mqttMessage.decoderResult();
         if (decoderResult.isFailure() && decoderResult.cause() instanceof TooLongFrameException) {
             tbMessageStatsReportClient.reportStats(INCOMING_MSGS);
-            tbMessageStatsReportClient.reportStats(DROPPED_MSGS);
+            tbMessageStatsReportClient.reportDroppedMsgs(1);
         }
     }
 

--- a/application/src/main/java/org/thingsboard/mqtt/broker/service/historical/stats/TbMessageStatsReportClient.java
+++ b/application/src/main/java/org/thingsboard/mqtt/broker/service/historical/stats/TbMessageStatsReportClient.java
@@ -22,6 +22,8 @@ public interface TbMessageStatsReportClient {
 
     void reportStats(String key, int count);
 
+    void reportDroppedMsgs(int count);
+
     void reportInboundTraffic(long bytes);
 
     void reportOutBoundTraffic(long bytes);

--- a/application/src/main/java/org/thingsboard/mqtt/broker/service/historical/stats/TbMessageStatsReportClient.java
+++ b/application/src/main/java/org/thingsboard/mqtt/broker/service/historical/stats/TbMessageStatsReportClient.java
@@ -15,13 +15,38 @@
  */
 package org.thingsboard.mqtt.broker.service.historical.stats;
 
+import org.thingsboard.mqtt.broker.common.data.BrokerConstants;
 
 public interface TbMessageStatsReportClient {
 
+    /**
+     * Reports a generic usage stat under the given key.
+     * <p>
+     * Do not use this for {@link BrokerConstants#DROPPED_MSGS}: dropped messages must be reported via
+     * {@link #reportDroppedMsgs()} / {@link #reportDroppedMsgs(int)} so the {@code droppedMsgs} Prometheus
+     * counter exposed on {@code /actuator/prometheus} stays in sync.
+     */
     void reportStats(String key);
 
+    /**
+     * Reports a generic usage stat under the given key, incremented by {@code count}.
+     * <p>
+     * Do not use this for {@link BrokerConstants#DROPPED_MSGS}: dropped messages must be reported via
+     * {@link #reportDroppedMsgs()} / {@link #reportDroppedMsgs(int)} so the {@code droppedMsgs} Prometheus
+     * counter exposed on {@code /actuator/prometheus} stays in sync.
+     */
     void reportStats(String key, int count);
 
+    /**
+     * Reports a single dropped message. Increments the {@code droppedMsgs} Prometheus counter (always,
+     * regardless of {@code historical-data-report.enabled}) and the historical stat (when enabled).
+     */
+    void reportDroppedMsgs();
+
+    /**
+     * Reports {@code count} dropped messages. Increments the {@code droppedMsgs} Prometheus counter (always,
+     * regardless of {@code historical-data-report.enabled}) and the historical stat (when enabled).
+     */
     void reportDroppedMsgs(int count);
 
     void reportInboundTraffic(long bytes);

--- a/application/src/main/java/org/thingsboard/mqtt/broker/service/historical/stats/TbMessageStatsReportClientImpl.java
+++ b/application/src/main/java/org/thingsboard/mqtt/broker/service/historical/stats/TbMessageStatsReportClientImpl.java
@@ -28,7 +28,6 @@ import org.thingsboard.mqtt.broker.common.data.BrokerConstants;
 import org.thingsboard.mqtt.broker.common.data.kv.BasicTsKvEntry;
 import org.thingsboard.mqtt.broker.common.data.kv.LongDataEntry;
 import org.thingsboard.mqtt.broker.common.data.kv.TsKvEntry;
-import org.thingsboard.mqtt.broker.common.stats.DefaultCounter;
 import org.thingsboard.mqtt.broker.common.util.DonAsynchron;
 import org.thingsboard.mqtt.broker.config.HistoricalDataReportProperties;
 import org.thingsboard.mqtt.broker.dao.timeseries.TimeseriesService;
@@ -40,6 +39,7 @@ import org.thingsboard.mqtt.broker.queue.TbQueueProducer;
 import org.thingsboard.mqtt.broker.queue.cluster.ServiceInfoProvider;
 import org.thingsboard.mqtt.broker.queue.common.TbProtoQueueMsg;
 import org.thingsboard.mqtt.broker.queue.provider.HistoricalDataQueueFactory;
+import org.thingsboard.mqtt.broker.service.stats.DroppedMsgStats;
 import org.thingsboard.mqtt.broker.service.stats.StatsManager;
 
 import java.time.LocalDateTime;
@@ -83,11 +83,11 @@ public class TbMessageStatsReportClientImpl implements TbMessageStatsReportClien
     // Cached at init time to avoid Spring MethodValidationInterceptor AOP overhead on the hot path
     // (HistoricalDataReportProperties is @Validated, so every getter call would otherwise go through a CGLIB proxy).
     private boolean enabled;
-    private DefaultCounter droppedMsgsCounter;
+    private DroppedMsgStats droppedMsgStats;
 
     @PostConstruct
     void init() {
-        droppedMsgsCounter = statsManager.createDroppedMsgsCounter();
+        droppedMsgStats = statsManager.getDroppedMsgStats();
         enabled = historicalDataReportProperties.isEnabled();
         if (!enabled) {
             return;
@@ -236,7 +236,7 @@ public class TbMessageStatsReportClientImpl implements TbMessageStatsReportClien
 
     @Override
     public void reportDroppedMsgs() {
-        droppedMsgsCounter.increment();
+        droppedMsgStats.increment();
         if (enabled) {
             stats.get(BrokerConstants.DROPPED_MSGS).incrementAndGet();
         }
@@ -244,7 +244,7 @@ public class TbMessageStatsReportClientImpl implements TbMessageStatsReportClien
 
     @Override
     public void reportDroppedMsgs(int count) {
-        droppedMsgsCounter.add(count);
+        droppedMsgStats.increment(count);
         if (enabled) {
             stats.get(BrokerConstants.DROPPED_MSGS).addAndGet(count);
         }

--- a/application/src/main/java/org/thingsboard/mqtt/broker/service/historical/stats/TbMessageStatsReportClientImpl.java
+++ b/application/src/main/java/org/thingsboard/mqtt/broker/service/historical/stats/TbMessageStatsReportClientImpl.java
@@ -29,7 +29,6 @@ import org.thingsboard.mqtt.broker.common.data.kv.BasicTsKvEntry;
 import org.thingsboard.mqtt.broker.common.data.kv.LongDataEntry;
 import org.thingsboard.mqtt.broker.common.data.kv.TsKvEntry;
 import org.thingsboard.mqtt.broker.common.stats.DefaultCounter;
-import org.thingsboard.mqtt.broker.common.stats.StatsFactory;
 import org.thingsboard.mqtt.broker.common.util.DonAsynchron;
 import org.thingsboard.mqtt.broker.config.HistoricalDataReportProperties;
 import org.thingsboard.mqtt.broker.dao.timeseries.TimeseriesService;
@@ -41,6 +40,7 @@ import org.thingsboard.mqtt.broker.queue.TbQueueProducer;
 import org.thingsboard.mqtt.broker.queue.cluster.ServiceInfoProvider;
 import org.thingsboard.mqtt.broker.queue.common.TbProtoQueueMsg;
 import org.thingsboard.mqtt.broker.queue.provider.HistoricalDataQueueFactory;
+import org.thingsboard.mqtt.broker.service.stats.StatsManager;
 
 import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
@@ -74,7 +74,7 @@ public class TbMessageStatsReportClientImpl implements TbMessageStatsReportClien
     private final TimeseriesService timeseriesService;
     private final HistoricalStatsTotalHelper helper;
     private final HistoricalDataReportProperties historicalDataReportProperties;
-    private final StatsFactory statsFactory;
+    private final StatsManager statsManager;
 
     private String serviceId;
     private ConcurrentMap<String, AtomicLong> stats;
@@ -87,7 +87,7 @@ public class TbMessageStatsReportClientImpl implements TbMessageStatsReportClien
 
     @PostConstruct
     void init() {
-        droppedMsgsCounter = statsFactory.createDefaultCounter(BrokerConstants.DROPPED_MSGS);
+        droppedMsgsCounter = statsManager.createDroppedMsgsCounter();
         enabled = historicalDataReportProperties.isEnabled();
         if (!enabled) {
             return;

--- a/application/src/main/java/org/thingsboard/mqtt/broker/service/historical/stats/TbMessageStatsReportClientImpl.java
+++ b/application/src/main/java/org/thingsboard/mqtt/broker/service/historical/stats/TbMessageStatsReportClientImpl.java
@@ -17,8 +17,6 @@ package org.thingsboard.mqtt.broker.service.historical.stats;
 
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
-import io.micrometer.core.instrument.Counter;
-import io.micrometer.core.instrument.MeterRegistry;
 import jakarta.annotation.PostConstruct;
 import jakarta.annotation.PreDestroy;
 import lombok.Data;
@@ -30,6 +28,8 @@ import org.thingsboard.mqtt.broker.common.data.BrokerConstants;
 import org.thingsboard.mqtt.broker.common.data.kv.BasicTsKvEntry;
 import org.thingsboard.mqtt.broker.common.data.kv.LongDataEntry;
 import org.thingsboard.mqtt.broker.common.data.kv.TsKvEntry;
+import org.thingsboard.mqtt.broker.common.stats.DefaultCounter;
+import org.thingsboard.mqtt.broker.common.stats.StatsFactory;
 import org.thingsboard.mqtt.broker.common.util.DonAsynchron;
 import org.thingsboard.mqtt.broker.config.HistoricalDataReportProperties;
 import org.thingsboard.mqtt.broker.dao.timeseries.TimeseriesService;
@@ -74,7 +74,7 @@ public class TbMessageStatsReportClientImpl implements TbMessageStatsReportClien
     private final TimeseriesService timeseriesService;
     private final HistoricalStatsTotalHelper helper;
     private final HistoricalDataReportProperties historicalDataReportProperties;
-    private final MeterRegistry meterRegistry;
+    private final StatsFactory statsFactory;
 
     private String serviceId;
     private ConcurrentMap<String, AtomicLong> stats;
@@ -83,11 +83,11 @@ public class TbMessageStatsReportClientImpl implements TbMessageStatsReportClien
     // Cached at init time to avoid Spring MethodValidationInterceptor AOP overhead on the hot path
     // (HistoricalDataReportProperties is @Validated, so every getter call would otherwise go through a CGLIB proxy).
     private boolean enabled;
-    private Counter droppedMsgsCounter;
+    private DefaultCounter droppedMsgsCounter;
 
     @PostConstruct
     void init() {
-        droppedMsgsCounter = meterRegistry.counter(BrokerConstants.DROPPED_MSGS);
+        droppedMsgsCounter = statsFactory.createDefaultCounter(BrokerConstants.DROPPED_MSGS);
         enabled = historicalDataReportProperties.isEnabled();
         if (!enabled) {
             return;
@@ -235,8 +235,16 @@ public class TbMessageStatsReportClientImpl implements TbMessageStatsReportClien
     }
 
     @Override
+    public void reportDroppedMsgs() {
+        droppedMsgsCounter.increment();
+        if (enabled) {
+            stats.get(BrokerConstants.DROPPED_MSGS).incrementAndGet();
+        }
+    }
+
+    @Override
     public void reportDroppedMsgs(int count) {
-        droppedMsgsCounter.increment(count);
+        droppedMsgsCounter.add(count);
         if (enabled) {
             stats.get(BrokerConstants.DROPPED_MSGS).addAndGet(count);
         }

--- a/application/src/main/java/org/thingsboard/mqtt/broker/service/historical/stats/TbMessageStatsReportClientImpl.java
+++ b/application/src/main/java/org/thingsboard/mqtt/broker/service/historical/stats/TbMessageStatsReportClientImpl.java
@@ -17,6 +17,8 @@ package org.thingsboard.mqtt.broker.service.historical.stats;
 
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
 import jakarta.annotation.PostConstruct;
 import jakarta.annotation.PreDestroy;
 import lombok.Data;
@@ -72,6 +74,7 @@ public class TbMessageStatsReportClientImpl implements TbMessageStatsReportClien
     private final TimeseriesService timeseriesService;
     private final HistoricalStatsTotalHelper helper;
     private final HistoricalDataReportProperties historicalDataReportProperties;
+    private final MeterRegistry meterRegistry;
 
     private String serviceId;
     private ConcurrentMap<String, AtomicLong> stats;
@@ -80,9 +83,11 @@ public class TbMessageStatsReportClientImpl implements TbMessageStatsReportClien
     // Cached at init time to avoid Spring MethodValidationInterceptor AOP overhead on the hot path
     // (HistoricalDataReportProperties is @Validated, so every getter call would otherwise go through a CGLIB proxy).
     private boolean enabled;
+    private Counter droppedMsgsCounter;
 
     @PostConstruct
     void init() {
+        droppedMsgsCounter = meterRegistry.counter(BrokerConstants.DROPPED_MSGS);
         enabled = historicalDataReportProperties.isEnabled();
         if (!enabled) {
             return;
@@ -226,6 +231,14 @@ public class TbMessageStatsReportClientImpl implements TbMessageStatsReportClien
         if (enabled) {
             AtomicLong al = stats.get(key);
             al.addAndGet(count);
+        }
+    }
+
+    @Override
+    public void reportDroppedMsgs(int count) {
+        droppedMsgsCounter.increment(count);
+        if (enabled) {
+            stats.get(BrokerConstants.DROPPED_MSGS).addAndGet(count);
         }
     }
 

--- a/application/src/main/java/org/thingsboard/mqtt/broker/service/mqtt/DefaultMqttMsgDeliveryService.java
+++ b/application/src/main/java/org/thingsboard/mqtt/broker/service/mqtt/DefaultMqttMsgDeliveryService.java
@@ -40,8 +40,6 @@ import org.thingsboard.mqtt.broker.util.MqttReasonCodeResolver;
 import java.util.List;
 import java.util.function.Consumer;
 
-import static org.thingsboard.mqtt.broker.common.data.BrokerConstants.DROPPED_MSGS;
-
 @Slf4j
 @Service
 public class DefaultMqttMsgDeliveryService implements MqttMsgDeliveryService {
@@ -92,7 +90,7 @@ public class DefaultMqttMsgDeliveryService implements MqttMsgDeliveryService {
                                              List<Integer> subscriptionIds) {
         if (!sessionCtx.isWritable()) {
             log.debug("[{}] Channel is not writable. Skip send Publish {}", sessionCtx.getClientId(), msg);
-            tbMessageStatsReportClient.reportStats(DROPPED_MSGS);
+            tbMessageStatsReportClient.reportDroppedMsgs(1);
             return;
         }
         if (isTraceEnabled) {

--- a/application/src/main/java/org/thingsboard/mqtt/broker/service/mqtt/DefaultMqttMsgDeliveryService.java
+++ b/application/src/main/java/org/thingsboard/mqtt/broker/service/mqtt/DefaultMqttMsgDeliveryService.java
@@ -90,7 +90,7 @@ public class DefaultMqttMsgDeliveryService implements MqttMsgDeliveryService {
                                              List<Integer> subscriptionIds) {
         if (!sessionCtx.isWritable()) {
             log.debug("[{}] Channel is not writable. Skip send Publish {}", sessionCtx.getClientId(), msg);
-            tbMessageStatsReportClient.reportDroppedMsgs(1);
+            tbMessageStatsReportClient.reportDroppedMsgs();
             return;
         }
         if (isTraceEnabled) {

--- a/application/src/main/java/org/thingsboard/mqtt/broker/service/mqtt/delivery/DefaultMqttPublishMsgDeliveryService.java
+++ b/application/src/main/java/org/thingsboard/mqtt/broker/service/mqtt/delivery/DefaultMqttPublishMsgDeliveryService.java
@@ -26,8 +26,6 @@ import org.thingsboard.mqtt.broker.session.ClientSessionCtx;
 
 import java.util.concurrent.TimeUnit;
 
-import static org.thingsboard.mqtt.broker.common.data.BrokerConstants.DROPPED_MSGS;
-
 @Service
 @Slf4j
 public class DefaultMqttPublishMsgDeliveryService implements MqttPublishMsgDeliveryService {
@@ -61,7 +59,7 @@ public class DefaultMqttPublishMsgDeliveryService implements MqttPublishMsgDeliv
         } catch (Exception e) {
             log.warn("[{}][{}] Failed to send PUBLISH msg to MQTT client", ctx.getClientId(), ctx.getSessionId(), e);
             if (!msg.fixedHeader().isRetain()) {
-                tbMessageStatsReportClient.reportStats(DROPPED_MSGS);
+                tbMessageStatsReportClient.reportDroppedMsgs(1);
             }
         }
     }
@@ -77,7 +75,7 @@ public class DefaultMqttPublishMsgDeliveryService implements MqttPublishMsgDeliv
         } catch (Exception e) {
             log.warn("[{}][{}] Failed to send PUBLISH msg to MQTT client", ctx.getClientId(), ctx.getSessionId(), e);
             if (!msg.fixedHeader().isRetain()) {
-                tbMessageStatsReportClient.reportStats(DROPPED_MSGS);
+                tbMessageStatsReportClient.reportDroppedMsgs(1);
             }
         }
     }

--- a/application/src/main/java/org/thingsboard/mqtt/broker/service/mqtt/delivery/DefaultMqttPublishMsgDeliveryService.java
+++ b/application/src/main/java/org/thingsboard/mqtt/broker/service/mqtt/delivery/DefaultMqttPublishMsgDeliveryService.java
@@ -59,7 +59,7 @@ public class DefaultMqttPublishMsgDeliveryService implements MqttPublishMsgDeliv
         } catch (Exception e) {
             log.warn("[{}][{}] Failed to send PUBLISH msg to MQTT client", ctx.getClientId(), ctx.getSessionId(), e);
             if (!msg.fixedHeader().isRetain()) {
-                tbMessageStatsReportClient.reportDroppedMsgs(1);
+                tbMessageStatsReportClient.reportDroppedMsgs();
             }
         }
     }
@@ -75,7 +75,7 @@ public class DefaultMqttPublishMsgDeliveryService implements MqttPublishMsgDeliv
         } catch (Exception e) {
             log.warn("[{}][{}] Failed to send PUBLISH msg to MQTT client", ctx.getClientId(), ctx.getSessionId(), e);
             if (!msg.fixedHeader().isRetain()) {
-                tbMessageStatsReportClient.reportDroppedMsgs(1);
+                tbMessageStatsReportClient.reportDroppedMsgs();
             }
         }
     }

--- a/application/src/main/java/org/thingsboard/mqtt/broker/service/mqtt/persistence/MsgPersistenceManagerImpl.java
+++ b/application/src/main/java/org/thingsboard/mqtt/broker/service/mqtt/persistence/MsgPersistenceManagerImpl.java
@@ -51,7 +51,6 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import static org.thingsboard.mqtt.broker.common.data.BrokerConstants.DROPPED_MSGS;
 import static org.thingsboard.mqtt.broker.common.data.ClientType.APPLICATION;
 import static org.thingsboard.mqtt.broker.common.data.ClientType.DEVICE;
 
@@ -135,7 +134,7 @@ public class MsgPersistenceManagerImpl implements MsgPersistenceManager {
 
         int dropped = totalCount - Math.max(availableTokens, 0);
         if (dropped > 0) {
-            tbMessageStatsReportClient.reportStats(DROPPED_MSGS, dropped);
+            tbMessageStatsReportClient.reportDroppedMsgs(dropped);
         }
 
         if (availableTokens <= 0) {

--- a/application/src/main/java/org/thingsboard/mqtt/broker/service/processing/MsgDispatcherServiceImpl.java
+++ b/application/src/main/java/org/thingsboard/mqtt/broker/service/processing/MsgDispatcherServiceImpl.java
@@ -108,7 +108,7 @@ public class MsgDispatcherServiceImpl implements MsgDispatcherService {
 
         MsgSubscriptions msgSubscriptions = getAllSubscriptionsForPubMsg(publishMsgProto, senderClientId);
         if (msgSubscriptions == null) {
-            tbMessageStatsReportClient.reportStats(DROPPED_MSGS);
+            tbMessageStatsReportClient.reportDroppedMsgs(1);
             callback.onSuccess();
             return;
         }

--- a/application/src/main/java/org/thingsboard/mqtt/broker/service/processing/MsgDispatcherServiceImpl.java
+++ b/application/src/main/java/org/thingsboard/mqtt/broker/service/processing/MsgDispatcherServiceImpl.java
@@ -57,8 +57,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
-import static org.thingsboard.mqtt.broker.common.data.BrokerConstants.DROPPED_MSGS;
-
 @Service
 @Slf4j
 @RequiredArgsConstructor
@@ -205,7 +203,7 @@ public class MsgDispatcherServiceImpl implements MsgDispatcherService {
         }
 
         if (dropped > 0) {
-            tbMessageStatsReportClient.reportStats(DROPPED_MSGS, dropped);
+            tbMessageStatsReportClient.reportDroppedMsgs(dropped);
         }
 
         return clientSubscriptions.subList(0, deliverCount);

--- a/application/src/main/java/org/thingsboard/mqtt/broker/service/processing/MsgDispatcherServiceImpl.java
+++ b/application/src/main/java/org/thingsboard/mqtt/broker/service/processing/MsgDispatcherServiceImpl.java
@@ -106,7 +106,7 @@ public class MsgDispatcherServiceImpl implements MsgDispatcherService {
 
         MsgSubscriptions msgSubscriptions = getAllSubscriptionsForPubMsg(publishMsgProto, senderClientId);
         if (msgSubscriptions == null) {
-            tbMessageStatsReportClient.reportDroppedMsgs(1);
+            tbMessageStatsReportClient.reportDroppedMsgs();
             callback.onSuccess();
             return;
         }

--- a/application/src/main/java/org/thingsboard/mqtt/broker/service/processing/PublishMsgConsumerServiceImpl.java
+++ b/application/src/main/java/org/thingsboard/mqtt/broker/service/processing/PublishMsgConsumerServiceImpl.java
@@ -41,8 +41,6 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 
-import static org.thingsboard.mqtt.broker.common.data.BrokerConstants.DROPPED_MSGS;
-
 @Service
 @Slf4j
 @RequiredArgsConstructor
@@ -172,7 +170,7 @@ public class PublishMsgConsumerServiceImpl implements PublishMsgConsumerService 
         }
 
         int dropped = totalMsgCount - availableTokens;
-        tbMessageStatsReportClient.reportStats(DROPPED_MSGS, dropped);
+        tbMessageStatsReportClient.reportDroppedMsgs(dropped);
 
         if (availableTokens <= 0) {
             log.debug("No available tokens left for total msgs bucket during consumer polling. Skipping {} messages", totalMsgCount);

--- a/application/src/main/java/org/thingsboard/mqtt/broker/service/processing/downlink/DownLinkQueuePublisherImpl.java
+++ b/application/src/main/java/org/thingsboard/mqtt/broker/service/processing/downlink/DownLinkQueuePublisherImpl.java
@@ -98,7 +98,7 @@ class DownLinkQueuePublisherImpl implements DownLinkQueuePublisher {
                     public void onFailure(Throwable t) {
                         callbackProcessor.submit(() -> {
                             log.warn("[{}] Failed to publish BASIC msg to {} service.", clientId, targetServiceId, t);
-                            tbMessageStatsReportClient.reportDroppedMsgs(1);
+                            tbMessageStatsReportClient.reportDroppedMsgs();
                         });
                     }
                 },

--- a/application/src/main/java/org/thingsboard/mqtt/broker/service/processing/downlink/DownLinkQueuePublisherImpl.java
+++ b/application/src/main/java/org/thingsboard/mqtt/broker/service/processing/downlink/DownLinkQueuePublisherImpl.java
@@ -40,8 +40,6 @@ import org.thingsboard.mqtt.broker.util.MqttPropertiesUtil;
 
 import java.util.concurrent.ExecutorService;
 
-import static org.thingsboard.mqtt.broker.common.data.BrokerConstants.DROPPED_MSGS;
-
 @Slf4j
 @Service
 @RequiredArgsConstructor
@@ -100,7 +98,7 @@ class DownLinkQueuePublisherImpl implements DownLinkQueuePublisher {
                     public void onFailure(Throwable t) {
                         callbackProcessor.submit(() -> {
                             log.warn("[{}] Failed to publish BASIC msg to {} service.", clientId, targetServiceId, t);
-                            tbMessageStatsReportClient.reportStats(DROPPED_MSGS);
+                            tbMessageStatsReportClient.reportDroppedMsgs(1);
                         });
                     }
                 },

--- a/application/src/main/java/org/thingsboard/mqtt/broker/service/processing/downlink/basic/BasicDownLinkProcessorImpl.java
+++ b/application/src/main/java/org/thingsboard/mqtt/broker/service/processing/downlink/basic/BasicDownLinkProcessorImpl.java
@@ -27,8 +27,6 @@ import org.thingsboard.mqtt.broker.service.mqtt.client.session.ClientSessionCtxS
 import org.thingsboard.mqtt.broker.service.subscription.Subscription;
 import org.thingsboard.mqtt.broker.session.ClientSessionCtx;
 
-import static org.thingsboard.mqtt.broker.common.data.BrokerConstants.DROPPED_MSGS;
-
 @Slf4j
 @Service
 @RequiredArgsConstructor
@@ -71,7 +69,7 @@ public class BasicDownLinkProcessorImpl implements BasicDownLinkProcessor {
     }
 
     private void dropMessage() {
-        tbMessageStatsReportClient.reportStats(DROPPED_MSGS);
+        tbMessageStatsReportClient.reportDroppedMsgs(1);
     }
 
     private void logClientEvent(String clientId) {

--- a/application/src/main/java/org/thingsboard/mqtt/broker/service/processing/downlink/basic/BasicDownLinkProcessorImpl.java
+++ b/application/src/main/java/org/thingsboard/mqtt/broker/service/processing/downlink/basic/BasicDownLinkProcessorImpl.java
@@ -69,7 +69,7 @@ public class BasicDownLinkProcessorImpl implements BasicDownLinkProcessor {
     }
 
     private void dropMessage() {
-        tbMessageStatsReportClient.reportDroppedMsgs(1);
+        tbMessageStatsReportClient.reportDroppedMsgs();
     }
 
     private void logClientEvent(String clientId) {

--- a/application/src/main/java/org/thingsboard/mqtt/broker/service/stats/DefaultDroppedMsgStats.java
+++ b/application/src/main/java/org/thingsboard/mqtt/broker/service/stats/DefaultDroppedMsgStats.java
@@ -1,0 +1,39 @@
+/**
+ * Copyright © 2016-2026 The Thingsboard Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.thingsboard.mqtt.broker.service.stats;
+
+import org.thingsboard.mqtt.broker.common.data.BrokerConstants;
+import org.thingsboard.mqtt.broker.common.stats.DefaultCounter;
+import org.thingsboard.mqtt.broker.common.stats.StatsFactory;
+
+public class DefaultDroppedMsgStats implements DroppedMsgStats {
+
+    private final DefaultCounter droppedMsgsCounter;
+
+    public DefaultDroppedMsgStats(StatsFactory statsFactory) {
+        this.droppedMsgsCounter = statsFactory.createDefaultCounter(BrokerConstants.DROPPED_MSGS);
+    }
+
+    @Override
+    public void increment() {
+        droppedMsgsCounter.increment();
+    }
+
+    @Override
+    public void increment(int count) {
+        droppedMsgsCounter.add(count);
+    }
+}

--- a/application/src/main/java/org/thingsboard/mqtt/broker/service/stats/DefaultDroppedMsgStats.java
+++ b/application/src/main/java/org/thingsboard/mqtt/broker/service/stats/DefaultDroppedMsgStats.java
@@ -36,4 +36,14 @@ public class DefaultDroppedMsgStats implements DroppedMsgStats {
     public void increment(int count) {
         droppedMsgsCounter.add(count);
     }
+
+    @Override
+    public int getCount() {
+        return droppedMsgsCounter.get();
+    }
+
+    @Override
+    public void reset() {
+        droppedMsgsCounter.clear();
+    }
 }

--- a/application/src/main/java/org/thingsboard/mqtt/broker/service/stats/DroppedMsgStats.java
+++ b/application/src/main/java/org/thingsboard/mqtt/broker/service/stats/DroppedMsgStats.java
@@ -25,4 +25,15 @@ public interface DroppedMsgStats {
     void increment();
 
     void increment(int count);
+
+    /**
+     * Number of messages dropped since the last {@link #reset()} — read for the periodic stats log line.
+     */
+    int getCount();
+
+    /**
+     * Clears the per-interval count read by {@link #getCount()}. The cumulative {@code droppedMsgs} Prometheus
+     * counter is unaffected and stays monotonic.
+     */
+    void reset();
 }

--- a/application/src/main/java/org/thingsboard/mqtt/broker/service/stats/DroppedMsgStats.java
+++ b/application/src/main/java/org/thingsboard/mqtt/broker/service/stats/DroppedMsgStats.java
@@ -1,0 +1,28 @@
+/**
+ * Copyright © 2016-2026 The Thingsboard Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.thingsboard.mqtt.broker.service.stats;
+
+/**
+ * Tracks dropped messages as a cumulative {@code droppedMsgs} Prometheus counter.
+ * Obtained from {@link StatsManager}, so it shares the {@code stats.enabled} master switch with every other
+ * broker metric; when stats are disabled the stub implementation is a no-op and nothing is exposed.
+ */
+public interface DroppedMsgStats {
+
+    void increment();
+
+    void increment(int count);
+}

--- a/application/src/main/java/org/thingsboard/mqtt/broker/service/stats/StatsManager.java
+++ b/application/src/main/java/org/thingsboard/mqtt/broker/service/stats/StatsManager.java
@@ -15,7 +15,6 @@
  */
 package org.thingsboard.mqtt.broker.service.stats;
 
-import org.thingsboard.mqtt.broker.common.stats.DefaultCounter;
 import org.thingsboard.mqtt.broker.common.stats.MessagesStats;
 import org.thingsboard.mqtt.broker.queue.TbQueueCallback;
 import org.thingsboard.mqtt.broker.service.mqtt.persistence.application.data.ApplicationSharedSubscriptionJob;
@@ -37,11 +36,11 @@ public interface StatsManager {
     MessagesStats createMsgDispatcherPublishStats();
 
     /**
-     * Creates the cumulative {@code droppedMsgs} Prometheus counter. Defined here so it shares the
-     * {@code stats.enabled} master switch with all other broker metrics: when stats are disabled the
-     * stub manager returns a no-op counter, so nothing is exposed on {@code /actuator/prometheus}.
+     * Returns the dropped-messages stats. Defined here so it shares the {@code stats.enabled} master switch
+     * with all other broker metrics: when stats are disabled the stub manager returns a no-op instance, so
+     * the {@code droppedMsgs} counter is not exposed on {@code /actuator/prometheus}.
      */
-    DefaultCounter createDroppedMsgsCounter();
+    DroppedMsgStats getDroppedMsgStats();
 
     ClientSessionEventConsumerStats createClientSessionEventConsumerStats(String consumerId);
 

--- a/application/src/main/java/org/thingsboard/mqtt/broker/service/stats/StatsManager.java
+++ b/application/src/main/java/org/thingsboard/mqtt/broker/service/stats/StatsManager.java
@@ -15,6 +15,7 @@
  */
 package org.thingsboard.mqtt.broker.service.stats;
 
+import org.thingsboard.mqtt.broker.common.stats.DefaultCounter;
 import org.thingsboard.mqtt.broker.common.stats.MessagesStats;
 import org.thingsboard.mqtt.broker.queue.TbQueueCallback;
 import org.thingsboard.mqtt.broker.service.mqtt.persistence.application.data.ApplicationSharedSubscriptionJob;
@@ -34,6 +35,13 @@ public interface StatsManager {
     TbQueueCallback wrapTbQueueCallback(TbQueueCallback queueCallback, MessagesStats stats);
 
     MessagesStats createMsgDispatcherPublishStats();
+
+    /**
+     * Creates the cumulative {@code droppedMsgs} Prometheus counter. Defined here so it shares the
+     * {@code stats.enabled} master switch with all other broker metrics: when stats are disabled the
+     * stub manager returns a no-op counter, so nothing is exposed on {@code /actuator/prometheus}.
+     */
+    DefaultCounter createDroppedMsgsCounter();
 
     ClientSessionEventConsumerStats createClientSessionEventConsumerStats(String consumerId);
 

--- a/application/src/main/java/org/thingsboard/mqtt/broker/service/stats/StatsManagerImpl.java
+++ b/application/src/main/java/org/thingsboard/mqtt/broker/service/stats/StatsManagerImpl.java
@@ -28,6 +28,8 @@ import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.util.CollectionUtils;
 import org.thingsboard.mqtt.broker.actors.ActorStatsManager;
+import org.thingsboard.mqtt.broker.common.data.BrokerConstants;
+import org.thingsboard.mqtt.broker.common.stats.DefaultCounter;
 import org.thingsboard.mqtt.broker.common.stats.MessagesStats;
 import org.thingsboard.mqtt.broker.common.stats.ResettableTimer;
 import org.thingsboard.mqtt.broker.common.stats.StatsConstantNames;
@@ -116,6 +118,12 @@ public class StatsManagerImpl implements StatsManager, ActorStatsManager, SqlQue
         MessagesStats stats = statsFactory.createMessagesStats(StatsType.MSG_DISPATCHER_PRODUCER.getPrintName());
         managedStats.add(stats);
         return stats;
+    }
+
+    @Override
+    public DefaultCounter createDroppedMsgsCounter() {
+        log.trace("Creating DroppedMsgsCounter");
+        return statsFactory.createDefaultCounter(BrokerConstants.DROPPED_MSGS);
     }
 
     @Override

--- a/application/src/main/java/org/thingsboard/mqtt/broker/service/stats/StatsManagerImpl.java
+++ b/application/src/main/java/org/thingsboard/mqtt/broker/service/stats/StatsManagerImpl.java
@@ -28,6 +28,7 @@ import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.util.CollectionUtils;
 import org.thingsboard.mqtt.broker.actors.ActorStatsManager;
+import org.thingsboard.mqtt.broker.common.data.BrokerConstants;
 import org.thingsboard.mqtt.broker.common.stats.MessagesStats;
 import org.thingsboard.mqtt.broker.common.stats.ResettableTimer;
 import org.thingsboard.mqtt.broker.common.stats.StatsConstantNames;
@@ -464,6 +465,9 @@ public class StatsManagerImpl implements StatsManager, ActorStatsManager, SqlQue
                 .collect(Collectors.joining(" "));
         log.info("[{}] Stats: {}", StatsType.FLOW_CONTROL.getPrintName(), flowControlStatsStr);
         flowControlStats.reset();
+
+        log.info("[{}] Stats: count = [{}]", BrokerConstants.DROPPED_MSGS, droppedMsgStats.getCount());
+        droppedMsgStats.reset();
 
         StringBuilder gaugeLogBuilder = new StringBuilder();
         for (Gauge gauge : gauges) {

--- a/application/src/main/java/org/thingsboard/mqtt/broker/service/stats/StatsManagerImpl.java
+++ b/application/src/main/java/org/thingsboard/mqtt/broker/service/stats/StatsManagerImpl.java
@@ -28,8 +28,6 @@ import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.util.CollectionUtils;
 import org.thingsboard.mqtt.broker.actors.ActorStatsManager;
-import org.thingsboard.mqtt.broker.common.data.BrokerConstants;
-import org.thingsboard.mqtt.broker.common.stats.DefaultCounter;
 import org.thingsboard.mqtt.broker.common.stats.MessagesStats;
 import org.thingsboard.mqtt.broker.common.stats.ResettableTimer;
 import org.thingsboard.mqtt.broker.common.stats.StatsConstantNames;
@@ -83,6 +81,7 @@ public class StatsManagerImpl implements StatsManager, ActorStatsManager, SqlQue
     private RetainedMsgConsumerStats retainedMsgConsumerStats;
     private ClientActorStats clientActorStats;
     private FlowControlStats flowControlStats;
+    private DroppedMsgStats droppedMsgStats;
 
     @Value("${stats.application-processor.enabled}")
     private boolean applicationProcessorStatsEnabled;
@@ -99,6 +98,7 @@ public class StatsManagerImpl implements StatsManager, ActorStatsManager, SqlQue
         this.flowControlStats = defaultFlowControlStats;
         gauges.add(new Gauge(StatsType.FLOW_CONTROL.getPrintName() + ".inflightCount", defaultFlowControlStats::getInflightCount));
         gauges.add(new Gauge(StatsType.FLOW_CONTROL.getPrintName() + ".delayedQueueSize", defaultFlowControlStats::getDelayedQueueSize));
+        this.droppedMsgStats = new DefaultDroppedMsgStats(statsFactory);
     }
 
     @PreDestroy
@@ -121,9 +121,8 @@ public class StatsManagerImpl implements StatsManager, ActorStatsManager, SqlQue
     }
 
     @Override
-    public DefaultCounter createDroppedMsgsCounter() {
-        log.trace("Creating DroppedMsgsCounter");
-        return statsFactory.createDefaultCounter(BrokerConstants.DROPPED_MSGS);
+    public DroppedMsgStats getDroppedMsgStats() {
+        return droppedMsgStats;
     }
 
     @Override

--- a/application/src/main/java/org/thingsboard/mqtt/broker/service/stats/StatsManagerStub.java
+++ b/application/src/main/java/org/thingsboard/mqtt/broker/service/stats/StatsManagerStub.java
@@ -15,13 +15,10 @@
  */
 package org.thingsboard.mqtt.broker.service.stats;
 
-import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Service;
 import org.thingsboard.mqtt.broker.actors.ActorStatsManager;
-import org.thingsboard.mqtt.broker.common.data.BrokerConstants;
-import org.thingsboard.mqtt.broker.common.stats.DefaultCounter;
 import org.thingsboard.mqtt.broker.common.stats.MessagesStats;
 import org.thingsboard.mqtt.broker.common.stats.StubMessagesStats;
 import org.thingsboard.mqtt.broker.queue.TbQueueCallback;
@@ -47,8 +44,6 @@ import java.util.concurrent.atomic.AtomicLong;
 public class StatsManagerStub implements StatsManager, ActorStatsManager, ProducerStatsManager, ConsumerStatsManager {
 
     private static final StubTimerStats timerStats = new StubTimerStats();
-    private static final DefaultCounter STUB_DROPPED_MSGS_COUNTER =
-            new DefaultCounter(new AtomicInteger(0), new SimpleMeterRegistry().counter(BrokerConstants.DROPPED_MSGS));
 
     @Override
     public TbQueueCallback wrapTbQueueCallback(TbQueueCallback queueCallback, MessagesStats stats) {
@@ -61,8 +56,8 @@ public class StatsManagerStub implements StatsManager, ActorStatsManager, Produc
     }
 
     @Override
-    public DefaultCounter createDroppedMsgsCounter() {
-        return STUB_DROPPED_MSGS_COUNTER;
+    public DroppedMsgStats getDroppedMsgStats() {
+        return StubDroppedMsgStats.STUB_DROPPED_MSG_STATS;
     }
 
     @Override

--- a/application/src/main/java/org/thingsboard/mqtt/broker/service/stats/StatsManagerStub.java
+++ b/application/src/main/java/org/thingsboard/mqtt/broker/service/stats/StatsManagerStub.java
@@ -15,10 +15,13 @@
  */
 package org.thingsboard.mqtt.broker.service.stats;
 
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Service;
 import org.thingsboard.mqtt.broker.actors.ActorStatsManager;
+import org.thingsboard.mqtt.broker.common.data.BrokerConstants;
+import org.thingsboard.mqtt.broker.common.stats.DefaultCounter;
 import org.thingsboard.mqtt.broker.common.stats.MessagesStats;
 import org.thingsboard.mqtt.broker.common.stats.StubMessagesStats;
 import org.thingsboard.mqtt.broker.queue.TbQueueCallback;
@@ -44,6 +47,8 @@ import java.util.concurrent.atomic.AtomicLong;
 public class StatsManagerStub implements StatsManager, ActorStatsManager, ProducerStatsManager, ConsumerStatsManager {
 
     private static final StubTimerStats timerStats = new StubTimerStats();
+    private static final DefaultCounter STUB_DROPPED_MSGS_COUNTER =
+            new DefaultCounter(new AtomicInteger(0), new SimpleMeterRegistry().counter(BrokerConstants.DROPPED_MSGS));
 
     @Override
     public TbQueueCallback wrapTbQueueCallback(TbQueueCallback queueCallback, MessagesStats stats) {
@@ -53,6 +58,11 @@ public class StatsManagerStub implements StatsManager, ActorStatsManager, Produc
     @Override
     public MessagesStats createMsgDispatcherPublishStats() {
         return StubMessagesStats.STUB_MESSAGE_STATS;
+    }
+
+    @Override
+    public DefaultCounter createDroppedMsgsCounter() {
+        return STUB_DROPPED_MSGS_COUNTER;
     }
 
     @Override

--- a/application/src/main/java/org/thingsboard/mqtt/broker/service/stats/StubDroppedMsgStats.java
+++ b/application/src/main/java/org/thingsboard/mqtt/broker/service/stats/StubDroppedMsgStats.java
@@ -1,0 +1,29 @@
+/**
+ * Copyright © 2016-2026 The Thingsboard Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.thingsboard.mqtt.broker.service.stats;
+
+public class StubDroppedMsgStats implements DroppedMsgStats {
+
+    public static final StubDroppedMsgStats STUB_DROPPED_MSG_STATS = new StubDroppedMsgStats();
+
+    @Override
+    public void increment() {
+    }
+
+    @Override
+    public void increment(int count) {
+    }
+}

--- a/application/src/main/java/org/thingsboard/mqtt/broker/service/stats/StubDroppedMsgStats.java
+++ b/application/src/main/java/org/thingsboard/mqtt/broker/service/stats/StubDroppedMsgStats.java
@@ -26,4 +26,13 @@ public class StubDroppedMsgStats implements DroppedMsgStats {
     @Override
     public void increment(int count) {
     }
+
+    @Override
+    public int getCount() {
+        return 0;
+    }
+
+    @Override
+    public void reset() {
+    }
 }

--- a/application/src/test/java/org/thingsboard/mqtt/broker/service/historical/stats/TbMessageStatsReportClientImplTest.java
+++ b/application/src/test/java/org/thingsboard/mqtt/broker/service/historical/stats/TbMessageStatsReportClientImplTest.java
@@ -25,6 +25,8 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.thingsboard.mqtt.broker.common.data.BrokerConstants;
 import org.thingsboard.mqtt.broker.common.data.kv.BasicTsKvEntry;
+import org.thingsboard.mqtt.broker.common.stats.DefaultStatsFactory;
+import org.thingsboard.mqtt.broker.common.stats.StatsFactory;
 import org.thingsboard.mqtt.broker.config.HistoricalDataReportProperties;
 import org.thingsboard.mqtt.broker.dao.timeseries.TimeseriesService;
 import org.thingsboard.mqtt.broker.gen.queue.ToUsageStatsMsgProto;
@@ -83,13 +85,14 @@ public class TbMessageStatsReportClientImplTest {
         meterRegistry = new SimpleMeterRegistry();
         autoCloseable = MockitoAnnotations.openMocks(this);
 
+        StatsFactory statsFactory = new DefaultStatsFactory(meterRegistry);
         tbMessageStatsReportClient = new TbMessageStatsReportClientImpl(
                 historicalDataQueueFactory,
                 serviceInfoProvider,
                 timeseriesService,
                 helper,
                 historicalDataReportProperties,
-                meterRegistry
+                statsFactory
         );
 
         when(serviceInfoProvider.getServiceId()).thenReturn("service-1");
@@ -341,7 +344,7 @@ public class TbMessageStatsReportClientImplTest {
     public void testReportDroppedMsgs_incrementsPrometheusCounterAndHistoricalAtomic() {
         tbMessageStatsReportClient.init();
 
-        tbMessageStatsReportClient.reportDroppedMsgs(1);
+        tbMessageStatsReportClient.reportDroppedMsgs();
 
         assertEquals(1.0, meterRegistry.counter(BrokerConstants.DROPPED_MSGS).count(), 0.0);
         assertEquals(1, tbMessageStatsReportClient.getStats().get(BrokerConstants.DROPPED_MSGS).get());
@@ -365,7 +368,7 @@ public class TbMessageStatsReportClientImplTest {
         // Sanity: with historical reporting disabled, the in-memory stats map is null.
         assertNull(tbMessageStatsReportClient.getStats());
 
-        tbMessageStatsReportClient.reportDroppedMsgs(1);
+        tbMessageStatsReportClient.reportDroppedMsgs();
 
         // Prometheus counter must still increment.
         assertEquals(1.0, meterRegistry.counter(BrokerConstants.DROPPED_MSGS).count(), 0.0);

--- a/application/src/test/java/org/thingsboard/mqtt/broker/service/historical/stats/TbMessageStatsReportClientImplTest.java
+++ b/application/src/test/java/org/thingsboard/mqtt/broker/service/historical/stats/TbMessageStatsReportClientImplTest.java
@@ -25,8 +25,7 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.thingsboard.mqtt.broker.common.data.BrokerConstants;
 import org.thingsboard.mqtt.broker.common.data.kv.BasicTsKvEntry;
-import org.thingsboard.mqtt.broker.common.stats.DefaultStatsFactory;
-import org.thingsboard.mqtt.broker.common.stats.StatsFactory;
+import org.thingsboard.mqtt.broker.common.stats.DefaultCounter;
 import org.thingsboard.mqtt.broker.config.HistoricalDataReportProperties;
 import org.thingsboard.mqtt.broker.dao.timeseries.TimeseriesService;
 import org.thingsboard.mqtt.broker.gen.queue.ToUsageStatsMsgProto;
@@ -35,6 +34,7 @@ import org.thingsboard.mqtt.broker.queue.TbQueueProducer;
 import org.thingsboard.mqtt.broker.queue.cluster.ServiceInfoProvider;
 import org.thingsboard.mqtt.broker.queue.common.TbProtoQueueMsg;
 import org.thingsboard.mqtt.broker.queue.provider.HistoricalDataQueueFactory;
+import org.thingsboard.mqtt.broker.service.stats.StatsManager;
 
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
@@ -43,6 +43,7 @@ import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -73,6 +74,8 @@ public class TbMessageStatsReportClientImplTest {
     private HistoricalDataReportProperties historicalDataReportProperties;
     @Mock
     private TbQueueProducer<TbProtoQueueMsg<ToUsageStatsMsgProto>> historicalStatsProducer;
+    @Mock
+    private StatsManager statsManager;
 
     private SimpleMeterRegistry meterRegistry;
 
@@ -85,14 +88,16 @@ public class TbMessageStatsReportClientImplTest {
         meterRegistry = new SimpleMeterRegistry();
         autoCloseable = MockitoAnnotations.openMocks(this);
 
-        StatsFactory statsFactory = new DefaultStatsFactory(meterRegistry);
+        DefaultCounter droppedMsgsCounter = new DefaultCounter(new AtomicInteger(0), meterRegistry.counter(BrokerConstants.DROPPED_MSGS));
+        when(statsManager.createDroppedMsgsCounter()).thenReturn(droppedMsgsCounter);
+
         tbMessageStatsReportClient = new TbMessageStatsReportClientImpl(
                 historicalDataQueueFactory,
                 serviceInfoProvider,
                 timeseriesService,
                 helper,
                 historicalDataReportProperties,
-                statsFactory
+                statsManager
         );
 
         when(serviceInfoProvider.getServiceId()).thenReturn("service-1");

--- a/application/src/test/java/org/thingsboard/mqtt/broker/service/historical/stats/TbMessageStatsReportClientImplTest.java
+++ b/application/src/test/java/org/thingsboard/mqtt/broker/service/historical/stats/TbMessageStatsReportClientImplTest.java
@@ -25,7 +25,7 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.thingsboard.mqtt.broker.common.data.BrokerConstants;
 import org.thingsboard.mqtt.broker.common.data.kv.BasicTsKvEntry;
-import org.thingsboard.mqtt.broker.common.stats.DefaultCounter;
+import org.thingsboard.mqtt.broker.common.stats.DefaultStatsFactory;
 import org.thingsboard.mqtt.broker.config.HistoricalDataReportProperties;
 import org.thingsboard.mqtt.broker.dao.timeseries.TimeseriesService;
 import org.thingsboard.mqtt.broker.gen.queue.ToUsageStatsMsgProto;
@@ -34,6 +34,8 @@ import org.thingsboard.mqtt.broker.queue.TbQueueProducer;
 import org.thingsboard.mqtt.broker.queue.cluster.ServiceInfoProvider;
 import org.thingsboard.mqtt.broker.queue.common.TbProtoQueueMsg;
 import org.thingsboard.mqtt.broker.queue.provider.HistoricalDataQueueFactory;
+import org.thingsboard.mqtt.broker.service.stats.DefaultDroppedMsgStats;
+import org.thingsboard.mqtt.broker.service.stats.DroppedMsgStats;
 import org.thingsboard.mqtt.broker.service.stats.StatsManager;
 
 import java.time.LocalDateTime;
@@ -43,7 +45,6 @@ import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -88,8 +89,8 @@ public class TbMessageStatsReportClientImplTest {
         meterRegistry = new SimpleMeterRegistry();
         autoCloseable = MockitoAnnotations.openMocks(this);
 
-        DefaultCounter droppedMsgsCounter = new DefaultCounter(new AtomicInteger(0), meterRegistry.counter(BrokerConstants.DROPPED_MSGS));
-        when(statsManager.createDroppedMsgsCounter()).thenReturn(droppedMsgsCounter);
+        DroppedMsgStats droppedMsgStats = new DefaultDroppedMsgStats(new DefaultStatsFactory(meterRegistry));
+        when(statsManager.getDroppedMsgStats()).thenReturn(droppedMsgStats);
 
         tbMessageStatsReportClient = new TbMessageStatsReportClientImpl(
                 historicalDataQueueFactory,

--- a/application/src/test/java/org/thingsboard/mqtt/broker/service/historical/stats/TbMessageStatsReportClientImplTest.java
+++ b/application/src/test/java/org/thingsboard/mqtt/broker/service/historical/stats/TbMessageStatsReportClientImplTest.java
@@ -17,10 +17,10 @@ package org.thingsboard.mqtt.broker.service.historical.stats;
 
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.thingsboard.mqtt.broker.common.data.BrokerConstants;
@@ -72,14 +72,25 @@ public class TbMessageStatsReportClientImplTest {
     @Mock
     private TbQueueProducer<TbProtoQueueMsg<ToUsageStatsMsgProto>> historicalStatsProducer;
 
-    @InjectMocks
+    private SimpleMeterRegistry meterRegistry;
+
     private TbMessageStatsReportClientImpl tbMessageStatsReportClient;
 
     AutoCloseable autoCloseable;
 
     @Before
     public void setUp() {
+        meterRegistry = new SimpleMeterRegistry();
         autoCloseable = MockitoAnnotations.openMocks(this);
+
+        tbMessageStatsReportClient = new TbMessageStatsReportClientImpl(
+                historicalDataQueueFactory,
+                serviceInfoProvider,
+                timeseriesService,
+                helper,
+                historicalDataReportProperties,
+                meterRegistry
+        );
 
         when(serviceInfoProvider.getServiceId()).thenReturn("service-1");
         when(historicalDataQueueFactory.createProducer(any())).thenReturn(historicalStatsProducer);
@@ -324,6 +335,40 @@ public class TbMessageStatsReportClientImplTest {
                 .plusMinutes(minute)
                 .toInstant(ZoneOffset.UTC)
                 .toEpochMilli();
+    }
+
+    @Test
+    public void testReportDroppedMsgs_incrementsPrometheusCounterAndHistoricalAtomic() {
+        tbMessageStatsReportClient.init();
+
+        tbMessageStatsReportClient.reportDroppedMsgs(1);
+
+        assertEquals(1.0, meterRegistry.counter(BrokerConstants.DROPPED_MSGS).count(), 0.0);
+        assertEquals(1, tbMessageStatsReportClient.getStats().get(BrokerConstants.DROPPED_MSGS).get());
+    }
+
+    @Test
+    public void testReportDroppedMsgs_withCount_incrementsBothCountersByCount() {
+        tbMessageStatsReportClient.init();
+
+        tbMessageStatsReportClient.reportDroppedMsgs(5);
+
+        assertEquals(5.0, meterRegistry.counter(BrokerConstants.DROPPED_MSGS).count(), 0.0);
+        assertEquals(5, tbMessageStatsReportClient.getStats().get(BrokerConstants.DROPPED_MSGS).get());
+    }
+
+    @Test
+    public void testReportDroppedMsgs_incrementsPrometheusCounterEvenWhenHistoricalDisabled() {
+        when(historicalDataReportProperties.isEnabled()).thenReturn(false);
+        tbMessageStatsReportClient.init();
+
+        // Sanity: with historical reporting disabled, the in-memory stats map is null.
+        assertNull(tbMessageStatsReportClient.getStats());
+
+        tbMessageStatsReportClient.reportDroppedMsgs(1);
+
+        // Prometheus counter must still increment.
+        assertEquals(1.0, meterRegistry.counter(BrokerConstants.DROPPED_MSGS).count(), 0.0);
     }
 
     @Test

--- a/application/src/test/java/org/thingsboard/mqtt/broker/service/processing/downlink/basic/BasicDownLinkProcessorImplTest.java
+++ b/application/src/test/java/org/thingsboard/mqtt/broker/service/processing/downlink/basic/BasicDownLinkProcessorImplTest.java
@@ -33,7 +33,6 @@ import org.thingsboard.mqtt.broker.service.subscription.Subscription;
 import org.thingsboard.mqtt.broker.session.ClientSessionCtx;
 
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -72,7 +71,7 @@ public class BasicDownLinkProcessorImplTest {
         basicDownLinkProcessor.process(clientId, publishMsgProto);
 
         verify(mqttMsgDeliveryService, never()).sendPublishMsgProtoToClient(any(), any());
-        verify(tbMessageStatsReportClient, never()).reportDroppedMsgs(anyInt());
+        verify(tbMessageStatsReportClient, never()).reportDroppedMsgs();
     }
 
     @Test
@@ -86,7 +85,7 @@ public class BasicDownLinkProcessorImplTest {
         basicDownLinkProcessor.process(clientId, publishMsgProto);
 
         verify(mqttMsgDeliveryService, times(1)).sendPublishMsgProtoToClient(any(), any());
-        verify(tbMessageStatsReportClient, never()).reportDroppedMsgs(anyInt());
+        verify(tbMessageStatsReportClient, never()).reportDroppedMsgs();
     }
 
     @Test
@@ -100,7 +99,7 @@ public class BasicDownLinkProcessorImplTest {
         basicDownLinkProcessor.process(clientId, publishMsgProto);
 
         verify(mqttMsgDeliveryService, never()).sendPublishMsgProtoToClient(any(), any());
-        verify(tbMessageStatsReportClient).reportDroppedMsgs(1);
+        verify(tbMessageStatsReportClient).reportDroppedMsgs();
     }
 
     @Test
@@ -113,7 +112,7 @@ public class BasicDownLinkProcessorImplTest {
         basicDownLinkProcessor.process(getSubscription(clientId), publishMsgProto);
 
         verify(mqttMsgDeliveryService, never()).sendPublishMsgProtoToClient(any(), any(), any());
-        verify(tbMessageStatsReportClient, never()).reportDroppedMsgs(anyInt());
+        verify(tbMessageStatsReportClient, never()).reportDroppedMsgs();
     }
 
     @Test
@@ -127,7 +126,7 @@ public class BasicDownLinkProcessorImplTest {
         basicDownLinkProcessor.process(getSubscription(clientId), publishMsgProto);
 
         verify(mqttMsgDeliveryService, times(1)).sendPublishMsgProtoToClient(any(), any(), any());
-        verify(tbMessageStatsReportClient, never()).reportDroppedMsgs(anyInt());
+        verify(tbMessageStatsReportClient, never()).reportDroppedMsgs();
     }
 
     @Test
@@ -141,7 +140,7 @@ public class BasicDownLinkProcessorImplTest {
         basicDownLinkProcessor.process(getSubscription(clientId), publishMsgProto);
 
         verify(mqttMsgDeliveryService, never()).sendPublishMsgProtoToClient(any(), any(), any());
-        verify(tbMessageStatsReportClient).reportDroppedMsgs(1);
+        verify(tbMessageStatsReportClient).reportDroppedMsgs();
     }
 
     private Subscription getSubscription(String clientId) {

--- a/application/src/test/java/org/thingsboard/mqtt/broker/service/processing/downlink/basic/BasicDownLinkProcessorImplTest.java
+++ b/application/src/test/java/org/thingsboard/mqtt/broker/service/processing/downlink/basic/BasicDownLinkProcessorImplTest.java
@@ -33,12 +33,11 @@ import org.thingsboard.mqtt.broker.service.subscription.Subscription;
 import org.thingsboard.mqtt.broker.session.ClientSessionCtx;
 
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static org.thingsboard.mqtt.broker.common.data.BrokerConstants.DROPPED_MSGS;
 
 @RunWith(SpringRunner.class)
 @ContextConfiguration(classes = BasicDownLinkProcessorImpl.class)
@@ -73,7 +72,7 @@ public class BasicDownLinkProcessorImplTest {
         basicDownLinkProcessor.process(clientId, publishMsgProto);
 
         verify(mqttMsgDeliveryService, never()).sendPublishMsgProtoToClient(any(), any());
-        verify(tbMessageStatsReportClient, never()).reportStats(eq(DROPPED_MSGS));
+        verify(tbMessageStatsReportClient, never()).reportDroppedMsgs(anyInt());
     }
 
     @Test
@@ -87,7 +86,7 @@ public class BasicDownLinkProcessorImplTest {
         basicDownLinkProcessor.process(clientId, publishMsgProto);
 
         verify(mqttMsgDeliveryService, times(1)).sendPublishMsgProtoToClient(any(), any());
-        verify(tbMessageStatsReportClient, never()).reportStats(eq(DROPPED_MSGS));
+        verify(tbMessageStatsReportClient, never()).reportDroppedMsgs(anyInt());
     }
 
     @Test
@@ -101,7 +100,7 @@ public class BasicDownLinkProcessorImplTest {
         basicDownLinkProcessor.process(clientId, publishMsgProto);
 
         verify(mqttMsgDeliveryService, never()).sendPublishMsgProtoToClient(any(), any());
-        verify(tbMessageStatsReportClient).reportStats(eq(DROPPED_MSGS));
+        verify(tbMessageStatsReportClient).reportDroppedMsgs(1);
     }
 
     @Test
@@ -114,7 +113,7 @@ public class BasicDownLinkProcessorImplTest {
         basicDownLinkProcessor.process(getSubscription(clientId), publishMsgProto);
 
         verify(mqttMsgDeliveryService, never()).sendPublishMsgProtoToClient(any(), any(), any());
-        verify(tbMessageStatsReportClient, never()).reportStats(eq(DROPPED_MSGS));
+        verify(tbMessageStatsReportClient, never()).reportDroppedMsgs(anyInt());
     }
 
     @Test
@@ -128,7 +127,7 @@ public class BasicDownLinkProcessorImplTest {
         basicDownLinkProcessor.process(getSubscription(clientId), publishMsgProto);
 
         verify(mqttMsgDeliveryService, times(1)).sendPublishMsgProtoToClient(any(), any(), any());
-        verify(tbMessageStatsReportClient, never()).reportStats(eq(DROPPED_MSGS));
+        verify(tbMessageStatsReportClient, never()).reportDroppedMsgs(anyInt());
     }
 
     @Test
@@ -142,7 +141,7 @@ public class BasicDownLinkProcessorImplTest {
         basicDownLinkProcessor.process(getSubscription(clientId), publishMsgProto);
 
         verify(mqttMsgDeliveryService, never()).sendPublishMsgProtoToClient(any(), any(), any());
-        verify(tbMessageStatsReportClient).reportStats(eq(DROPPED_MSGS));
+        verify(tbMessageStatsReportClient).reportDroppedMsgs(1);
     }
 
     private Subscription getSubscription(String clientId) {

--- a/application/src/test/java/org/thingsboard/mqtt/broker/service/stats/DefaultDroppedMsgStatsTest.java
+++ b/application/src/test/java/org/thingsboard/mqtt/broker/service/stats/DefaultDroppedMsgStatsTest.java
@@ -1,0 +1,72 @@
+/**
+ * Copyright © 2016-2026 The Thingsboard Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.thingsboard.mqtt.broker.service.stats;
+
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.Before;
+import org.junit.Test;
+import org.thingsboard.mqtt.broker.common.data.BrokerConstants;
+import org.thingsboard.mqtt.broker.common.stats.DefaultStatsFactory;
+import org.thingsboard.mqtt.broker.common.stats.StatsFactory;
+
+import static org.junit.Assert.assertEquals;
+
+public class DefaultDroppedMsgStatsTest {
+
+    private SimpleMeterRegistry meterRegistry;
+    private DefaultDroppedMsgStats droppedMsgStats;
+
+    @Before
+    public void setUp() {
+        meterRegistry = new SimpleMeterRegistry();
+        StatsFactory statsFactory = new DefaultStatsFactory(meterRegistry);
+        droppedMsgStats = new DefaultDroppedMsgStats(statsFactory);
+    }
+
+    @Test
+    public void givenFreshStats_whenIncrement_thenCountAndPrometheusCounterIncrease() {
+        droppedMsgStats.increment();
+        droppedMsgStats.increment();
+
+        assertEquals(2, droppedMsgStats.getCount());
+        assertEquals(2.0, meterRegistry.counter(BrokerConstants.DROPPED_MSGS).count(), 0.0);
+    }
+
+    @Test
+    public void givenFreshStats_whenIncrementByCount_thenCountAndPrometheusCounterIncreaseByCount() {
+        droppedMsgStats.increment(5);
+
+        assertEquals(5, droppedMsgStats.getCount());
+        assertEquals(5.0, meterRegistry.counter(BrokerConstants.DROPPED_MSGS).count(), 0.0);
+    }
+
+    @Test
+    public void givenIncrementedStats_whenReset_thenCountClearedButPrometheusCounterStaysMonotonic() {
+        droppedMsgStats.increment(3);
+
+        droppedMsgStats.reset();
+
+        // The per-interval count is cleared so the next periodic log line starts fresh...
+        assertEquals(0, droppedMsgStats.getCount());
+        // ...but the cumulative Prometheus counter must never be reset.
+        assertEquals(3.0, meterRegistry.counter(BrokerConstants.DROPPED_MSGS).count(), 0.0);
+
+        droppedMsgStats.increment(2);
+
+        assertEquals(2, droppedMsgStats.getCount());
+        assertEquals(5.0, meterRegistry.counter(BrokerConstants.DROPPED_MSGS).count(), 0.0);
+    }
+}


### PR DESCRIPTION
## Pull Request description

Resolves #303.

Exposes the cumulative dropped-message count as a Micrometer counter **`droppedMsgs`** on the existing `/actuator/prometheus` endpoint, so operators can alert on message drops directly with Prometheus.

**What changed**
- Added `reportDroppedMsgs()` and `reportDroppedMsgs(int count)` to `TbMessageStatsReportClient`. Its generic `reportStats(...)` methods are now documented as off-limits for `DROPPED_MSGS` — dropped messages must go through `reportDroppedMsgs(...)` so the Prometheus counter stays in sync.
- The `droppedMsgs` counter is a no-tag Micrometer `Counter` created through the `StatsManager` → `DroppedMsgStats` abstraction (`DefaultDroppedMsgStats` via `StatsFactory.createDefaultCounter`). Because it is obtained from `StatsManager`, it shares the `stats.enabled` master switch with every other broker metric.
- `TbMessageStatsReportClientImpl` resolves `DroppedMsgStats` from `StatsManager` in `@PostConstruct init()` **before** the `historical-data-report.enabled` early-exit, so `reportDroppedMsgs(...)` always increments the Prometheus counter and — only when `historical-data-report.enabled=true` — also bumps the in-memory historical `AtomicLong`.
- Migrated all 14 existing `reportStats(DROPPED_MSGS[, n])` call sites (11 files) to `reportDroppedMsgs(...)`.
- `StatsManagerImpl.printStats()` now logs the per-interval dropped count alongside the other drop counters (e.g. `flowControl`) and resets it each interval. The per-interval reset clears only the in-memory count used for the log line; the cumulative Prometheus counter is untouched and stays monotonic.

**Metric availability**
- The counter is exposed whenever stats are enabled (`stats.enabled=true`, the default) and is **independent of `historical-data-report.enabled`** — it is present and scrapeable even when historical persistence is turned off.
- When `stats.enabled=false`, the broker wires the no-op stats stub, so — like every other broker metric — the `droppedMsgs` counter is not registered or exposed.

**Backward compatibility**
- The existing in-memory `AtomicLong` → PostgreSQL historical pipeline is unchanged and still gated by `historical-data-report.enabled`, so existing historical `droppedMsgs` dashboards / time series are unaffected. No schema change, no new dependency.

**Sample scrape** (`/actuator/prometheus`):

```
# HELP droppedMsgs_total
# TYPE droppedMsgs_total counter
droppedMsgs_total 0.0
```

**Documentation**
- The Prometheus / monitoring documentation should be updated to mention the new `droppedMsgs_total` counter exposed on `/actuator/prometheus`.

## General checklist

- [x] You have reviewed the guidelines [document](https://docs.google.com/document/d/1A4Vc3wrHsY_159b9RG5LOtCryoH6VPwgOhrFEzJKwbI/edit?usp=sharing).
- [x] [Labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels#about-labels) that classify your pull request have been added.
- [x] The [milestone](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones) is specified and corresponds to fix version.
- [x] Description references specific [issue](https://github.com/thingsboard/tbmq/issues) (#303).
- [x] Description contains human-readable scope of changes.
- [x] Description contains brief notes about what needs to be added to the documentation.
- [x] No merge conflicts, commented blocks of code, code formatting issues.
- [x] Changes are backward compatible or upgrade script is provided.

## Front-End feature checklist

_N/A — back-end only change (no front-end / UI changes)._

- [x] Screenshots with affected component(s) are added. The best option is to provide 2 screens: before and after changes;
- [x] If you change the widget or other API, ensure it is backward-compatible or upgrade script is present.

## Back-End feature checklist

- [x] Added corresponding unit and/or integration test(s). Provide written explanation in the PR description if you have failed to add tests. — 3 new tests in `TbMessageStatsReportClientImplTest` (single drop, batched count, and counter increments even when historical reporting is disabled) and 3 in the new `DefaultDroppedMsgStatsTest` (increment, batched increment, and `reset()` clears the per-interval count while the cumulative Prometheus counter stays monotonic); `BasicDownLinkProcessorImplTest` verifications updated for `reportDroppedMsgs()`. All added/updated unit tests pass.
- [x] If new dependency was added: the dependency tree is checked for conflicts. — No new dependency added; Micrometer / `micrometer-registry-prometheus` were already on the classpath.
