### PR TITLE
fix(backpressure): decrement nonWritableClientsCount on session disconnect

### DIFF
--- a/application/src/main/java/org/thingsboard/mqtt/broker/actors/client/service/channel/ChannelBackpressureManager.java
+++ b/application/src/main/java/org/thingsboard/mqtt/broker/actors/client/service/channel/ChannelBackpressureManager.java
@@ -16,11 +16,14 @@
 package org.thingsboard.mqtt.broker.actors.client.service.channel;
 
 import org.thingsboard.mqtt.broker.actors.client.state.ClientActorState;
+import org.thingsboard.mqtt.broker.actors.client.state.ClientActorStateInfo;
 
 public interface ChannelBackpressureManager {
 
     void onChannelWritable(ClientActorState state);
 
     void onChannelNonWritable(ClientActorState state);
+
+    void onSessionDisconnect(ClientActorStateInfo state);
 
 }

--- a/application/src/main/java/org/thingsboard/mqtt/broker/actors/client/service/channel/ChannelBackpressureManagerImpl.java
+++ b/application/src/main/java/org/thingsboard/mqtt/broker/actors/client/service/channel/ChannelBackpressureManagerImpl.java
@@ -21,11 +21,13 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.thingsboard.mqtt.broker.actors.client.state.ClientActorState;
+import org.thingsboard.mqtt.broker.actors.client.state.ClientActorStateInfo;
 import org.thingsboard.mqtt.broker.actors.client.state.SessionState;
 import org.thingsboard.mqtt.broker.common.data.ClientType;
 import org.thingsboard.mqtt.broker.service.mqtt.persistence.application.ApplicationPersistenceProcessor;
 import org.thingsboard.mqtt.broker.service.mqtt.persistence.device.DevicePersistenceProcessor;
 import org.thingsboard.mqtt.broker.service.stats.StatsManager;
+import org.thingsboard.mqtt.broker.session.ClientSessionCtx;
 
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -54,16 +56,21 @@ public class ChannelBackpressureManagerImpl implements ChannelBackpressureManage
         // FlowControl: drain any messages buffered while the window was full.
         // Must run BEFORE the early-returns below so it fires on every writability flip,
         // including the clean-session path.
-        state.getCurrentSessionCtx().onChannelWritable();
+        ClientSessionCtx sessionCtx = state.getCurrentSessionCtx();
+        sessionCtx.onChannelWritable();
+
+        // Decrement is gated on the per-session flag, not on SessionState, because clean-session clients
+        // never transition to CHANNEL_NON_WRITABLE (see onChannelNonWritable below).
+        boolean wasCounted = decrementCounterIfCounted(sessionCtx);
+        if (wasCounted) {
+            log.info("[{}] Channel is writable", state.getClientId());
+        }
 
         if (!SessionState.CHANNEL_NON_WRITABLE.equals(state.getCurrentSessionState())) {
             log.debug("[{}] Received channel writable event when current state is not CHANNEL_NON_WRITABLE", state.getClientId());
             return;
-        } else {
-            log.info("[{}] Channel is writable", state.getClientId());
         }
-        nonWritableClientsCount.updateAndGet(current -> current == 0 ? 0 : current - 1);
-        if (state.getCurrentSessionCtx().isCleanSession()) {
+        if (sessionCtx.isCleanSession()) {
             return;
         }
         state.updateSessionState(SessionState.CONNECTED);
@@ -79,11 +86,13 @@ public class ChannelBackpressureManagerImpl implements ChannelBackpressureManage
         if (!SessionState.CONNECTED.equals(state.getCurrentSessionState())) {
             log.debug("[{}] Received CHANNEL_NON_WRITABLE when current state is not CONNECTED", state.getClientId());
             return;
-        } else {
-            log.warn("[{}] Channel became non-writable", state.getClientId());
         }
-        nonWritableClientsCount.incrementAndGet();
-        if (state.getCurrentSessionCtx().isCleanSession()) {
+        ClientSessionCtx sessionCtx = state.getCurrentSessionCtx();
+        if (!incrementCounterIfNotCounted(sessionCtx)) {
+            return;
+        }
+        log.warn("[{}] Channel became non-writable", state.getClientId());
+        if (sessionCtx.isCleanSession()) {
             return;
         }
         state.updateSessionState(SessionState.CHANNEL_NON_WRITABLE);
@@ -92,6 +101,33 @@ public class ChannelBackpressureManagerImpl implements ChannelBackpressureManage
         } else if (DEVICE.equals(getClientType(state))) {
             devicePersistenceProcessor.processChannelNonWritable(state.getClientId());
         }
+    }
+
+    @Override
+    public void onSessionDisconnect(ClientActorStateInfo state) {
+        ClientSessionCtx sessionCtx = state.getCurrentSessionCtx();
+        if (sessionCtx == null) {
+            return;
+        }
+        if (decrementCounterIfCounted(sessionCtx)) {
+            log.debug("[{}] Decremented non-writable clients counter on session disconnect", state.getClientId());
+        }
+    }
+
+    private boolean incrementCounterIfNotCounted(ClientSessionCtx sessionCtx) {
+        if (sessionCtx.getNonWritableCounted().compareAndSet(false, true)) {
+            nonWritableClientsCount.incrementAndGet();
+            return true;
+        }
+        return false;
+    }
+
+    private boolean decrementCounterIfCounted(ClientSessionCtx sessionCtx) {
+        if (sessionCtx.getNonWritableCounted().compareAndSet(true, false)) {
+            nonWritableClientsCount.decrementAndGet();
+            return true;
+        }
+        return false;
     }
 
     private ClientType getClientType(ClientActorState state) {

--- a/application/src/main/java/org/thingsboard/mqtt/broker/actors/client/service/disconnect/DisconnectServiceImpl.java
+++ b/application/src/main/java/org/thingsboard/mqtt/broker/actors/client/service/disconnect/DisconnectServiceImpl.java
@@ -22,6 +22,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.thingsboard.mqtt.broker.actors.client.messages.mqtt.MqttDisconnectMsg;
+import org.thingsboard.mqtt.broker.actors.client.service.channel.ChannelBackpressureManager;
 import org.thingsboard.mqtt.broker.actors.client.state.ClientActorStateInfo;
 import org.thingsboard.mqtt.broker.common.data.ClientInfo;
 import org.thingsboard.mqtt.broker.common.data.SessionInfo;
@@ -58,6 +59,7 @@ public class DisconnectServiceImpl implements DisconnectService {
     private final AuthorizationRuleService authorizationRuleService;
     private final FlowControlService flowControlService;
     private final TbMessageStatsReportClient tbMessageStatsReportClient;
+    private final ChannelBackpressureManager channelBackpressureManager;
 
     @Override
     public void disconnect(ClientActorStateInfo actorState, MqttDisconnectMsg disconnectMsg) {
@@ -140,6 +142,7 @@ public class DisconnectServiceImpl implements DisconnectService {
         sessionCtx.releasePublishedInFlightCtx();
         flowControlService.removeFromMap(sessionCtx.getClientId());
         tbMessageStatsReportClient.removeClient(sessionCtx.getClientId());
+        channelBackpressureManager.onSessionDisconnect(actorState);
         closeChannel(sessionCtx);
 
         log.debug("[{}][{}] Client disconnected", sessionCtx.getClientId(), sessionCtx.getSessionId());

--- a/application/src/main/java/org/thingsboard/mqtt/broker/session/ClientSessionCtx.java
+++ b/application/src/main/java/org/thingsboard/mqtt/broker/session/ClientSessionCtx.java
@@ -38,6 +38,7 @@ import org.thingsboard.mqtt.broker.service.stats.FlowControlStats;
 import java.net.InetSocketAddress;
 import java.util.List;
 import java.util.UUID;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 @Slf4j
 @Data
@@ -49,6 +50,9 @@ public class ClientSessionCtx implements SessionContext {
     private final PubResponseProcessingCtx pubResponseProcessingCtx;
     private final MsgIdSequence msgIdSeq = new MsgIdSequence();
     private final AwaitingPubRelPacketsCtx awaitingPubRelPacketsCtx = new AwaitingPubRelPacketsCtx();
+    // Tracks whether this session is currently counted in the broker-wide nonWritableClientsCount gauge.
+    // Used to make increment/decrement idempotent and to allow decrement on abrupt disconnect.
+    private final AtomicBoolean nonWritableCounted = new AtomicBoolean(false);
 
     private volatile SessionInfo sessionInfo;
     private volatile List<AuthRulePatterns> authRulePatterns;

--- a/application/src/test/java/org/thingsboard/mqtt/broker/actors/client/service/channel/ChannelBackpressureManagerImplTest.java
+++ b/application/src/test/java/org/thingsboard/mqtt/broker/actors/client/service/channel/ChannelBackpressureManagerImplTest.java
@@ -19,9 +19,9 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.thingsboard.mqtt.broker.actors.client.state.ClientActorState;
 import org.thingsboard.mqtt.broker.actors.client.state.SessionState;
@@ -31,6 +31,7 @@ import org.thingsboard.mqtt.broker.service.mqtt.persistence.device.DevicePersist
 import org.thingsboard.mqtt.broker.service.stats.StatsManager;
 import org.thingsboard.mqtt.broker.session.ClientSessionCtx;
 
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -45,14 +46,14 @@ import static org.mockito.Mockito.when;
 @ContextConfiguration(classes = ChannelBackpressureManagerImpl.class)
 public class ChannelBackpressureManagerImplTest {
 
-    @MockBean
+    @MockitoBean
     ApplicationPersistenceProcessor applicationPersistenceProcessor;
-    @MockBean
+    @MockitoBean
     DevicePersistenceProcessor devicePersistenceProcessor;
-    @MockBean
+    @MockitoBean
     StatsManager statsManager;
 
-    @SpyBean
+    @MockitoSpyBean
     ChannelBackpressureManagerImpl channelBackpressureManager;
 
     ClientActorState state;
@@ -67,6 +68,7 @@ public class ChannelBackpressureManagerImplTest {
         when(state.getClientId()).thenReturn(clientId);
         when(state.getCurrentSessionCtx()).thenReturn(ctx);
         when(ctx.isCleanSession()).thenReturn(false);
+        when(ctx.getNonWritableCounted()).thenReturn(new AtomicBoolean());
 
         when(statsManager.createNonWritableClientsCounter()).thenReturn(new AtomicInteger());
         channelBackpressureManager.init();
@@ -222,6 +224,93 @@ public class ChannelBackpressureManagerImplTest {
         channelBackpressureManager.onChannelWritable(state);
 
         verify(ctx, times(1)).onChannelWritable();
+    }
+
+    @Test
+    public void givenPersistentClientCountedAsNonWritable_whenOnSessionDisconnect_thenCounterDecremented() {
+        when(ctx.getClientType()).thenReturn(ClientType.APPLICATION);
+        when(state.getCurrentSessionState()).thenReturn(SessionState.CONNECTED);
+        channelBackpressureManager.onChannelNonWritable(state);
+        assertThatCounterIs(1);
+
+        when(state.getCurrentSessionState()).thenReturn(SessionState.DISCONNECTING);
+        channelBackpressureManager.onSessionDisconnect(state);
+
+        assertThatCounterIs(0);
+    }
+
+    @Test
+    public void givenCleanSessionClientCountedAsNonWritable_whenOnSessionDisconnect_thenCounterDecremented() {
+        setCleanSession();
+        when(ctx.getClientType()).thenReturn(ClientType.DEVICE);
+        when(state.getCurrentSessionState()).thenReturn(SessionState.CONNECTED);
+        channelBackpressureManager.onChannelNonWritable(state);
+        assertThatCounterIs(1);
+
+        when(state.getCurrentSessionState()).thenReturn(SessionState.DISCONNECTING);
+        channelBackpressureManager.onSessionDisconnect(state);
+
+        assertThatCounterIs(0);
+    }
+
+    @Test
+    public void givenClientNotCountedAsNonWritable_whenOnSessionDisconnect_thenCounterUnchanged() {
+        channelBackpressureManager.onSessionDisconnect(state);
+
+        assertThatCounterIs(0);
+    }
+
+    @Test
+    public void givenClientAlreadyDecremented_whenOnSessionDisconnect_thenCounterUnchanged() {
+        when(ctx.getClientType()).thenReturn(ClientType.APPLICATION);
+        when(state.getCurrentSessionState()).thenReturn(SessionState.CONNECTED);
+        channelBackpressureManager.onChannelNonWritable(state);
+        assertThatCounterIs(1);
+
+        when(state.getCurrentSessionState()).thenReturn(SessionState.CHANNEL_NON_WRITABLE);
+        channelBackpressureManager.onChannelWritable(state);
+        assertThatCounterIs(0);
+
+        when(state.getCurrentSessionState()).thenReturn(SessionState.DISCONNECTING);
+        channelBackpressureManager.onSessionDisconnect(state);
+
+        assertThatCounterIs(0);
+    }
+
+    @Test
+    public void givenCleanSessionClient_whenChannelGoesNonWritableThenWritable_thenCounterDecremented() {
+        setCleanSession();
+        when(ctx.getClientType()).thenReturn(ClientType.DEVICE);
+        when(state.getCurrentSessionState()).thenReturn(SessionState.CONNECTED);
+
+        channelBackpressureManager.onChannelNonWritable(state);
+        assertThatCounterIs(1);
+
+        // Clean-session clients never transition to CHANNEL_NON_WRITABLE; state stays CONNECTED.
+        channelBackpressureManager.onChannelWritable(state);
+
+        assertThatCounterIs(0);
+    }
+
+    @Test
+    public void onChannelNonWritable_isIdempotent_doesNotDoubleCount() {
+        when(ctx.getClientType()).thenReturn(ClientType.DEVICE);
+        when(state.getCurrentSessionState()).thenReturn(SessionState.CONNECTED);
+
+        channelBackpressureManager.onChannelNonWritable(state);
+        // Second call (e.g. duplicate writability event) must not double-count.
+        channelBackpressureManager.onChannelNonWritable(state);
+
+        assertThatCounterIs(1);
+    }
+
+    @Test
+    public void onSessionDisconnect_isNoOp_whenSessionCtxIsNull() {
+        when(state.getCurrentSessionCtx()).thenReturn(null);
+
+        channelBackpressureManager.onSessionDisconnect(state);
+
+        assertThatCounterIs(0);
     }
 
     private void assertThatCounterIs(int expected) {

--- a/application/src/test/java/org/thingsboard/mqtt/broker/actors/client/service/disconnect/DisconnectServiceImplTest.java
+++ b/application/src/test/java/org/thingsboard/mqtt/broker/actors/client/service/disconnect/DisconnectServiceImplTest.java
@@ -28,6 +28,7 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.thingsboard.mqtt.broker.actors.client.messages.mqtt.MqttDisconnectMsg;
+import org.thingsboard.mqtt.broker.actors.client.service.channel.ChannelBackpressureManager;
 import org.thingsboard.mqtt.broker.actors.client.state.ClientActorStateInfo;
 import org.thingsboard.mqtt.broker.actors.client.state.QueuedMqttMessages;
 import org.thingsboard.mqtt.broker.common.data.ClientInfo;
@@ -85,6 +86,8 @@ public class DisconnectServiceImplTest {
     FlowControlService flowControlService;
     @MockitoBean
     TbMessageStatsReportClient tbMessageStatsReportClient;
+    @MockitoBean
+    ChannelBackpressureManager channelBackpressureManager;
 
     @MockitoSpyBean
     DisconnectServiceImpl disconnectService;
@@ -186,6 +189,16 @@ public class DisconnectServiceImplTest {
 
         verify(msgPersistenceManager, times(1)).stopProcessingPersistedMessages(any());
         verify(msgPersistenceManager, times(1)).saveAwaitingQoS2Packets(any());
+    }
+
+    @Test
+    public void cleanupClientSession_notifiesChannelBackpressureManagerOnSessionDisconnect() {
+        when(sessionInfo.isPersistent()).thenReturn(false);
+
+        MqttDisconnectMsg disconnectMsg = newDisconnectMsg(new DisconnectReason(ON_DISCONNECT_MSG));
+        disconnectService.cleanupClientSession(clientActorState, disconnectMsg, -1);
+
+        verify(channelBackpressureManager).onSessionDisconnect(clientActorState);
     }
 
     @Test


### PR DESCRIPTION
## Pull Request description

Fixes #318.

The `nonWritableClientsCount` gauge only ever climbed and never went back down. Once a client's channel became non-writable, that `+1` stayed forever — even after the client disconnected and reconnected.

**Root cause:** the counter was only decremented on the "channel writable again" event (`ChannelBackpressureManagerImpl#onChannelWritable`), and that decrement was gated on `SessionState == CHANNEL_NON_WRITABLE`. If a client disconnected while still non-writable (OOM kill, network drop, TCP RST), the channel simply closed and the "writable again" event never fired — so the decrement never happened. The gauge is a single broker-wide number with no per-client tracking, so a reconnect could not repair the stale count either. As a side effect, clean-session clients leaked too: they were incremented but never transitioned to `CHANNEL_NON_WRITABLE`, so the gated decrement was always skipped on recovery.

**Scope of changes:**
- Add a per-session `AtomicBoolean nonWritableCounted` to `ClientSessionCtx` that tracks whether this session currently contributes to the gauge.
- Make increment/decrement idempotent via `compareAndSet`, and gate the decrement on this per-session flag instead of `SessionState`. This fixes the clean-session leak and prevents double counting on duplicate writability events.
- Add `ChannelBackpressureManager#onSessionDisconnect(...)`, invoked from `DisconnectServiceImpl#cleanupClientSession(...)`, so the gauge is decremented as part of every disconnect flow — including abrupt closes, which reach this path via the channel close-future listener (`MqttSessionHandler#operationComplete` → `ON_CHANNEL_CLOSED`). The instant-reconnect / session-takeover path also decrements the old session correctly, because `disconnectCurrentSession` runs before the actor swaps in the new session context.

**Testing:** added 8 unit tests across `ChannelBackpressureManagerImplTest` and `DisconnectServiceImplTest` covering disconnect-time decrement (persistent and clean-session), idempotency, the already-decremented and not-counted cases, and the `null` session-context no-op. Verified red/green: neutering the new decrement makes exactly the two disconnect tests fail.

**Documentation:** none required — internal metric-accuracy fix with no API, schema, or configuration change.

## General checklist

- [x] You have reviewed the guidelines [document](https://docs.google.com/document/d/1A4Vc3wrHsY_159b9RG5LOtCryoH6VPwgOhrFEzJKwbI/edit?usp=sharing).
- [x] [Labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels#about-labels) that classify your pull request have been added.
- [x] The [milestone](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones) is specified and corresponds to fix version.
- [x] Description references specific [issue](https://github.com/thingsboard/tbmq/issues).
- [x] Description contains human-readable scope of changes.
- [x] Description contains brief notes about what needs to be added to the documentation.
- [x] No merge conflicts, commented blocks of code, code formatting issues.
- [x] Changes are backward compatible or upgrade script is provided.

## Front-End feature checklist

_N/A — no front-end changes._

- [x] Screenshots with affected component(s) are added. The best option is to provide 2 screens: before and after changes;
- [x] If you change the widget or other API, ensure it is backward-compatible or upgrade script is present.

## Back-End feature checklist

- [x] Added corresponding unit and/or integration test(s). Provide written explanation in the PR description if you have failed to add tests.
- [x] If new dependency was added: the dependency tree is checked for conflicts.
