### PR TITLE
fix(server): don't close PROXY protocol LOCAL connections (health checks)

### DIFF
--- a/application/src/main/java/org/thingsboard/mqtt/broker/server/ip/ProxyIpAddressHandler.java
+++ b/application/src/main/java/org/thingsboard/mqtt/broker/server/ip/ProxyIpAddressHandler.java
@@ -37,8 +37,15 @@ public class ProxyIpAddressHandler extends ChannelInboundHandlerAdapter {
                 // We no longer need this channel in the pipeline. Similar to HAProxyMessageDecoder
                 ctx.pipeline().remove(this);
             } else {
-                log.trace("Received local health-check connection message: {}", proxyMsg);
-                ctx.close();
+                // PROXY protocol LOCAL command (lower 4 bits of the version/command byte are 0) — used by
+                // load balancers for connections not relayed on behalf of a client, e.g. HAProxy/Traefik
+                // health checks. Per the PROXY protocol spec the receiver MUST accept such a connection as
+                // valid and use the real connection endpoints, discarding the (absent) address block.
+                // Closing here fails TLS health checks, so the LB marks the backend DOWN and stops routing
+                // all traffic to it (see GH#322). Drop this handler and let the connection proceed; the real
+                // socket address is used downstream via MqttSessionHandler#getAddress.
+                log.trace("[{}] Received PROXY LOCAL command (e.g. health-check); proceeding with the real socket address", ctx.channel().id());
+                ctx.pipeline().remove(this);
             }
         } else {
             log.warn("[{}] Received unexpected msg, expected HAProxyMessage: {}", ctx.channel().id(), msg);

--- a/application/src/test/java/org/thingsboard/mqtt/broker/server/ip/ProxyIpAddressHandlerTest.java
+++ b/application/src/test/java/org/thingsboard/mqtt/broker/server/ip/ProxyIpAddressHandlerTest.java
@@ -1,0 +1,105 @@
+/**
+ * Copyright © 2016-2026 The Thingsboard Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.thingsboard.mqtt.broker.server.ip;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.embedded.EmbeddedChannel;
+import io.netty.handler.codec.haproxy.HAProxyCommand;
+import io.netty.handler.codec.haproxy.HAProxyMessage;
+import io.netty.handler.codec.haproxy.HAProxyProtocolVersion;
+import io.netty.handler.codec.haproxy.HAProxyProxiedProtocol;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.thingsboard.mqtt.broker.server.MqttSessionHandler;
+
+import java.net.InetSocketAddress;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ProxyIpAddressHandlerTest {
+
+    private EmbeddedChannel channel;
+
+    @Before
+    public void setUp() {
+        channel = new EmbeddedChannel(new ProxyIpAddressHandler());
+    }
+
+    @After
+    public void tearDown() {
+        channel.finishAndReleaseAll();
+    }
+
+    private static HAProxyMessage proxyMessage() {
+        return new HAProxyMessage(HAProxyProtocolVersion.V2, HAProxyCommand.PROXY,
+                HAProxyProxiedProtocol.TCP4, "203.0.113.7", "10.0.0.5", 51234, 8883);
+    }
+
+    // PROXY command with real client addresses (a relayed client connection) — as before the fix.
+    private static HAProxyMessage localMessage() {
+        return new HAProxyMessage(HAProxyProtocolVersion.V2, HAProxyCommand.LOCAL,
+                HAProxyProxiedProtocol.UNKNOWN, null, null, 0, 0);
+    }
+
+    @Test
+    public void givenProxyCommand_whenChannelRead_thenAddressSetAndHandlerRemoved() {
+        channel.writeInbound(proxyMessage());
+
+        InetSocketAddress addr = channel.attr(MqttSessionHandler.ADDRESS).get();
+        assertThat(addr).isNotNull();
+        assertThat(addr.getHostString()).isEqualTo("203.0.113.7");
+        assertThat(addr.getPort()).isEqualTo(51234);
+        assertThat(channel.isActive()).isTrue();
+        assertThat(channel.pipeline().get(ProxyIpAddressHandler.class)).isNull();
+    }
+
+    // GH#322: a LOCAL command (e.g. HAProxy/Traefik health check) must NOT close the connection.
+    // Before the fix the handler called ctx.close() here, failing TLS health checks and taking the
+    // whole backend DOWN. Per the PROXY protocol spec the receiver must accept it and use the real
+    // socket endpoints (left to MqttSessionHandler#getAddress, so ADDRESS stays unset here).
+    @Test
+    public void givenLocalCommand_whenChannelRead_thenConnectionStaysOpenAndHandlerRemoved() {
+        channel.writeInbound(localMessage());
+
+        assertThat(channel.isActive()).isTrue();
+        assertThat(channel.attr(MqttSessionHandler.ADDRESS).get()).isNull();
+        assertThat(channel.pipeline().get(ProxyIpAddressHandler.class)).isNull();
+    }
+
+    // After a LOCAL command the handler removes itself, so subsequent bytes (e.g. the TLS ClientHello
+    // of the health check) flow downstream instead of hitting the "unexpected msg" branch and closing.
+    @Test
+    public void givenLocalCommandThenBytes_whenChannelRead_thenBytesForwardedAndConnectionStaysOpen() {
+        channel.writeInbound(localMessage());
+        ByteBuf tlsClientHelloBytes = Unpooled.wrappedBuffer(new byte[]{0x16, 0x03, 0x01, 0x00, 0x05});
+        channel.writeInbound(tlsClientHelloBytes);
+
+        assertThat(channel.isActive()).isTrue();
+        ByteBuf forwarded = channel.readInbound();
+        assertThat(forwarded).isNotNull();
+        assertThat(forwarded.readableBytes()).isEqualTo(5);
+        forwarded.release();
+    }
+
+    @Test
+    public void givenNonHAProxyMessage_whenChannelRead_thenConnectionClosed() {
+        channel.writeInbound("not-a-haproxy-message");
+
+        assertThat(channel.isActive()).isFalse();
+    }
+}

--- a/application/src/test/java/org/thingsboard/mqtt/broker/server/ip/ProxyIpAddressHandlerTest.java
+++ b/application/src/test/java/org/thingsboard/mqtt/broker/server/ip/ProxyIpAddressHandlerTest.java
@@ -45,12 +45,13 @@ public class ProxyIpAddressHandlerTest {
         channel.finishAndReleaseAll();
     }
 
+    // PROXY command with real client addresses (a relayed client connection).
     private static HAProxyMessage proxyMessage() {
         return new HAProxyMessage(HAProxyProtocolVersion.V2, HAProxyCommand.PROXY,
                 HAProxyProxiedProtocol.TCP4, "203.0.113.7", "10.0.0.5", 51234, 8883);
     }
 
-    // PROXY command with real client addresses (a relayed client connection) — as before the fix.
+    // LOCAL command with no addresses — models a load balancer health-check connection (GH#322).
     private static HAProxyMessage localMessage() {
         return new HAProxyMessage(HAProxyProtocolVersion.V2, HAProxyCommand.LOCAL,
                 HAProxyProxiedProtocol.UNKNOWN, null, null, 0, 0);


### PR DESCRIPTION
## Pull Request description

Fixes #322 — `proxy_protocol_v2` is broken when TBMQ sits behind a modern load balancer (HAProxy ≥ 2.x, Traefik) with TLS and health checks enabled.

### Root cause
`ProxyIpAddressHandler` closed any `HAProxyMessage` that had no source address (`ctx.close()`). The PROXY **v2 LOCAL** command decodes to exactly that — and load balancers emit the LOCAL command on health-check connections (connections not relayed on behalf of a real client). With TLS on the listener, closing before the TLS handshake makes the LB health check fail (`Layer6 / SSL handshake failure`); after the configured `fall` count the backend is marked **DOWN** and the LB stops routing all client traffic to it. Net effect: proxy protocol v2 appears completely broken behind modern LBs.

This is also a PROXY protocol spec violation — the spec states the receiver MUST accept a LOCAL connection as valid and use the real connection endpoints.

Why only v2 / only newer LBs: PROXY v1 has no LOCAL command, so its health checks carry a normal `PROXY TCP4 …` line that the handler accepts (v1 always works). Older HAProxy (1.8) emitted a full PROXY command for health checks too, so it also worked; HAProxy later fixed this to send the spec-compliant LOCAL command (haproxy/haproxy#511), which is what trips the bug.

### Scope of changes
- `ProxyIpAddressHandler`: on the LOCAL command, remove the handler and let the connection proceed instead of closing it. The real socket address is used downstream via `MqttSessionHandler#getAddress` (which already falls back to `ctx.channel().remoteAddress()` when the address attribute is unset). Genuinely unexpected (non-`HAProxyMessage`) messages still close the connection.
- Added `ProxyIpAddressHandlerTest` (EmbeddedChannel) covering: LOCAL keeps the connection open and removes the handler; bytes after LOCAL are forwarded downstream; PROXY sets the real client address; a non-HAProxy message closes the connection.

Verified end-to-end with HAProxy 3.0 in front of TBMQ over TLS: before the fix the `send-proxy-v2` backend is marked DOWN and clients cannot connect; after the fix the backend stays UP and clients connect through the v2 path.

### Documentation
No documentation changes required.

## General checklist

- [x] You have reviewed the guidelines [document](https://docs.google.com/document/d/1A4Vc3wrHsY_159b9RG5LOtCryoH6VPwgOhrFEzJKwbI/edit?usp=sharing).
- [x] [Labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels#about-labels) that classify your pull request have been added.
- [x] The [milestone](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones) is specified and corresponds to fix version.
- [x] Description references specific [issue](https://github.com/thingsboard/tbmq/issues).
- [x] Description contains human-readable scope of changes.
- [x] Description contains brief notes about what needs to be added to the documentation.
- [x] No merge conflicts, commented blocks of code, code formatting issues.
- [x] Changes are backward compatible or upgrade script is provided.

## Front-End feature checklist

Not applicable — back-end only change.

## Back-End feature checklist

- [x] Added corresponding unit test(s) (`ProxyIpAddressHandlerTest`).
- [x] No new dependency was added.
