### PR TITLE
fix(server): release HAProxyMessage in ProxyIpAddressHandler

### DIFF
--- a/application/src/main/java/org/thingsboard/mqtt/broker/server/ip/ProxyIpAddressHandler.java
+++ b/application/src/main/java/org/thingsboard/mqtt/broker/server/ip/ProxyIpAddressHandler.java
@@ -18,6 +18,7 @@ package org.thingsboard.mqtt.broker.server.ip;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.handler.codec.haproxy.HAProxyMessage;
+import io.netty.util.ReferenceCountUtil;
 import lombok.extern.slf4j.Slf4j;
 import org.thingsboard.mqtt.broker.server.MqttSessionHandler;
 
@@ -28,28 +29,35 @@ public class ProxyIpAddressHandler extends ChannelInboundHandlerAdapter {
 
     @Override
     public void channelRead(ChannelHandlerContext ctx, Object msg) {
-        log.trace("[{}] Received msg: {}", ctx.channel().id(), msg);
-        if (msg instanceof HAProxyMessage proxyMsg) {
-            if (proxyMsg.sourceAddress() != null && proxyMsg.sourcePort() > 0) {
-                InetSocketAddress address = new InetSocketAddress(proxyMsg.sourceAddress(), proxyMsg.sourcePort());
-                log.trace("[{}] Setting address: {}", ctx.channel().id(), address);
-                ctx.channel().attr(MqttSessionHandler.ADDRESS).set(address);
-                // We no longer need this channel in the pipeline. Similar to HAProxyMessageDecoder
+        // We are the terminal consumer of msg: it is never forwarded via ctx.fireChannelRead, so we own its
+        // reference count and release it on every path in the finally block below.
+        try {
+            log.trace("[{}] Received msg: {}", ctx.channel().id(), msg);
+            if (msg instanceof HAProxyMessage proxyMsg) {
+                if (proxyMsg.sourceAddress() != null && proxyMsg.sourcePort() > 0) {
+                    InetSocketAddress address = new InetSocketAddress(proxyMsg.sourceAddress(), proxyMsg.sourcePort());
+                    log.trace("[{}] Setting address: {}", ctx.channel().id(), address);
+                    ctx.channel().attr(MqttSessionHandler.ADDRESS).set(address);
+                } else {
+                    // PROXY protocol LOCAL command (lower 4 bits of the version/command byte are 0) — used by
+                    // load balancers for connections not relayed on behalf of a client, e.g. HAProxy/Traefik
+                    // health checks. Per the PROXY protocol spec the receiver MUST accept such a connection as
+                    // valid and use the real connection endpoints, discarding the (absent) address block.
+                    // Closing here fails TLS health checks, so the LB marks the backend DOWN and stops routing
+                    // all traffic to it (see GH#322). Let the connection proceed; the real socket address is
+                    // used downstream via MqttSessionHandler#getAddress.
+                    log.trace("[{}] Received PROXY LOCAL command (e.g. health-check); proceeding with the real socket address", ctx.channel().id());
+                }
+                // The single PROXY header is consumed; drop this handler. Similar to HAProxyMessageDecoder.
                 ctx.pipeline().remove(this);
             } else {
-                // PROXY protocol LOCAL command (lower 4 bits of the version/command byte are 0) — used by
-                // load balancers for connections not relayed on behalf of a client, e.g. HAProxy/Traefik
-                // health checks. Per the PROXY protocol spec the receiver MUST accept such a connection as
-                // valid and use the real connection endpoints, discarding the (absent) address block.
-                // Closing here fails TLS health checks, so the LB marks the backend DOWN and stops routing
-                // all traffic to it (see GH#322). Drop this handler and let the connection proceed; the real
-                // socket address is used downstream via MqttSessionHandler#getAddress.
-                log.trace("[{}] Received PROXY LOCAL command (e.g. health-check); proceeding with the real socket address", ctx.channel().id());
-                ctx.pipeline().remove(this);
+                log.warn("[{}] Received unexpected msg, expected HAProxyMessage: {}", ctx.channel().id(), msg);
+                ctx.close();
             }
-        } else {
-            log.warn("[{}] Received unexpected msg, expected HAProxyMessage: {}", ctx.channel().id(), msg);
-            ctx.close();
+        } finally {
+            // HAProxyMessage is reference-counted and HAProxyMessageDecoder hands it off without releasing,
+            // so release it here to free any TLV buffers a PROXY frame may carry (e.g. an AWS NLB VPCE-ID TLV).
+            ReferenceCountUtil.release(msg);
         }
     }
 

--- a/application/src/test/java/org/thingsboard/mqtt/broker/server/ip/ProxyIpAddressHandlerTest.java
+++ b/application/src/test/java/org/thingsboard/mqtt/broker/server/ip/ProxyIpAddressHandlerTest.java
@@ -103,4 +103,26 @@ public class ProxyIpAddressHandlerTest {
 
         assertThat(channel.isActive()).isFalse();
     }
+
+    // The handler is the terminal consumer of the reference-counted HAProxyMessage (it never forwards it
+    // downstream), so it must release it — otherwise the message (and any TLV buffers it carries) leaks.
+    @Test
+    public void givenProxyCommand_whenChannelRead_thenMessageReleased() {
+        HAProxyMessage msg = proxyMessage();
+        assertThat(msg.refCnt()).isEqualTo(1);
+
+        channel.writeInbound(msg);
+
+        assertThat(msg.refCnt()).isZero();
+    }
+
+    @Test
+    public void givenLocalCommand_whenChannelRead_thenMessageReleased() {
+        HAProxyMessage msg = localMessage();
+        assertThat(msg.refCnt()).isEqualTo(1);
+
+        channel.writeInbound(msg);
+
+        assertThat(msg.refCnt()).isZero();
+    }
 }


### PR DESCRIPTION
## Pull Request description

Follow-up cleanup spotted while reviewing the PROXY-protocol health-check fix (#326, issue #322).

`ProxyIpAddressHandler` is the terminal consumer of the reference-counted `io.netty.handler.codec.haproxy.HAProxyMessage`: `HAProxyMessageDecoder` decodes the PROXY header, fires the message to this handler, and does **not** release it. The handler reads the real client address (or recognizes a LOCAL/health-check command), removes itself from the pipeline, and never forwards the message via `ctx.fireChannelRead` — but it also never released it, leaving the message's reference count un-decremented.

Impact:
- For PROXY v2 frames carrying TLVs (e.g. an AWS NLB `PP2_TYPE_AWS` VPCE-ID TLV, or `send-proxy-v2-ssl` client-cert/ALPN data), the TLVs are retained `ByteBuf` slices of the header buffer, so that buffer is never freed — a native-memory leak on every such connection.
- For TLV-less frames (plain PROXY headers and LOCAL health checks) nothing is retained, so it is effectively a no-op, but it is still an incorrect reference-count contract violation.

Fix: release the message in a `finally` so every path is covered (including the defensive unexpected-message branch), and consolidate the now-duplicated `pipeline().remove(this)`. The handler is the terminal consumer (it never calls `ctx.fireChannelRead`), so it owns the message and a blanket release is correct.

Scope of changes:
- `ProxyIpAddressHandler.channelRead`: wrap the body in `try { ... } finally { ReferenceCountUtil.release(msg); }`; single `remove(this)` after the branch logic.

Verification (end-to-end, before vs after): with Netty's leak detector at PARANOID (`NETTY_LEAK_DETECTOR_LVL=PARANOID`), ~300 client connections driven through a PROXY-protocol listener plus a forced GC:
- Unfixed broker — Netty reported `LEAK: HAProxyMessage.release() was not called before it's garbage-collected`, access-record hint `'ipAdrHandler' will handle the message from this point` (= this handler).
- Broker rebuilt with this change — 0 leak reports across repeated GCs and health checks, and no `IllegalReferenceCountException` (no over-release).

Unit tests in `ProxyIpAddressHandlerTest` assert `refCnt()` drops to 0 after `channelRead` for both the PROXY and LOCAL paths (6/6 passing).

Documentation: none required (internal reference-count handling; no config or API change).

## General checklist

- [x] You have reviewed the guidelines [document](https://docs.google.com/document/d/1A4Vc3wrHsY_159b9RG5LOtCryoH6VPwgOhrFEzJKwbI/edit?usp=sharing).
- [x] [Labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels#about-labels) that classify your pull request have been added.
- [x] The [milestone](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones) is specified and corresponds to fix version.
- [x] Description references specific [issue](https://github.com/thingsboard/tbmq/issues).
- [x] Description contains human-readable scope of changes.
- [x] Description contains brief notes about what needs to be added to the documentation.
- [x] No merge conflicts, commented blocks of code, code formatting issues.
- [x] Changes are backward compatible or upgrade script is provided.

## Front-End feature checklist

N/A — back-end only change.

## Back-End feature checklist

- [x] Added corresponding unit and/or integration test(s). `ProxyIpAddressHandlerTest` now asserts the `HAProxyMessage` reference count drops to 0 after `channelRead` for both the PROXY and LOCAL paths (these fail without the fix). Also verified end-to-end with Netty's leak detector at PARANOID (see Verification above).
- [x] If new dependency was added: the dependency tree is checked for conflicts. No new dependency — `io.netty.util.ReferenceCountUtil` is already on the classpath and used elsewhere (e.g. `MqttSessionHandler`).
