### PR TITLE
fix(application): enforce APPLICATION QoS1 retry cap, DUP-on-retransmit, ack WARN noise, give-up observability (GH#320)

### DIFF
--- a/application/src/main/java/org/thingsboard/mqtt/broker/service/mqtt/persistence/application/ApplicationPersistenceProcessorImpl.java
+++ b/application/src/main/java/org/thingsboard/mqtt/broker/service/mqtt/persistence/application/ApplicationPersistenceProcessorImpl.java
@@ -56,10 +56,13 @@ import org.thingsboard.mqtt.broker.service.mqtt.persistence.application.processi
 import org.thingsboard.mqtt.broker.service.mqtt.persistence.application.processing.PersistedMsg;
 import org.thingsboard.mqtt.broker.service.mqtt.persistence.application.processing.PersistedPubRelMsg;
 import org.thingsboard.mqtt.broker.service.mqtt.persistence.application.processing.PersistedPublishMsg;
+import org.thingsboard.mqtt.broker.service.historical.stats.TbMessageStatsReportClient;
 import org.thingsboard.mqtt.broker.service.mqtt.persistence.application.topic.ApplicationTopicService;
 import org.thingsboard.mqtt.broker.service.mqtt.persistence.application.util.ApplicationClientHelperService;
 import org.thingsboard.mqtt.broker.service.stats.ApplicationProcessorStats;
 import org.thingsboard.mqtt.broker.service.stats.StatsManager;
+
+import static org.thingsboard.mqtt.broker.common.data.BrokerConstants.DROPPED_MSGS;
 import org.thingsboard.mqtt.broker.service.subscription.shared.TopicSharedSubscription;
 import org.thingsboard.mqtt.broker.session.ClientMqttActorManager;
 import org.thingsboard.mqtt.broker.session.ClientSessionCtx;
@@ -110,6 +113,7 @@ public class ApplicationPersistenceProcessorImpl implements ApplicationPersisten
     private final ApplicationTopicService applicationTopicService;
     private final ApplicationClientHelperService appClientHelperService;
     private final AppMsgDeliveryStrategy appMsgDeliveryStrategy;
+    private final TbMessageStatsReportClient tbMessageStatsReportClient;
     private final boolean isTraceEnabled = log.isTraceEnabled();
     private final boolean isDebugEnabled = log.isDebugEnabled();
 
@@ -652,6 +656,7 @@ public class ApplicationPersistenceProcessorImpl implements ApplicationPersisten
         stats.log(totalPublishMsgs, totalPubRelMsgs, result, decision.isCommit());
 
         if (decision.isCommit()) {
+            reportSkippedMessagesIfAny(clientId, result);
             log.debug("[{}] Committing pack", clientId);
             ctx.clear();
             consumer.commitSync();
@@ -663,6 +668,33 @@ public class ApplicationPersistenceProcessorImpl implements ApplicationPersisten
             submitStrategy.update(decision.getReprocessMap());
         }
         return false;
+    }
+
+    private void reportSkippedMessagesIfAny(String clientId, ApplicationPackProcessingResult result) {
+        int skippedPublish = result.getPublishPendingMap().size();
+        int skippedPubRel = result.getPubRelPendingMap().size();
+        int skipped = skippedPublish + skippedPubRel;
+        if (skipped == 0) {
+            return;
+        }
+        log.warn("[{}] Giving up on pack: skipping {} un-acked message(s) [PUBLISH: {}, PUBREL: {}]{}. " +
+                        "Set APPLICATION ack-strategy retries to 0 for unlimited retries (strict at-least-once).",
+                clientId, skipped, skippedPublish, skippedPubRel, skippedPublishOffsets(result));
+        tbMessageStatsReportClient.reportStats(DROPPED_MSGS, skipped);
+    }
+
+    private String skippedPublishOffsets(ApplicationPackProcessingResult result) {
+        var pendingPublishes = result.getPublishPendingMap().values();
+        if (pendingPublishes.isEmpty()) {
+            return "";
+        }
+        long minOffset = Long.MAX_VALUE;
+        long maxOffset = Long.MIN_VALUE;
+        for (PersistedPublishMsg msg : pendingPublishes) {
+            minOffset = Math.min(minOffset, msg.getPacketOffset());
+            maxOffset = Math.max(maxOffset, msg.getPacketOffset());
+        }
+        return ", PUBLISH offsets [" + minOffset + ".." + maxOffset + "]";
     }
 
     private ApplicationPackProcessingCtx createPackProcessingCtx(ApplicationSubmitStrategy submitStrategy,

--- a/application/src/main/java/org/thingsboard/mqtt/broker/service/mqtt/persistence/application/ApplicationPersistenceProcessorImpl.java
+++ b/application/src/main/java/org/thingsboard/mqtt/broker/service/mqtt/persistence/application/ApplicationPersistenceProcessorImpl.java
@@ -37,7 +37,6 @@ import org.thingsboard.mqtt.broker.queue.cluster.ServiceInfoProvider;
 import org.thingsboard.mqtt.broker.queue.common.TbProtoQueueMsg;
 import org.thingsboard.mqtt.broker.queue.provider.ApplicationPersistenceMsgQueueFactory;
 import org.thingsboard.mqtt.broker.service.analysis.ClientLogger;
-import org.thingsboard.mqtt.broker.service.historical.stats.TbMessageStatsReportClient;
 import org.thingsboard.mqtt.broker.service.mqtt.MqttMsgDeliveryService;
 import org.thingsboard.mqtt.broker.service.mqtt.PublishMsg;
 import org.thingsboard.mqtt.broker.service.mqtt.persistence.application.data.ApplicationMainProcessingState;
@@ -111,8 +110,6 @@ public class ApplicationPersistenceProcessorImpl implements ApplicationPersisten
     private final ApplicationTopicService applicationTopicService;
     private final ApplicationClientHelperService appClientHelperService;
     private final AppMsgDeliveryStrategy appMsgDeliveryStrategy;
-    private final TbMessageStatsReportClient tbMessageStatsReportClient;
-    private final boolean isTraceEnabled = log.isTraceEnabled();
     private final boolean isDebugEnabled = log.isDebugEnabled();
 
     @Value("${queue.application-persisted-msg.poll-interval}")
@@ -427,7 +424,7 @@ public class ApplicationPersistenceProcessorImpl implements ApplicationPersisten
                 if (messages.isEmpty() && pubRelMsgCtx.nothingToDeliver()) {
                     continue;
                 }
-                pubRelMsgCtx = processMainPack(pubRelMsgCtx, messages, clientSessionCtx, persistedMsgCtx, consumer, stats, sessionId, clientState);
+                pubRelMsgCtx = processMainPack(pubRelMsgCtx, messages, clientSessionCtx, persistedMsgCtx, consumer, stats, clientState);
             } catch (Exception e) {
                 if (isClientSessionActive(sessionId, clientState)) {
                     log.warn("[{}] Failed to process messages from queue", clientId, e);
@@ -444,12 +441,14 @@ public class ApplicationPersistenceProcessorImpl implements ApplicationPersisten
                                                     ApplicationPersistedMsgCtx persistedMsgCtx,
                                                     TbQueueControlledOffsetConsumer<TbProtoQueueMsg<PublishMsgProto>> consumer,
                                                     ApplicationProcessorStats stats,
-                                                    UUID sessionId,
                                                     ClientActorStateInfo clientState) throws InterruptedException {
         String clientId = clientSessionCtx.getClientId();
+        UUID sessionId = clientSessionCtx.getSessionId();
         long packStart = System.nanoTime();
 
         ApplicationSubmitStrategy submitStrategy = submitStrategyFactory.newInstance(clientId);
+        ApplicationAckStrategy ackStrategy = acknowledgeStrategyFactory.newInstance(clientId);
+
         List<PersistedMsg> messagesToDeliver = buildMessagesToDeliver(pubRelMsgCtx, clientSessionCtx, persistedMsgCtx, messages, null);
         submitStrategy.init(messagesToDeliver);
 
@@ -457,7 +456,6 @@ public class ApplicationPersistenceProcessorImpl implements ApplicationPersisten
             log.debug("[{}] Starting main pack, {} messages to deliver", clientId, messagesToDeliver.size());
         }
 
-        ApplicationAckStrategy ackStrategy = acknowledgeStrategyFactory.newInstance(clientId);
         ApplicationPubRelMsgCtx newPubRelMsgCtx = new ApplicationPubRelMsgCtx(Sets.newConcurrentHashSet());
         while (isClientSessionActive(sessionId, clientState)) {
             ApplicationPackProcessingCtx ctx = createPackProcessingCtx(submitStrategy, newPubRelMsgCtx, stats);
@@ -554,14 +552,15 @@ public class ApplicationPersistenceProcessorImpl implements ApplicationPersisten
         long packStart = System.nanoTime();
 
         ApplicationSubmitStrategy submitStrategy = submitStrategyFactory.newInstance(clientId);
+        ApplicationAckStrategy ackStrategy = acknowledgeStrategyFactory.newInstance(clientId);
+
         List<PersistedMsg> messagesToDeliver = buildMessagesToDeliver(pubRelMsgCtx, clientSessionCtx, persistedMsgCtx, messages, subscription);
         submitStrategy.init(messagesToDeliver);
 
-        if (isTraceEnabled) {
+        if (log.isTraceEnabled()) {
             log.trace("[{}] Starting shared subscription pack, {} messages to deliver", clientId, messagesToDeliver.size());
         }
 
-        ApplicationAckStrategy ackStrategy = acknowledgeStrategyFactory.newInstance(clientId);
         ApplicationPubRelMsgCtx newPubRelMsgCtx = new ApplicationPubRelMsgCtx(Sets.newConcurrentHashSet());
         while (isJobActive(job)) {
             ApplicationPackProcessingCtx ctx = createPackProcessingCtx(submitStrategy, newPubRelMsgCtx, stats);
@@ -607,7 +606,7 @@ public class ApplicationPersistenceProcessorImpl implements ApplicationPersisten
         for (TbProtoQueueMsg<PublishMsgProto> msg : publishProtoMessages) {
             MsgExpiryResult msgExpiryResult = MqttPropertiesUtil.getMsgExpiryResult(msg.getHeaders(), currentTs);
             if (msgExpiryResult.isExpired()) {
-                if (isTraceEnabled) {
+                if (log.isTraceEnabled()) {
                     log.trace("[{}] Message at offset {} has expired, skipping", clientId, msg.getOffset());
                 }
                 continue;
@@ -690,9 +689,8 @@ public class ApplicationPersistenceProcessorImpl implements ApplicationPersisten
             return;
         }
         log.warn("[{}] Giving up on pack: skipping {} un-acked message(s) [PUBLISH: {}, PUBREL: {}]{}. " +
-                        "Set APPLICATION ack-strategy retries to 0 for unlimited retries (strict at-least-once).",
+                        "Set APPLICATION ack-strategy retries to 0 for unlimited retries.",
                 clientId, skipped, skippedPublish, skippedPubRel, skippedPublishOffsets(result));
-        tbMessageStatsReportClient.reportDroppedMsgs(skipped);
     }
 
     private String skippedPublishOffsets(ApplicationPackProcessingResult result) {
@@ -852,7 +850,7 @@ public class ApplicationPersistenceProcessorImpl implements ApplicationPersisten
     }
 
     private void cancelJob(ApplicationSharedSubscriptionJob job) {
-        if (isDebugEnabled) {
+        if (log.isDebugEnabled()) {
             log.debug("Cancelling shared subscription job for subscription {}", job.getSubscription());
         }
         Future<?> future = job.getFuture();
@@ -965,7 +963,7 @@ public class ApplicationPersistenceProcessorImpl implements ApplicationPersisten
             Thread.sleep(pollDuration);
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
-            if (isTraceEnabled) {
+            if (log.isTraceEnabled()) {
                 log.trace("Thread interrupted during error backoff sleep", e);
             }
         }

--- a/application/src/main/java/org/thingsboard/mqtt/broker/service/mqtt/persistence/application/ApplicationPersistenceProcessorImpl.java
+++ b/application/src/main/java/org/thingsboard/mqtt/broker/service/mqtt/persistence/application/ApplicationPersistenceProcessorImpl.java
@@ -719,7 +719,9 @@ public class ApplicationPersistenceProcessorImpl implements ApplicationPersisten
     private void processPubAckInSharedCtx(String clientId, int packetId, String format) {
         Set<ApplicationSharedSubscriptionCtx> contexts = sharedPackProcessingCtxMap.get(clientId);
         if (CollectionUtils.isEmpty(contexts)) {
-            log.warn(format, clientId, packetId);
+            if (isDebugEnabled) {
+                log.debug(format, clientId, packetId);
+            }
             return;
         }
         for (ApplicationSharedSubscriptionCtx ctx : contexts) {
@@ -736,7 +738,9 @@ public class ApplicationPersistenceProcessorImpl implements ApplicationPersisten
     private void processPubRecInSharedCtx(ClientSessionCtx clientSessionCtx, int packetId, String format, boolean sendPubRelMsg) {
         Set<ApplicationSharedSubscriptionCtx> contexts = sharedPackProcessingCtxMap.get(clientSessionCtx.getClientId());
         if (CollectionUtils.isEmpty(contexts)) {
-            log.warn(format, clientSessionCtx.getClientId(), packetId);
+            if (isDebugEnabled) {
+                log.debug(format, clientSessionCtx.getClientId(), packetId);
+            }
             if (sendPubRelMsg) {
                 mqttMsgDeliveryService.sendPubRelMsgToClient(clientSessionCtx, packetId);
             }
@@ -759,7 +763,9 @@ public class ApplicationPersistenceProcessorImpl implements ApplicationPersisten
     private void processPubCompInSharedCtx(String clientId, int packetId, String format) {
         Set<ApplicationSharedSubscriptionCtx> contexts = sharedPackProcessingCtxMap.get(clientId);
         if (CollectionUtils.isEmpty(contexts)) {
-            log.warn(format, clientId, packetId);
+            if (isDebugEnabled) {
+                log.debug(format, clientId, packetId);
+            }
             return;
         }
         for (ApplicationSharedSubscriptionCtx ctx : contexts) {

--- a/application/src/main/java/org/thingsboard/mqtt/broker/service/mqtt/persistence/application/ApplicationPersistenceProcessorImpl.java
+++ b/application/src/main/java/org/thingsboard/mqtt/broker/service/mqtt/persistence/application/ApplicationPersistenceProcessorImpl.java
@@ -441,6 +441,7 @@ public class ApplicationPersistenceProcessorImpl implements ApplicationPersisten
             log.debug("[{}] Starting main pack, {} messages to deliver", clientId, messagesToDeliver.size());
         }
 
+        ApplicationAckStrategy ackStrategy = acknowledgeStrategyFactory.newInstance(clientId);
         ApplicationPubRelMsgCtx newPubRelMsgCtx = new ApplicationPubRelMsgCtx(Sets.newConcurrentHashSet());
         while (isClientSessionActive(sessionId, clientState)) {
             ApplicationPackProcessingCtx ctx = createPackProcessingCtx(submitStrategy, newPubRelMsgCtx, stats);
@@ -455,7 +456,7 @@ public class ApplicationPersistenceProcessorImpl implements ApplicationPersisten
                 ctx.await(packProcessingTimeout, TimeUnit.MILLISECONDS);
             }
 
-            if (tryCommitPack(clientId, consumer, stats, submitStrategy, ctx, totalPublishMsgs, totalPubRelMsgs)) {
+            if (tryCommitPack(clientId, consumer, stats, ackStrategy, submitStrategy, ctx, totalPublishMsgs, totalPubRelMsgs)) {
                 break;
             }
         }
@@ -544,6 +545,7 @@ public class ApplicationPersistenceProcessorImpl implements ApplicationPersisten
             log.trace("[{}] Starting shared subscription pack, {} messages to deliver", clientId, messagesToDeliver.size());
         }
 
+        ApplicationAckStrategy ackStrategy = acknowledgeStrategyFactory.newInstance(clientId);
         ApplicationPubRelMsgCtx newPubRelMsgCtx = new ApplicationPubRelMsgCtx(Sets.newConcurrentHashSet());
         while (isJobActive(job)) {
             ApplicationPackProcessingCtx ctx = createPackProcessingCtx(submitStrategy, newPubRelMsgCtx, stats);
@@ -558,7 +560,7 @@ public class ApplicationPersistenceProcessorImpl implements ApplicationPersisten
                 ctx.await(packProcessingTimeout, TimeUnit.MILLISECONDS);
             }
 
-            if (tryCommitPack(clientId, consumer, stats, submitStrategy, ctx, totalPublishMsgs, totalPubRelMsgs)) {
+            if (tryCommitPack(clientId, consumer, stats, ackStrategy, submitStrategy, ctx, totalPublishMsgs, totalPubRelMsgs)) {
                 break;
             }
         }
@@ -637,12 +639,12 @@ public class ApplicationPersistenceProcessorImpl implements ApplicationPersisten
     private boolean tryCommitPack(String clientId,
                                   TbQueueControlledOffsetConsumer<TbProtoQueueMsg<PublishMsgProto>> consumer,
                                   ApplicationProcessorStats stats,
+                                  ApplicationAckStrategy ackStrategy,
                                   ApplicationSubmitStrategy submitStrategy,
                                   ApplicationPackProcessingCtx ctx,
                                   int totalPublishMsgs,
                                   int totalPubRelMsgs) {
         log.trace("[{}] Analyzing pack processing result", clientId);
-        ApplicationAckStrategy ackStrategy = acknowledgeStrategyFactory.newInstance(clientId);
 
         ApplicationPackProcessingResult result = new ApplicationPackProcessingResult(ctx);
         ApplicationProcessingDecision decision = ackStrategy.analyze(result);

--- a/application/src/main/java/org/thingsboard/mqtt/broker/service/mqtt/persistence/application/ApplicationPersistenceProcessorImpl.java
+++ b/application/src/main/java/org/thingsboard/mqtt/broker/service/mqtt/persistence/application/ApplicationPersistenceProcessorImpl.java
@@ -63,8 +63,6 @@ import org.thingsboard.mqtt.broker.service.stats.ApplicationProcessorStats;
 import org.thingsboard.mqtt.broker.service.stats.StatsManager;
 import org.thingsboard.mqtt.broker.service.subscription.shared.TopicSharedSubscription;
 import org.thingsboard.mqtt.broker.session.ClientMqttActorManager;
-
-import static org.thingsboard.mqtt.broker.common.data.BrokerConstants.DROPPED_MSGS;
 import org.thingsboard.mqtt.broker.session.ClientSessionCtx;
 import org.thingsboard.mqtt.broker.session.DisconnectReason;
 import org.thingsboard.mqtt.broker.session.DisconnectReasonType;
@@ -680,7 +678,7 @@ public class ApplicationPersistenceProcessorImpl implements ApplicationPersisten
         log.warn("[{}] Giving up on pack: skipping {} un-acked message(s) [PUBLISH: {}, PUBREL: {}]{}. " +
                         "Set APPLICATION ack-strategy retries to 0 for unlimited retries (strict at-least-once).",
                 clientId, skipped, skippedPublish, skippedPubRel, skippedPublishOffsets(result));
-        tbMessageStatsReportClient.reportStats(DROPPED_MSGS, skipped);
+        tbMessageStatsReportClient.reportDroppedMsgs(skipped);
     }
 
     private String skippedPublishOffsets(ApplicationPackProcessingResult result) {

--- a/application/src/main/java/org/thingsboard/mqtt/broker/service/mqtt/persistence/application/ApplicationPersistenceProcessorImpl.java
+++ b/application/src/main/java/org/thingsboard/mqtt/broker/service/mqtt/persistence/application/ApplicationPersistenceProcessorImpl.java
@@ -258,9 +258,11 @@ public class ApplicationPersistenceProcessorImpl implements ApplicationPersisten
         ApplicationPackProcessingCtx processingContext = mainPackProcessingCtxMap.get(clientId);
         if (processingContext == null) {
             if (isDebugEnabled) {
-                log.debug("[{}] No main processing context for PubAck, packetId: {}", clientId, packetId);
+                log.debug("[{}] No in-flight main pack for PubAck (packetId: {}); checking shared-subscription packs", clientId, packetId);
             }
-            processPubAckInSharedCtx(clientId, packetId, "[{}] No processing context found for PubAck, packetId: {}");
+            processPubAckInSharedCtx(clientId, packetId,
+                    "[{}] Discarding PubAck for packetId {}: no in-flight main or shared-subscription pack is awaiting it " +
+                            "(likely a duplicate/late ack, or its pack was already committed or given up)");
         } else {
             var handled = processingContext.onPubAck(packetId);
             if (handled) {
@@ -269,7 +271,9 @@ public class ApplicationPersistenceProcessorImpl implements ApplicationPersisten
                 }
                 return;
             }
-            processPubAckInSharedCtx(clientId, packetId, "[{}] No shared subscription context found for PubAck, packetId: {}");
+            processPubAckInSharedCtx(clientId, packetId,
+                    "[{}] Discarding PubAck for packetId {}: not awaited by the in-flight main pack and no shared-subscription pack is active " +
+                            "(likely a duplicate/late ack, or its pack was already committed or given up)");
         }
     }
 
@@ -279,10 +283,12 @@ public class ApplicationPersistenceProcessorImpl implements ApplicationPersisten
         ApplicationPackProcessingCtx processingContext = mainPackProcessingCtxMap.get(clientId);
         if (processingContext == null) {
             if (isDebugEnabled) {
-                log.debug("[{}] No main processing context for PubRec, packetId: {}", clientId, packetId);
+                log.debug("[{}] No in-flight main pack for PubRec (packetId: {}); checking shared-subscription packs", clientId, packetId);
             }
             processPubRecInSharedCtx(clientSessionCtx, packetId,
-                    "[{}] No processing context found for PubRec, packetId: {}", true);
+                    "[{}] PubRec for packetId {} not awaited by any in-flight main or shared-subscription pack; " +
+                            "still sending PUBREL to complete the QoS2 handshake " +
+                            "(likely a duplicate/late ack, or its pack was already committed or given up)", true);
         } else {
             var handled = processingContext.onPubRec(packetId, true);
             if (handled) {
@@ -292,7 +298,9 @@ public class ApplicationPersistenceProcessorImpl implements ApplicationPersisten
                 return;
             }
             processPubRecInSharedCtx(clientSessionCtx, packetId,
-                    "[{}] No shared subscription context found for PubRec, packetId: {}", true);
+                    "[{}] PubRec for packetId {} not awaited by the in-flight main pack and no shared-subscription pack is active; " +
+                            "still sending PUBREL to complete the QoS2 handshake " +
+                            "(likely a duplicate/late ack, or its pack was already committed or given up)", true);
         }
     }
 
@@ -302,10 +310,11 @@ public class ApplicationPersistenceProcessorImpl implements ApplicationPersisten
         ApplicationPackProcessingCtx processingContext = mainPackProcessingCtxMap.get(clientId);
         if (processingContext == null) {
             if (isDebugEnabled) {
-                log.debug("[{}] No main processing context for PubRec (no PubRel delivery), packetId: {}", clientId, packetId);
+                log.debug("[{}] No in-flight main pack for PubRec without PubRel delivery (packetId: {}); checking shared-subscription packs", clientId, packetId);
             }
             processPubRecInSharedCtx(clientSessionCtx, packetId,
-                    "[{}] No processing context found for PubRec (no PubRel delivery), packetId: {}", false);
+                    "[{}] Discarding PubRec (no PubRel delivery) for packetId {}: no in-flight main or shared-subscription pack is awaiting it " +
+                            "(likely a duplicate/late ack, or its pack was already committed or given up)", false);
         } else {
             var handled = processingContext.onPubRec(packetId, false);
             if (handled) {
@@ -315,7 +324,8 @@ public class ApplicationPersistenceProcessorImpl implements ApplicationPersisten
                 return;
             }
             processPubRecInSharedCtx(clientSessionCtx, packetId,
-                    "[{}] No shared subscription context found for PubRec (no PubRel delivery), packetId: {}", false);
+                    "[{}] Discarding PubRec (no PubRel delivery) for packetId {}: not awaited by the in-flight main pack and no shared-subscription pack is active " +
+                            "(likely a duplicate/late ack, or its pack was already committed or given up)", false);
         }
     }
 
@@ -324,9 +334,11 @@ public class ApplicationPersistenceProcessorImpl implements ApplicationPersisten
         ApplicationPackProcessingCtx processingContext = mainPackProcessingCtxMap.get(clientId);
         if (processingContext == null) {
             if (isDebugEnabled) {
-                log.debug("[{}] No main processing context for PubComp, packetId: {}", clientId, packetId);
+                log.debug("[{}] No in-flight main pack for PubComp (packetId: {}); checking shared-subscription packs", clientId, packetId);
             }
-            processPubCompInSharedCtx(clientId, packetId, "[{}] No processing context found for PubComp, packetId: {}");
+            processPubCompInSharedCtx(clientId, packetId,
+                    "[{}] Discarding PubComp for packetId {}: no in-flight main or shared-subscription pack is awaiting it " +
+                            "(likely a duplicate/late ack, or its pack was already committed or given up)");
         } else {
             var handled = processingContext.onPubComp(packetId);
             if (handled) {
@@ -335,7 +347,9 @@ public class ApplicationPersistenceProcessorImpl implements ApplicationPersisten
                 }
                 return;
             }
-            processPubCompInSharedCtx(clientId, packetId, "[{}] No shared subscription context found for PubComp, packetId: {}");
+            processPubCompInSharedCtx(clientId, packetId,
+                    "[{}] Discarding PubComp for packetId {}: not awaited by the in-flight main pack and no shared-subscription pack is active " +
+                            "(likely a duplicate/late ack, or its pack was already committed or given up)");
         }
     }
 

--- a/application/src/main/java/org/thingsboard/mqtt/broker/service/mqtt/persistence/application/ApplicationPersistenceProcessorImpl.java
+++ b/application/src/main/java/org/thingsboard/mqtt/broker/service/mqtt/persistence/application/ApplicationPersistenceProcessorImpl.java
@@ -37,6 +37,7 @@ import org.thingsboard.mqtt.broker.queue.cluster.ServiceInfoProvider;
 import org.thingsboard.mqtt.broker.queue.common.TbProtoQueueMsg;
 import org.thingsboard.mqtt.broker.queue.provider.ApplicationPersistenceMsgQueueFactory;
 import org.thingsboard.mqtt.broker.service.analysis.ClientLogger;
+import org.thingsboard.mqtt.broker.service.historical.stats.TbMessageStatsReportClient;
 import org.thingsboard.mqtt.broker.service.mqtt.MqttMsgDeliveryService;
 import org.thingsboard.mqtt.broker.service.mqtt.PublishMsg;
 import org.thingsboard.mqtt.broker.service.mqtt.persistence.application.data.ApplicationMainProcessingState;
@@ -56,15 +57,14 @@ import org.thingsboard.mqtt.broker.service.mqtt.persistence.application.processi
 import org.thingsboard.mqtt.broker.service.mqtt.persistence.application.processing.PersistedMsg;
 import org.thingsboard.mqtt.broker.service.mqtt.persistence.application.processing.PersistedPubRelMsg;
 import org.thingsboard.mqtt.broker.service.mqtt.persistence.application.processing.PersistedPublishMsg;
-import org.thingsboard.mqtt.broker.service.historical.stats.TbMessageStatsReportClient;
 import org.thingsboard.mqtt.broker.service.mqtt.persistence.application.topic.ApplicationTopicService;
 import org.thingsboard.mqtt.broker.service.mqtt.persistence.application.util.ApplicationClientHelperService;
 import org.thingsboard.mqtt.broker.service.stats.ApplicationProcessorStats;
 import org.thingsboard.mqtt.broker.service.stats.StatsManager;
-
-import static org.thingsboard.mqtt.broker.common.data.BrokerConstants.DROPPED_MSGS;
 import org.thingsboard.mqtt.broker.service.subscription.shared.TopicSharedSubscription;
 import org.thingsboard.mqtt.broker.session.ClientMqttActorManager;
+
+import static org.thingsboard.mqtt.broker.common.data.BrokerConstants.DROPPED_MSGS;
 import org.thingsboard.mqtt.broker.session.ClientSessionCtx;
 import org.thingsboard.mqtt.broker.session.DisconnectReason;
 import org.thingsboard.mqtt.broker.session.DisconnectReasonType;

--- a/application/src/main/java/org/thingsboard/mqtt/broker/service/mqtt/persistence/application/processing/ApplicationMsgAcknowledgeStrategyFactory.java
+++ b/application/src/main/java/org/thingsboard/mqtt/broker/service/mqtt/persistence/application/processing/ApplicationMsgAcknowledgeStrategyFactory.java
@@ -54,11 +54,11 @@ public class ApplicationMsgAcknowledgeStrategyFactory {
                 }
             }
             if (log.isTraceEnabled()) {
-                publishPendingMsgMap.forEach((packetId, msg) ->
+                publishPendingMsgMap.forEach((_, msg) ->
                         log.trace("[{}] Timeout PUBLISH message: topic - {}, packetId - {}.",
                                 clientId, msg.getPublishMsg().getTopicName(), msg.getPacketId())
                 );
-                pubRelPendingMsgMap.forEach((packetId, msg) ->
+                pubRelPendingMsgMap.forEach((_, msg) ->
                         log.trace("[{}] Timeout PUBREL message: packetId - {}.",
                                 clientId, msg.getPacketId())
                 );
@@ -90,11 +90,11 @@ public class ApplicationMsgAcknowledgeStrategyFactory {
                 log.debug("[{}] Going to reprocess {} PUBLISH and {} PUBREL messages", clientId, publishPendingMsgMap.size(), pubRelPendingMsgMap.size());
             }
             if (log.isTraceEnabled()) {
-                publishPendingMsgMap.forEach((packetId, msg) ->
+                publishPendingMsgMap.forEach((_, msg) ->
                         log.trace("[{}] Going to reprocess PUBLISH message: topic - {}, packetId - {}.",
                                 clientId, msg.getPublishMsg().getTopicName(), msg.getPacketId())
                 );
-                pubRelPendingMsgMap.forEach((packetId, msg) ->
+                pubRelPendingMsgMap.forEach((_, msg) ->
                         log.trace("[{}] Going to reprocess PUBREL message: packetId - {}.",
                                 clientId, msg.getPacketId())
                 );
@@ -113,13 +113,8 @@ public class ApplicationMsgAcknowledgeStrategyFactory {
     }
 
     private static PersistedPublishMsg getDupMsg(PersistedPublishMsg persistedPublishMsg) {
-        return persistedPublishMsg
-                .toBuilder()
-                .publishMsg(persistedPublishMsg
-                        .getPublishMsg()
-                        .toBuilder()
-                        .isDup(true)
-                        .build())
+        return persistedPublishMsg.toBuilder()
+                .publishMsg(persistedPublishMsg.getPublishMsg().toBuilder().isDup(true).build())
                 .build();
     }
 }

--- a/application/src/main/java/org/thingsboard/mqtt/broker/service/mqtt/persistence/application/processing/BurstSubmitStrategy.java
+++ b/application/src/main/java/org/thingsboard/mqtt/broker/service/mqtt/persistence/application/processing/BurstSubmitStrategy.java
@@ -57,8 +57,9 @@ public class BurstSubmitStrategy implements ApplicationSubmitStrategy {
     public void update(Map<Integer, PersistedMsg> reprocessMap) {
         List<PersistedMsg> newOrderedMessages = new ArrayList<>(reprocessMap.size());
         for (PersistedMsg msg : orderedMessages) {
-            if (reprocessMap.containsKey(msg.getPacketId())) {
-                newOrderedMessages.add(msg);
+            PersistedMsg reprocessMsg = reprocessMap.get(msg.getPacketId());
+            if (reprocessMsg != null) {
+                newOrderedMessages.add(reprocessMsg);
             }
         }
         orderedMessages = newOrderedMessages;

--- a/application/src/test/java/org/thingsboard/mqtt/broker/service/mqtt/persistence/application/ApplicationPersistenceProcessorImplTest.java
+++ b/application/src/test/java/org/thingsboard/mqtt/broker/service/mqtt/persistence/application/ApplicationPersistenceProcessorImplTest.java
@@ -72,8 +72,10 @@ import java.util.concurrent.atomic.AtomicInteger;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.atLeastOnce;
+import static org.thingsboard.mqtt.broker.common.data.BrokerConstants.DROPPED_MSGS;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.lenient;
@@ -100,6 +102,7 @@ class ApplicationPersistenceProcessorImplTest {
     @Mock ApplicationTopicService applicationTopicService;
     @Mock ApplicationClientHelperService appClientHelperService;
     @Mock AppMsgDeliveryStrategy appMsgDeliveryStrategy;
+    @Mock org.thingsboard.mqtt.broker.service.historical.stats.TbMessageStatsReportClient tbMessageStatsReportClient;
 
     @InjectMocks
     ApplicationPersistenceProcessorImpl processor;
@@ -512,6 +515,57 @@ class ApplicationPersistenceProcessorImplTest {
         // The ack strategy must be created once per pack and reused across retries so the cap accumulates.
         // Today it is recreated on every retry, so this is called once per attempt instead of exactly once.
         verify(acknowledgeStrategyFactory, times(1)).newInstance("appClient");
+    }
+
+    @Test
+    void tryCommitPack_whenGivingUpWithPendingMessages_reportsDroppedMsgs() {
+        // SKIP_ALL commits the pack on the first analysis even with pending messages (give-up by design).
+        ApplicationAckStrategyConfiguration ackConfig = new ApplicationAckStrategyConfiguration();
+        ackConfig.setType(AckStrategyType.SKIP_ALL);
+        ackConfig.setRetries(0);
+        ApplicationMsgAcknowledgeStrategyFactory realFactory = new ApplicationMsgAcknowledgeStrategyFactory(ackConfig);
+        when(acknowledgeStrategyFactory.newInstance("appClient")).thenAnswer(inv -> realFactory.newInstance("appClient"));
+        ReflectionTestUtils.setField(processor, "packProcessingTimeout", 30L);
+        when(submitStrategyFactory.newInstance("appClient")).thenAnswer(inv -> new BurstSubmitStrategy("appClient"));
+        stopProcessorAfterDeliveries(5);
+
+        TbQueueControlledOffsetConsumer<TbProtoQueueMsg<PublishMsgProto>> consumer = mockConsumer();
+        UUID sessionId = UUID.randomUUID();
+        ClientActorStateInfo clientState = activeClientState("appClient", sessionId);
+
+        ApplicationPubRelMsgCtx pubRelMsgCtx = new ApplicationPubRelMsgCtx(Sets.newConcurrentHashSet());
+        pubRelMsgCtx.addPubRelMsg(new PersistedPubRelMsg(1, 0L));
+
+        invokeProcessMainPack(pubRelMsgCtx, Collections.emptyList(), clientSessionCtx("appClient"),
+                mock(ApplicationPersistedMsgCtx.class), consumer, mock(ApplicationProcessorStats.class),
+                sessionId, clientState);
+
+        verify(tbMessageStatsReportClient, atLeastOnce()).reportStats(DROPPED_MSGS, 1);
+    }
+
+    @Test
+    void tryCommitPack_whenCleanCommitWithNoPendingMessages_doesNotReportDroppedMsgs() {
+        ApplicationAckStrategyConfiguration ackConfig = new ApplicationAckStrategyConfiguration();
+        ackConfig.setType(AckStrategyType.RETRY_ALL);
+        ackConfig.setRetries(3);
+        ApplicationMsgAcknowledgeStrategyFactory realFactory = new ApplicationMsgAcknowledgeStrategyFactory(ackConfig);
+        when(acknowledgeStrategyFactory.newInstance("appClient")).thenAnswer(inv -> realFactory.newInstance("appClient"));
+        when(submitStrategyFactory.newInstance("appClient")).thenAnswer(inv -> new BurstSubmitStrategy("appClient"));
+        stopProcessorAfterDeliveries(5);
+
+        TbQueueControlledOffsetConsumer<TbProtoQueueMsg<PublishMsgProto>> consumer = mockConsumer();
+        UUID sessionId = UUID.randomUUID();
+        ClientActorStateInfo clientState = activeClientState("appClient", sessionId);
+
+        // Empty pack: nothing pending -> clean commit, no skip.
+        ApplicationPubRelMsgCtx emptyPubRelMsgCtx = new ApplicationPubRelMsgCtx(Sets.newConcurrentHashSet());
+
+        invokeProcessMainPack(emptyPubRelMsgCtx, Collections.emptyList(), clientSessionCtx("appClient"),
+                mock(ApplicationPersistedMsgCtx.class), consumer, mock(ApplicationProcessorStats.class),
+                sessionId, clientState);
+
+        verify(tbMessageStatsReportClient, never()).reportStats(eq(DROPPED_MSGS), anyInt());
+        verify(consumer, atLeastOnce()).commitSync();
     }
 
     // ===== Helpers =====

--- a/application/src/test/java/org/thingsboard/mqtt/broker/service/mqtt/persistence/application/ApplicationPersistenceProcessorImplTest.java
+++ b/application/src/test/java/org/thingsboard/mqtt/broker/service/mqtt/persistence/application/ApplicationPersistenceProcessorImplTest.java
@@ -23,6 +23,8 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
+import org.thingsboard.mqtt.broker.actors.client.state.ClientActorStateInfo;
+import org.thingsboard.mqtt.broker.actors.client.state.SessionState;
 import org.thingsboard.mqtt.broker.gen.queue.PublishMsgProto;
 import org.thingsboard.mqtt.broker.queue.TbQueueAdmin;
 import org.thingsboard.mqtt.broker.queue.TbQueueControlledOffsetConsumer;
@@ -35,29 +37,44 @@ import org.thingsboard.mqtt.broker.service.mqtt.persistence.application.data.App
 import org.thingsboard.mqtt.broker.service.mqtt.persistence.application.data.ApplicationSharedSubscriptionCtx;
 import org.thingsboard.mqtt.broker.service.mqtt.persistence.application.data.ApplicationSharedSubscriptionJob;
 import org.thingsboard.mqtt.broker.service.mqtt.persistence.application.delivery.AppMsgDeliveryStrategy;
+import org.thingsboard.mqtt.broker.service.mqtt.persistence.application.processing.AckStrategyType;
+import org.thingsboard.mqtt.broker.service.mqtt.persistence.application.processing.ApplicationAckStrategy;
+import org.thingsboard.mqtt.broker.service.mqtt.persistence.application.processing.ApplicationAckStrategyConfiguration;
 import org.thingsboard.mqtt.broker.service.mqtt.persistence.application.processing.ApplicationMsgAcknowledgeStrategyFactory;
 import org.thingsboard.mqtt.broker.service.mqtt.persistence.application.processing.ApplicationPackProcessingCtx;
+import org.thingsboard.mqtt.broker.service.mqtt.persistence.application.processing.ApplicationPersistedMsgCtx;
 import org.thingsboard.mqtt.broker.service.mqtt.persistence.application.processing.ApplicationPersistedMsgCtxService;
+import org.thingsboard.mqtt.broker.service.mqtt.persistence.application.processing.ApplicationProcessingDecision;
+import org.thingsboard.mqtt.broker.service.mqtt.persistence.application.processing.ApplicationPubRelMsgCtx;
 import org.thingsboard.mqtt.broker.service.mqtt.persistence.application.processing.ApplicationSubmitStrategyFactory;
+import org.thingsboard.mqtt.broker.service.mqtt.persistence.application.processing.BurstSubmitStrategy;
+import org.thingsboard.mqtt.broker.service.mqtt.persistence.application.processing.PersistedPubRelMsg;
 import org.thingsboard.mqtt.broker.service.mqtt.persistence.application.topic.ApplicationTopicService;
 import org.thingsboard.mqtt.broker.service.mqtt.persistence.application.util.ApplicationClientHelperService;
+import org.thingsboard.mqtt.broker.service.stats.ApplicationProcessorStats;
 import org.thingsboard.mqtt.broker.service.stats.StatsManager;
 import org.thingsboard.mqtt.broker.service.subscription.shared.TopicSharedSubscription;
 import org.thingsboard.mqtt.broker.session.ClientMqttActorManager;
 import org.thingsboard.mqtt.broker.session.ClientSessionCtx;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
+import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
@@ -65,6 +82,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class ApplicationPersistenceProcessorImplTest {
@@ -436,7 +454,111 @@ class ApplicationPersistenceProcessorImplTest {
         jobs.forEach(j -> assertThat(j.isInterrupted()).isFalse());
     }
 
+    // ===== GH#320: APPLICATION QoS1 RETRY_ALL ack-strategy lifecycle =====
+    // These two tests are expected to FAIL on the current code: tryCommitPack() instantiates a new
+    // ApplicationAckStrategy on every retry, so RetryStrategy#retryCount restarts at 0 each time and the
+    // configured retry cap is never reached. A client that never acks therefore loops forever instead of
+    // giving up, the Kafka offset is never committed, and consumer lag grows without bound.
+
+    @Test
+    void processMainPack_retryAll_whenClientNeverAcks_mustGiveUpAndCommitAfterRetryCap() {
+        ApplicationAckStrategyConfiguration ackConfig = new ApplicationAckStrategyConfiguration();
+        ackConfig.setType(AckStrategyType.RETRY_ALL);
+        ackConfig.setRetries(2);
+        // Delegate to a real factory so the production RetryStrategy (with real counting) is exercised.
+        ApplicationMsgAcknowledgeStrategyFactory realFactory = new ApplicationMsgAcknowledgeStrategyFactory(ackConfig);
+        when(acknowledgeStrategyFactory.newInstance("appClient")).thenAnswer(inv -> realFactory.newInstance("appClient"));
+        ReflectionTestUtils.setField(processor, "packProcessingTimeout", 30L);
+        when(submitStrategyFactory.newInstance("appClient")).thenAnswer(inv -> new BurstSubmitStrategy("appClient"));
+        // Safety net: a buggy unbounded-retry loop would never exit on its own.
+        stopProcessorAfterDeliveries(20);
+
+        TbQueueControlledOffsetConsumer<TbProtoQueueMsg<PublishMsgProto>> consumer = mockConsumer();
+        UUID sessionId = UUID.randomUUID();
+        ClientActorStateInfo clientState = activeClientState("appClient", sessionId);
+
+        // A single never-acked PUBREL keeps the pack pending across every retry.
+        ApplicationPubRelMsgCtx pubRelMsgCtx = new ApplicationPubRelMsgCtx(Sets.newConcurrentHashSet());
+        pubRelMsgCtx.addPubRelMsg(new PersistedPubRelMsg(1, 0L));
+
+        invokeProcessMainPack(pubRelMsgCtx, Collections.emptyList(), clientSessionCtx("appClient"),
+                mock(ApplicationPersistedMsgCtx.class), consumer, mock(ApplicationProcessorStats.class),
+                sessionId, clientState);
+
+        // Expected: after the cap of 2 retries the pack is committed (give up). Today: never committed.
+        verify(consumer, atLeastOnce()).commitSync();
+    }
+
+    @Test
+    void processMainPack_retryAll_mustObtainAckStrategyOncePerPack_notOncePerRetry() {
+        ApplicationAckStrategy alwaysReprocess = mock(ApplicationAckStrategy.class);
+        when(alwaysReprocess.analyze(any())).thenReturn(new ApplicationProcessingDecision(false, Map.of()));
+        when(acknowledgeStrategyFactory.newInstance("appClient")).thenReturn(alwaysReprocess);
+        ReflectionTestUtils.setField(processor, "packProcessingTimeout", 5L);
+        when(submitStrategyFactory.newInstance("appClient")).thenAnswer(inv -> new BurstSubmitStrategy("appClient"));
+        stopProcessorAfterDeliveries(10);
+
+        TbQueueControlledOffsetConsumer<TbProtoQueueMsg<PublishMsgProto>> consumer = mockConsumer();
+        UUID sessionId = UUID.randomUUID();
+        ClientActorStateInfo clientState = activeClientState("appClient", sessionId);
+
+        ApplicationPubRelMsgCtx pubRelMsgCtx = new ApplicationPubRelMsgCtx(Sets.newConcurrentHashSet());
+        pubRelMsgCtx.addPubRelMsg(new PersistedPubRelMsg(1, 0L));
+
+        invokeProcessMainPack(pubRelMsgCtx, Collections.emptyList(), clientSessionCtx("appClient"),
+                mock(ApplicationPersistedMsgCtx.class), consumer, mock(ApplicationProcessorStats.class),
+                sessionId, clientState);
+
+        // The ack strategy must be created once per pack and reused across retries so the cap accumulates.
+        // Today it is recreated on every retry, so this is called once per attempt instead of exactly once.
+        verify(acknowledgeStrategyFactory, times(1)).newInstance("appClient");
+    }
+
     // ===== Helpers =====
+
+    @SuppressWarnings("unchecked")
+    private TbQueueControlledOffsetConsumer<TbProtoQueueMsg<PublishMsgProto>> mockConsumer() {
+        return mock(TbQueueControlledOffsetConsumer.class);
+    }
+
+    private ClientActorStateInfo activeClientState(String clientId, UUID sessionId) {
+        ClientActorStateInfo state = mock(ClientActorStateInfo.class);
+        lenient().when(state.getClientId()).thenReturn(clientId);
+        when(state.getCurrentSessionId()).thenReturn(sessionId);
+        when(state.getCurrentSessionState()).thenReturn(SessionState.CONNECTED);
+        return state;
+    }
+
+    private void stopProcessorAfterDeliveries(int maxDeliveries) {
+        AtomicInteger deliveries = new AtomicInteger();
+        doAnswer(invocation -> {
+            if (deliveries.incrementAndGet() >= maxDeliveries) {
+                ReflectionTestUtils.setField(processor, "stopped", true);
+            }
+            return null;
+        }).when(appMsgDeliveryStrategy).process(any(), any());
+    }
+
+    private void invokeProcessMainPack(ApplicationPubRelMsgCtx pubRelMsgCtx,
+                                       List<TbProtoQueueMsg<PublishMsgProto>> messages,
+                                       ClientSessionCtx clientSessionCtx,
+                                       ApplicationPersistedMsgCtx persistedMsgCtx,
+                                       TbQueueControlledOffsetConsumer<TbProtoQueueMsg<PublishMsgProto>> consumer,
+                                       ApplicationProcessorStats stats,
+                                       UUID sessionId,
+                                       ClientActorStateInfo clientState) {
+        try {
+            var method = ApplicationPersistenceProcessorImpl.class.getDeclaredMethod(
+                    "processMainPack",
+                    ApplicationPubRelMsgCtx.class, List.class, ClientSessionCtx.class,
+                    ApplicationPersistedMsgCtx.class, TbQueueControlledOffsetConsumer.class,
+                    ApplicationProcessorStats.class, UUID.class, ClientActorStateInfo.class);
+            method.setAccessible(true);
+            method.invoke(processor, pubRelMsgCtx, messages, clientSessionCtx, persistedMsgCtx, consumer, stats, sessionId, clientState);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
 
     private boolean invokeIsProcessorActive() {
         try {

--- a/application/src/test/java/org/thingsboard/mqtt/broker/service/mqtt/persistence/application/ApplicationPersistenceProcessorImplTest.java
+++ b/application/src/test/java/org/thingsboard/mqtt/broker/service/mqtt/persistence/application/ApplicationPersistenceProcessorImplTest.java
@@ -699,4 +699,48 @@ class ApplicationPersistenceProcessorImplTest {
             logger.detachAppender(appender);
         }
     }
+
+    @Test
+    void processPubRec_whenLateDuplicateAndNoSharedSubscriptions_doesNotLogWarn_andStillSendsPubRel() {
+        Logger logger = (Logger) LoggerFactory.getLogger(ApplicationPersistenceProcessorImpl.class);
+        ListAppender<ILoggingEvent> appender = new ListAppender<>();
+        appender.start();
+        logger.addAppender(appender);
+        try {
+            // Main context exists but does not contain the packet -> routes to processPubRecInSharedCtx(sendPubRelMsg=true).
+            // With no shared contexts present, must (a) log no WARN and (b) still send PubRel.
+            mainPackProcessingCtxMap().put("appClient", new ApplicationPackProcessingCtx("appClient"));
+
+            ClientSessionCtx ctx = clientSessionCtx("appClient");
+            processor.processPubRec(ctx, 101);
+
+            assertThat(appender.list)
+                    .as("a late/duplicate PubRec with no shared subscriptions must not log at WARN")
+                    .noneMatch(event -> event.getLevel() == Level.WARN);
+            verify(mqttMsgDeliveryService).sendPubRelMsgToClient(any(), eq(101));
+        } finally {
+            logger.detachAppender(appender);
+        }
+    }
+
+    @Test
+    void processPubComp_whenLateDuplicateAndNoSharedSubscriptions_doesNotLogWarn() {
+        Logger logger = (Logger) LoggerFactory.getLogger(ApplicationPersistenceProcessorImpl.class);
+        ListAppender<ILoggingEvent> appender = new ListAppender<>();
+        appender.start();
+        logger.addAppender(appender);
+        try {
+            // Main context exists but does not contain the packet -> routes to processPubCompInSharedCtx.
+            // With no shared contexts present, must log no WARN.
+            mainPackProcessingCtxMap().put("appClient", new ApplicationPackProcessingCtx("appClient"));
+
+            processor.processPubComp("appClient", 202);
+
+            assertThat(appender.list)
+                    .as("a late/duplicate PubComp with no shared subscriptions must not log at WARN")
+                    .noneMatch(event -> event.getLevel() == Level.WARN);
+        } finally {
+            logger.detachAppender(appender);
+        }
+    }
 }

--- a/application/src/test/java/org/thingsboard/mqtt/broker/service/mqtt/persistence/application/ApplicationPersistenceProcessorImplTest.java
+++ b/application/src/test/java/org/thingsboard/mqtt/broker/service/mqtt/persistence/application/ApplicationPersistenceProcessorImplTest.java
@@ -32,6 +32,7 @@ import org.thingsboard.mqtt.broker.queue.cluster.ServiceInfoProvider;
 import org.thingsboard.mqtt.broker.queue.common.TbProtoQueueMsg;
 import org.thingsboard.mqtt.broker.queue.provider.ApplicationPersistenceMsgQueueFactory;
 import org.thingsboard.mqtt.broker.service.analysis.ClientLogger;
+import org.thingsboard.mqtt.broker.service.historical.stats.TbMessageStatsReportClient;
 import org.thingsboard.mqtt.broker.service.mqtt.MqttMsgDeliveryService;
 import org.thingsboard.mqtt.broker.service.mqtt.persistence.application.data.ApplicationMainProcessingState;
 import org.thingsboard.mqtt.broker.service.mqtt.persistence.application.data.ApplicationSharedSubscriptionCtx;
@@ -107,7 +108,7 @@ class ApplicationPersistenceProcessorImplTest {
     @Mock ApplicationTopicService applicationTopicService;
     @Mock ApplicationClientHelperService appClientHelperService;
     @Mock AppMsgDeliveryStrategy appMsgDeliveryStrategy;
-    @Mock org.thingsboard.mqtt.broker.service.historical.stats.TbMessageStatsReportClient tbMessageStatsReportClient;
+    @Mock TbMessageStatsReportClient tbMessageStatsReportClient;
 
     @InjectMocks
     ApplicationPersistenceProcessorImpl processor;

--- a/application/src/test/java/org/thingsboard/mqtt/broker/service/mqtt/persistence/application/ApplicationPersistenceProcessorImplTest.java
+++ b/application/src/test/java/org/thingsboard/mqtt/broker/service/mqtt/persistence/application/ApplicationPersistenceProcessorImplTest.java
@@ -57,6 +57,11 @@ import org.thingsboard.mqtt.broker.service.subscription.shared.TopicSharedSubscr
 import org.thingsboard.mqtt.broker.session.ClientMqttActorManager;
 import org.thingsboard.mqtt.broker.session.ClientSessionCtx;
 
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import org.slf4j.LoggerFactory;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -668,5 +673,29 @@ class ApplicationPersistenceProcessorImplTest {
         ClientSessionCtx ctx = mock(ClientSessionCtx.class);
         lenient().when(ctx.getClientId()).thenReturn(clientId);
         return ctx;
+    }
+
+    @Test
+    void processPubAck_whenLateDuplicateAckAndNoSharedSubscriptions_doesNotLogWarn() {
+        Logger logger = (Logger) LoggerFactory.getLogger(ApplicationPersistenceProcessorImpl.class);
+        ListAppender<ILoggingEvent> appender = new ListAppender<>();
+        appender.start();
+        logger.addAppender(appender);
+        try {
+            @SuppressWarnings("unchecked")
+            ConcurrentMap<String, ApplicationPackProcessingCtx> mainCtxMap =
+                    (ConcurrentMap<String, ApplicationPackProcessingCtx>)
+                            ReflectionTestUtils.getField(processor, "mainPackProcessingCtxMap");
+            // Main context exists but does not contain the packet -> late/duplicate PubAck; no shared subs exist.
+            mainCtxMap.put("appClient", new ApplicationPackProcessingCtx("appClient"));
+
+            processor.processPubAck("appClient", 2708);
+
+            assertThat(appender.list)
+                    .as("a late/duplicate PubAck with no shared subscriptions must not log at WARN")
+                    .noneMatch(event -> event.getLevel() == Level.WARN);
+        } finally {
+            logger.detachAppender(appender);
+        }
     }
 }

--- a/application/src/test/java/org/thingsboard/mqtt/broker/service/mqtt/persistence/application/ApplicationPersistenceProcessorImplTest.java
+++ b/application/src/test/java/org/thingsboard/mqtt/broker/service/mqtt/persistence/application/ApplicationPersistenceProcessorImplTest.java
@@ -81,7 +81,6 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.atLeastOnce;
-import static org.thingsboard.mqtt.broker.common.data.BrokerConstants.DROPPED_MSGS;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.lenient;
@@ -546,7 +545,7 @@ class ApplicationPersistenceProcessorImplTest {
                 mock(ApplicationPersistedMsgCtx.class), consumer, mock(ApplicationProcessorStats.class),
                 sessionId, clientState);
 
-        verify(tbMessageStatsReportClient, atLeastOnce()).reportStats(DROPPED_MSGS, 1);
+        verify(tbMessageStatsReportClient, atLeastOnce()).reportDroppedMsgs(1);
     }
 
     @Test
@@ -570,7 +569,7 @@ class ApplicationPersistenceProcessorImplTest {
                 mock(ApplicationPersistedMsgCtx.class), consumer, mock(ApplicationProcessorStats.class),
                 sessionId, clientState);
 
-        verify(tbMessageStatsReportClient, never()).reportStats(eq(DROPPED_MSGS), anyInt());
+        verify(tbMessageStatsReportClient, never()).reportDroppedMsgs(anyInt());
         verify(consumer, atLeastOnce()).commitSync();
     }
 

--- a/application/src/test/java/org/thingsboard/mqtt/broker/service/mqtt/persistence/application/ApplicationPersistenceProcessorImplTest.java
+++ b/application/src/test/java/org/thingsboard/mqtt/broker/service/mqtt/persistence/application/ApplicationPersistenceProcessorImplTest.java
@@ -32,7 +32,6 @@ import org.thingsboard.mqtt.broker.queue.cluster.ServiceInfoProvider;
 import org.thingsboard.mqtt.broker.queue.common.TbProtoQueueMsg;
 import org.thingsboard.mqtt.broker.queue.provider.ApplicationPersistenceMsgQueueFactory;
 import org.thingsboard.mqtt.broker.service.analysis.ClientLogger;
-import org.thingsboard.mqtt.broker.service.historical.stats.TbMessageStatsReportClient;
 import org.thingsboard.mqtt.broker.service.mqtt.MqttMsgDeliveryService;
 import org.thingsboard.mqtt.broker.service.mqtt.persistence.application.data.ApplicationMainProcessingState;
 import org.thingsboard.mqtt.broker.service.mqtt.persistence.application.data.ApplicationSharedSubscriptionCtx;
@@ -78,7 +77,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.doAnswer;
@@ -107,7 +105,6 @@ class ApplicationPersistenceProcessorImplTest {
     @Mock ApplicationTopicService applicationTopicService;
     @Mock ApplicationClientHelperService appClientHelperService;
     @Mock AppMsgDeliveryStrategy appMsgDeliveryStrategy;
-    @Mock TbMessageStatsReportClient tbMessageStatsReportClient;
 
     @InjectMocks
     ApplicationPersistenceProcessorImpl processor;
@@ -462,12 +459,6 @@ class ApplicationPersistenceProcessorImplTest {
         jobs.forEach(j -> assertThat(j.isInterrupted()).isFalse());
     }
 
-    // ===== GH#320: APPLICATION QoS1 RETRY_ALL ack-strategy lifecycle =====
-    // These two tests are expected to FAIL on the current code: tryCommitPack() instantiates a new
-    // ApplicationAckStrategy on every retry, so RetryStrategy#retryCount restarts at 0 each time and the
-    // configured retry cap is never reached. A client that never acks therefore loops forever instead of
-    // giving up, the Kafka offset is never committed, and consumer lag grows without bound.
-
     @Test
     void processMainPack_retryAll_whenClientNeverAcks_mustGiveUpAndCommitAfterRetryCap() {
         ApplicationAckStrategyConfiguration ackConfig = new ApplicationAckStrategyConfiguration();
@@ -489,11 +480,10 @@ class ApplicationPersistenceProcessorImplTest {
         ApplicationPubRelMsgCtx pubRelMsgCtx = new ApplicationPubRelMsgCtx(Sets.newConcurrentHashSet());
         pubRelMsgCtx.addPubRelMsg(new PersistedPubRelMsg(1, 0L));
 
-        invokeProcessMainPack(pubRelMsgCtx, Collections.emptyList(), clientSessionCtx("appClient"),
+        invokeProcessMainPack(pubRelMsgCtx, Collections.emptyList(), clientSessionCtx("appClient", sessionId),
                 mock(ApplicationPersistedMsgCtx.class), consumer, mock(ApplicationProcessorStats.class),
-                sessionId, clientState);
+                clientState);
 
-        // Expected: after the cap of 2 retries the pack is committed (give up). Today: never committed.
         verify(consumer, atLeastOnce()).commitSync();
     }
 
@@ -513,64 +503,12 @@ class ApplicationPersistenceProcessorImplTest {
         ApplicationPubRelMsgCtx pubRelMsgCtx = new ApplicationPubRelMsgCtx(Sets.newConcurrentHashSet());
         pubRelMsgCtx.addPubRelMsg(new PersistedPubRelMsg(1, 0L));
 
-        invokeProcessMainPack(pubRelMsgCtx, Collections.emptyList(), clientSessionCtx("appClient"),
+        invokeProcessMainPack(pubRelMsgCtx, Collections.emptyList(), clientSessionCtx("appClient", sessionId),
                 mock(ApplicationPersistedMsgCtx.class), consumer, mock(ApplicationProcessorStats.class),
-                sessionId, clientState);
+                clientState);
 
         // The ack strategy must be created once per pack and reused across retries so the cap accumulates.
-        // Today it is recreated on every retry, so this is called once per attempt instead of exactly once.
         verify(acknowledgeStrategyFactory, times(1)).newInstance("appClient");
-    }
-
-    @Test
-    void tryCommitPack_whenGivingUpWithPendingMessages_reportsDroppedMsgs() {
-        // SKIP_ALL commits the pack on the first analysis even with pending messages (give-up by design).
-        ApplicationAckStrategyConfiguration ackConfig = new ApplicationAckStrategyConfiguration();
-        ackConfig.setType(AckStrategyType.SKIP_ALL);
-        ackConfig.setRetries(0);
-        ApplicationMsgAcknowledgeStrategyFactory realFactory = new ApplicationMsgAcknowledgeStrategyFactory(ackConfig);
-        when(acknowledgeStrategyFactory.newInstance("appClient")).thenAnswer(inv -> realFactory.newInstance("appClient"));
-        ReflectionTestUtils.setField(processor, "packProcessingTimeout", 30L);
-        when(submitStrategyFactory.newInstance("appClient")).thenAnswer(inv -> new BurstSubmitStrategy("appClient"));
-        stopProcessorAfterDeliveries(5);
-
-        TbQueueControlledOffsetConsumer<TbProtoQueueMsg<PublishMsgProto>> consumer = mockConsumer();
-        UUID sessionId = UUID.randomUUID();
-        ClientActorStateInfo clientState = activeClientState("appClient", sessionId);
-
-        ApplicationPubRelMsgCtx pubRelMsgCtx = new ApplicationPubRelMsgCtx(Sets.newConcurrentHashSet());
-        pubRelMsgCtx.addPubRelMsg(new PersistedPubRelMsg(1, 0L));
-
-        invokeProcessMainPack(pubRelMsgCtx, Collections.emptyList(), clientSessionCtx("appClient"),
-                mock(ApplicationPersistedMsgCtx.class), consumer, mock(ApplicationProcessorStats.class),
-                sessionId, clientState);
-
-        verify(tbMessageStatsReportClient, atLeastOnce()).reportDroppedMsgs(1);
-    }
-
-    @Test
-    void tryCommitPack_whenCleanCommitWithNoPendingMessages_doesNotReportDroppedMsgs() {
-        ApplicationAckStrategyConfiguration ackConfig = new ApplicationAckStrategyConfiguration();
-        ackConfig.setType(AckStrategyType.RETRY_ALL);
-        ackConfig.setRetries(3);
-        ApplicationMsgAcknowledgeStrategyFactory realFactory = new ApplicationMsgAcknowledgeStrategyFactory(ackConfig);
-        when(acknowledgeStrategyFactory.newInstance("appClient")).thenAnswer(inv -> realFactory.newInstance("appClient"));
-        when(submitStrategyFactory.newInstance("appClient")).thenAnswer(inv -> new BurstSubmitStrategy("appClient"));
-        stopProcessorAfterDeliveries(5);
-
-        TbQueueControlledOffsetConsumer<TbProtoQueueMsg<PublishMsgProto>> consumer = mockConsumer();
-        UUID sessionId = UUID.randomUUID();
-        ClientActorStateInfo clientState = activeClientState("appClient", sessionId);
-
-        // Empty pack: nothing pending -> clean commit, no skip.
-        ApplicationPubRelMsgCtx emptyPubRelMsgCtx = new ApplicationPubRelMsgCtx(Sets.newConcurrentHashSet());
-
-        invokeProcessMainPack(emptyPubRelMsgCtx, Collections.emptyList(), clientSessionCtx("appClient"),
-                mock(ApplicationPersistedMsgCtx.class), consumer, mock(ApplicationProcessorStats.class),
-                sessionId, clientState);
-
-        verify(tbMessageStatsReportClient, never()).reportDroppedMsgs(anyInt());
-        verify(consumer, atLeastOnce()).commitSync();
     }
 
     // ===== Helpers =====
@@ -604,16 +542,15 @@ class ApplicationPersistenceProcessorImplTest {
                                        ApplicationPersistedMsgCtx persistedMsgCtx,
                                        TbQueueControlledOffsetConsumer<TbProtoQueueMsg<PublishMsgProto>> consumer,
                                        ApplicationProcessorStats stats,
-                                       UUID sessionId,
                                        ClientActorStateInfo clientState) {
         try {
             var method = ApplicationPersistenceProcessorImpl.class.getDeclaredMethod(
                     "processMainPack",
                     ApplicationPubRelMsgCtx.class, List.class, ClientSessionCtx.class,
                     ApplicationPersistedMsgCtx.class, TbQueueControlledOffsetConsumer.class,
-                    ApplicationProcessorStats.class, UUID.class, ClientActorStateInfo.class);
+                    ApplicationProcessorStats.class, ClientActorStateInfo.class);
             method.setAccessible(true);
-            method.invoke(processor, pubRelMsgCtx, messages, clientSessionCtx, persistedMsgCtx, consumer, stats, sessionId, clientState);
+            method.invoke(processor, pubRelMsgCtx, messages, clientSessionCtx, persistedMsgCtx, consumer, stats, clientState);
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
@@ -672,6 +609,14 @@ class ApplicationPersistenceProcessorImplTest {
     private ClientSessionCtx clientSessionCtx(String clientId) {
         ClientSessionCtx ctx = mock(ClientSessionCtx.class);
         lenient().when(ctx.getClientId()).thenReturn(clientId);
+        return ctx;
+    }
+
+    // processMainPack derives sessionId from the passed ctx; in production it is clientState.getCurrentSessionCtx(),
+    // so getSessionId() must equal clientState.getCurrentSessionId() for the isClientSessionActive guard to pass.
+    private ClientSessionCtx clientSessionCtx(String clientId, UUID sessionId) {
+        ClientSessionCtx ctx = clientSessionCtx(clientId);
+        when(ctx.getSessionId()).thenReturn(sessionId);
         return ctx;
     }
 

--- a/application/src/test/java/org/thingsboard/mqtt/broker/service/mqtt/persistence/application/processing/ApplicationMsgAcknowledgeStrategyFactoryTest.java
+++ b/application/src/test/java/org/thingsboard/mqtt/broker/service/mqtt/persistence/application/processing/ApplicationMsgAcknowledgeStrategyFactoryTest.java
@@ -1,0 +1,91 @@
+/**
+ * Copyright © 2016-2026 The Thingsboard Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.thingsboard.mqtt.broker.service.mqtt.persistence.application.processing;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit characterization of the ACK strategies behind APPLICATION persisted-message processing.
+ * <p>
+ * These tests pin down the building blocks of the GH#320 investigation:
+ * <ul>
+ *     <li>{@link #retryStrategy_whenSameInstanceReused_givesUpAfterConfiguredRetries()} — the
+ *     {@code RETRY_ALL} strategy is correct <em>in isolation</em>: one instance counts attempts and
+ *     gives up after the configured cap.</li>
+ *     <li>{@link #retryStrategy_whenRecreatedForEachAttempt_neverGivesUp()} — recreating the strategy
+ *     for every retry (exactly what {@code ApplicationPersistenceProcessorImpl#tryCommitPack} does)
+ *     resets the counter, so the cap is dead and retries are effectively unbounded.</li>
+ *     <li>{@link #skipStrategy_commitsImmediatelyEvenWithPendingMessages()} — {@code SKIP_ALL} is
+ *     at-most-once by design: it always commits, intentionally dropping un-acked messages.</li>
+ * </ul>
+ */
+class ApplicationMsgAcknowledgeStrategyFactoryTest {
+
+    private static final String CLIENT_ID = "appClient";
+
+    private ApplicationMsgAcknowledgeStrategyFactory factory(AckStrategyType type, int retries) {
+        ApplicationAckStrategyConfiguration config = new ApplicationAckStrategyConfiguration();
+        config.setType(type);
+        config.setRetries(retries);
+        return new ApplicationMsgAcknowledgeStrategyFactory(config);
+    }
+
+    private ApplicationPackProcessingResult resultWithPendingPubRel() {
+        ApplicationPackProcessingCtx ctx = new ApplicationPackProcessingCtx(CLIENT_ID);
+        ctx.getPubRelPendingMsgMap().put(1, new PersistedPubRelMsg(1, 0L));
+        return new ApplicationPackProcessingResult(ctx);
+    }
+
+    @Test
+    void retryStrategy_whenSameInstanceReused_givesUpAfterConfiguredRetries() {
+        ApplicationAckStrategy strategy = factory(AckStrategyType.RETRY_ALL, 2).newInstance(CLIENT_ID);
+
+        assertThat(strategy.analyze(resultWithPendingPubRel()).isCommit())
+                .as("attempt 1 must reprocess, not commit").isFalse();
+        assertThat(strategy.analyze(resultWithPendingPubRel()).isCommit())
+                .as("attempt 2 must reprocess, not commit").isFalse();
+        assertThat(strategy.analyze(resultWithPendingPubRel()).isCommit())
+                .as("attempt 3 exceeds the cap of 2 retries -> strategy must give up and commit").isTrue();
+    }
+
+    @Test
+    void retryStrategy_whenRecreatedForEachAttempt_neverGivesUp() {
+        ApplicationMsgAcknowledgeStrategyFactory factory = factory(AckStrategyType.RETRY_ALL, 2);
+
+        boolean gaveUp = false;
+        for (int attempt = 1; attempt <= 100; attempt++) {
+            ApplicationAckStrategy freshStrategyPerAttempt = factory.newInstance(CLIENT_ID);
+            if (freshStrategyPerAttempt.analyze(resultWithPendingPubRel()).isCommit()) {
+                gaveUp = true;
+                break;
+            }
+        }
+        assertThat(gaveUp)
+                .as("a fresh RetryStrategy per attempt resets retryCount, so the configured retry cap is never reached")
+                .isFalse();
+    }
+
+    @Test
+    void skipStrategy_commitsImmediatelyEvenWithPendingMessages() {
+        ApplicationAckStrategy strategy = factory(AckStrategyType.SKIP_ALL, 0).newInstance(CLIENT_ID);
+
+        assertThat(strategy.analyze(resultWithPendingPubRel()).isCommit())
+                .as("SKIP_ALL commits the pack on the first analysis regardless of pending acks (at-most-once by design)")
+                .isTrue();
+    }
+}

--- a/application/src/test/java/org/thingsboard/mqtt/broker/service/mqtt/persistence/application/processing/BurstSubmitStrategyTest.java
+++ b/application/src/test/java/org/thingsboard/mqtt/broker/service/mqtt/persistence/application/processing/BurstSubmitStrategyTest.java
@@ -1,0 +1,52 @@
+/**
+ * Copyright © 2016-2026 The Thingsboard Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.thingsboard.mqtt.broker.service.mqtt.persistence.application.processing;
+
+import org.junit.jupiter.api.Test;
+import org.thingsboard.mqtt.broker.service.mqtt.PublishMsg;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class BurstSubmitStrategyTest {
+
+    @Test
+    void update_rebuildsFromDupFlaggedReprocessCopies_notTheOriginalMessages() {
+        PublishMsg publishMsg = new PublishMsg(1, "test/topic", new byte[]{1}, 1, false, false);
+        PersistedPublishMsg original = new PersistedPublishMsg(publishMsg, 10L, false);
+
+        BurstSubmitStrategy strategy = new BurstSubmitStrategy("appClient");
+        strategy.init(List.of(original));
+
+        // The RetryStrategy puts a DUP-flagged copy (same packetId) into the reprocess map.
+        PersistedPublishMsg dupCopy = original.toBuilder()
+                .publishMsg(original.getPublishMsg().toBuilder().isDup(true).build())
+                .build();
+
+        strategy.update(Map.of(1, dupCopy));
+
+        List<PersistedMsg> reprocessed = strategy.getOrderedMessages();
+        assertThat(reprocessed).hasSize(1);
+        assertThat(reprocessed.get(0).getPublishMsg().isDup())
+                .as("retransmitted QoS1 PUBLISH must carry DUP=1 (MQTT 3.3.1.1)")
+                .isTrue();
+        assertThat(reprocessed.get(0))
+                .as("update() must use the reprocess-map copy, not the original message")
+                .isSameAs(dupCopy);
+    }
+}

--- a/application/src/test/java/org/thingsboard/mqtt/broker/service/mqtt/persistence/application/processing/BurstSubmitStrategyTest.java
+++ b/application/src/test/java/org/thingsboard/mqtt/broker/service/mqtt/persistence/application/processing/BurstSubmitStrategyTest.java
@@ -49,4 +49,61 @@ class BurstSubmitStrategyTest {
                 .as("update() must use the reprocess-map copy, not the original message")
                 .isSameAs(dupCopy);
     }
+
+    @Test
+    void update_multiMessage_preservesOrderAndSubstitutesBothDupCopies() {
+        PublishMsg msg1 = new PublishMsg(1, "test/topic", new byte[]{1}, 1, false, false);
+        PublishMsg msg2 = new PublishMsg(2, "test/topic", new byte[]{2}, 1, false, false);
+        PersistedPublishMsg original1 = new PersistedPublishMsg(msg1, 10L, false);
+        PersistedPublishMsg original2 = new PersistedPublishMsg(msg2, 20L, false);
+
+        BurstSubmitStrategy strategy = new BurstSubmitStrategy("appClient");
+        strategy.init(List.of(original1, original2));
+
+        PersistedPublishMsg dup1 = original1.toBuilder()
+                .publishMsg(original1.getPublishMsg().toBuilder().isDup(true).build())
+                .build();
+        PersistedPublishMsg dup2 = original2.toBuilder()
+                .publishMsg(original2.getPublishMsg().toBuilder().isDup(true).build())
+                .build();
+
+        strategy.update(Map.of(1, dup1, 2, dup2));
+
+        List<PersistedMsg> reprocessed = strategy.getOrderedMessages();
+        assertThat(reprocessed).hasSize(2);
+        assertThat(reprocessed.get(0).getPacketId())
+                .as("first message must retain packetId 1 (original insertion order preserved)")
+                .isEqualTo(1);
+        assertThat(reprocessed.get(1).getPacketId())
+                .as("second message must retain packetId 2 (original insertion order preserved)")
+                .isEqualTo(2);
+        assertThat(reprocessed.get(0).getPublishMsg().isDup()).as("first message must carry DUP=1").isTrue();
+        assertThat(reprocessed.get(1).getPublishMsg().isDup()).as("second message must carry DUP=1").isTrue();
+        assertThat(reprocessed.get(0)).as("update() must use dup1 copy for packetId 1").isSameAs(dup1);
+        assertThat(reprocessed.get(1)).as("update() must use dup2 copy for packetId 2").isSameAs(dup2);
+    }
+
+    @Test
+    void update_dropFiltering_dropsMessageAbsentFromReprocessMap() {
+        PublishMsg msg1 = new PublishMsg(1, "test/topic", new byte[]{1}, 1, false, false);
+        PublishMsg msg2 = new PublishMsg(2, "test/topic", new byte[]{2}, 1, false, false);
+        PersistedPublishMsg original1 = new PersistedPublishMsg(msg1, 10L, false);
+        PersistedPublishMsg original2 = new PersistedPublishMsg(msg2, 20L, false);
+
+        BurstSubmitStrategy strategy = new BurstSubmitStrategy("appClient");
+        strategy.init(List.of(original1, original2));
+
+        // Reprocess map contains only packetId 1; packetId 2 is absent and must be dropped.
+        PersistedPublishMsg dup1 = original1.toBuilder()
+                .publishMsg(original1.getPublishMsg().toBuilder().isDup(true).build())
+                .build();
+
+        strategy.update(Map.of(1, dup1));
+
+        List<PersistedMsg> reprocessed = strategy.getOrderedMessages();
+        assertThat(reprocessed).hasSize(1);
+        assertThat(reprocessed.get(0).getPacketId())
+                .as("only the message present in the reprocess map must survive")
+                .isEqualTo(1);
+    }
 }


### PR DESCRIPTION
## Pull Request description

Addresses several defects in **APPLICATION**-type persisted-message processing reported in #320, plus adds observability so silent message-skips become visible.

**What this PR fixes**

1. **RETRY_ALL retry cap was never enforced.** `tryCommitPack` created a fresh `ApplicationAckStrategy` on every retry iteration, so the retry counter (held in the strategy instance) reset to zero each pass and `retries` was never reached — with the default `RETRY_ALL`/`retries=3` config the broker retried the same un-acked pack forever instead of giving up after the cap. The strategy is now created **once per pack** in `processMainPack`/`processSharedPack` and passed into `tryCommitPack`, so the counter accumulates and the cap is honored. A committed characterization test pins the old (broken) behavior.

2. **Give-up message-skips were silent.** When the ack strategy decides to commit a pack with messages still un-acked (by design under `SKIP_ALL`, or under `RETRY_ALL` once the now-enforced cap is hit), those messages are dropped with no signal. The broker now logs a WARN at that single give-up site.

3. **Retransmitted QoS 1 PUBLISH was sent with DUP=0** (issue's secondary defect). `BurstSubmitStrategy.update` rebuilt its pack from the original messages and discarded the DUP-flagged copies the retry strategy had prepared. It now rebuilds from the reprocess-map values, so retransmits carry **DUP=1** per MQTT 3.3.1.1.

4. **Spurious `No shared subscription context found for PubAck/PubRec/PubComp` WARN** (issue's secondary defect). A late/duplicate ack for a client with no shared subscriptions logged at WARN on every occurrence. These three empty-context logs are downgraded to guarded DEBUG; the PubRel delivery on the PubRec path is preserved.

## General checklist

- [x] You have reviewed the guidelines [document](https://docs.google.com/document/d/1A4Vc3wrHsY_159b9RG5LOtCryoH6VPwgOhrFEzJKwbI/edit?usp=sharing).
- [x] [Labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels#about-labels) that classify your pull request have been added.
- [x] The [milestone](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones) is specified and corresponds to fix version.
- [x] Description references specific [issue](https://github.com/thingsboard/tbmq/issues).
- [x] Description contains human-readable scope of changes.
- [x] No merge conflicts, commented blocks of code, code formatting issues.
- [x] Description contains brief notes about what needs to be added to the documentation.
- [x] Changes are backward compatible or upgrade script is provided.

## Front-End feature checklist

- [x] Screenshots with affected component(s) are added. The best option is to provide 2 screens: before and after changes;
- [x] If you change the widget or other API, ensure it is backward-compatible or upgrade script is present.

_No front-end changes._

## Back-End feature checklist

- [x] Added corresponding unit and/or integration test(s). Provide written explanation in the PR description if you have failed to add tests.
- [x] If new dependency was added: the dependency tree is checked for conflicts. _(No new dependencies.)_
