### PR TITLE
Fix device shared subscription delivery for cross-node subscribers

### DIFF
--- a/application/src/main/java/org/thingsboard/mqtt/broker/service/processing/shared/DeviceSharedSubscriptionProcessorImpl.java
+++ b/application/src/main/java/org/thingsboard/mqtt/broker/service/processing/shared/DeviceSharedSubscriptionProcessorImpl.java
@@ -119,7 +119,12 @@ public class DeviceSharedSubscriptionProcessorImpl implements DeviceSharedSubscr
         for (Subscription subscription : subscriptions) {
             if (subscription.getClientSessionInfo().isConnected()) {
                 ClientSessionCtx clientSessionCtx = clientSessionCtxService.getClientSessionCtx(subscription.getClientId());
-                if (clientSessionCtx != null && clientSessionCtx.isWritable()) {
+                // A null ctx means the connected subscriber's session lives on another cluster node.
+                // Target selection and device delivery are cluster-wide (delivery is routed via the per-client
+                // device queue keyed by clientId), and backpressure for a remote subscriber is handled by that
+                // node's device actor - so a remote connected subscriber is eligible. The channel writability
+                // check only applies when the session is local to this node.
+                if (clientSessionCtx == null || clientSessionCtx.isWritable()) {
                     return subscription;
                 }
             }

--- a/application/src/test/java/org/thingsboard/mqtt/broker/service/processing/shared/DeviceSharedSubscriptionProcessorImplTest.java
+++ b/application/src/test/java/org/thingsboard/mqtt/broker/service/processing/shared/DeviceSharedSubscriptionProcessorImplTest.java
@@ -125,6 +125,41 @@ public class DeviceSharedSubscriptionProcessorImplTest {
         assertEquals("topic3", subscription.getTopicFilter());
     }
 
+    @Test
+    public void givenConnectedSubscriptionOnAnotherNode_whenFindAnyConnectedSubscription_thenReturnSubscription() {
+        // The connected subscriber's live session is on another cluster node, so there is no local
+        // ClientSessionCtx here. It must still be eligible: selection and device delivery are cluster-wide
+        // (routed via the per-client device queue), and backpressure is handled by that node's device actor.
+        List<Subscription> subscriptions = List.of(
+                new Subscription("topic1", 1, ClientSessionInfo.builder().connected(false).build()),
+                new Subscription("topic2", 2, ClientSessionInfo.builder().clientId("remoteClient").connected(true).build()),
+                new Subscription("topic3", 0, ClientSessionInfo.builder().connected(false).build())
+        );
+
+        when(clientSessionCtxService.getClientSessionCtx(eq("remoteClient"))).thenReturn(null);
+
+        Subscription subscription = processor.findAnyConnectedSubscription(subscriptions);
+        assertEquals("topic2", subscription.getTopicFilter());
+    }
+
+    @Test
+    public void givenLocalNonWritableAndRemoteConnected_whenFindAnyConnectedSubscription_thenReturnRemote() {
+        // A connected member on this node whose channel is saturated must be skipped (local backpressure),
+        // but a connected member on another node (no local ctx) is still eligible.
+        List<Subscription> subscriptions = List.of(
+                new Subscription("local", 1, ClientSessionInfo.builder().clientId("localClient").connected(true).build()),
+                new Subscription("remote", 2, ClientSessionInfo.builder().clientId("remoteClient").connected(true).build())
+        );
+
+        ClientSessionCtx localCtx = mock(ClientSessionCtx.class);
+        when(localCtx.isWritable()).thenReturn(false);
+        when(clientSessionCtxService.getClientSessionCtx(eq("localClient"))).thenReturn(localCtx);
+        when(clientSessionCtxService.getClientSessionCtx(eq("remoteClient"))).thenReturn(null);
+
+        Subscription subscription = processor.findAnyConnectedSubscription(subscriptions);
+        assertEquals("remote", subscription.getTopicFilter());
+    }
+
     private Subscription newSubscription(int mqttQoSValue, String shareName) {
         return new Subscription("topic", mqttQoSValue, clientSessionInfo, shareName, SubscriptionOptions.newInstance());
     }


### PR DESCRIPTION
## Pull Request description

Fixes the message-delivery issue reported in #255 for **device persistent shared subscriptions** running in a **cluster**.

### Problem

For a device shared subscription, each published message is processed on a single broker node, chosen by the message topic (`tbmq.msg.all` is keyed by topic name) and therefore independent of where the group's subscribers are connected. `DeviceSharedSubscriptionProcessorImpl#findAnyConnectedSubscription` only treated a group member as eligible for live delivery when its session was **local** to that processing node (`clientSessionCtxService.getClientSessionCtx(clientId) != null && isWritable()`) — and `ClientSessionCtxService` is a node-local registry of live Netty channels.

In a multi-node cluster the processing node usually hosts none of the group's members, so:

- if a member was **offline + persistent**, the message was diverted to the per-share-group store (`ss_<group>_<topicFilter>`), which is only drained on connect when no other member of the group is connected; or
- if all members were **connected but on other nodes**, the message was skipped entirely.

Either way, connected members received nothing. This was most visible after one member of the group disconnected: it became an offline-persistent subscriber that diverted traffic into the share-group store, starving the still-connected members until every member disconnected and one reconnected alone.

### Fix

Target selection (round-robin) and device delivery are already cluster-wide — the selected client's message is persisted to its per-client store and routed to the node it is connected to via `DownLinkProxy`. Only the eligibility gate was node-local.

`findAnyConnectedSubscription` now treats a connected member with no local `ClientSessionCtx` (i.e. connected on another node) as eligible, and applies the channel-writability check only when the session is local to this node:

```java
if (clientSessionCtx == null || clientSessionCtx.isWritable()) {
    return subscription;
}
```

With this change the divert-to-`ss_` / skip path is taken only when no member of the group is connected anywhere (its intended "all offline" purpose).

### Scope of changes

- `DeviceSharedSubscriptionProcessorImpl#findAnyConnectedSubscription` — one-line eligibility change (+ explanatory comment).
- `DeviceSharedSubscriptionProcessorImplTest` — two regression tests: a member connected on another node (no local ctx), and a mix of a local non-writable member with a remote connected member.

### Validation

- Unit tests: `DeviceSharedSubscriptionProcessorImplTest` green (6/6).
- End-to-end: built the broker image with this change and deployed to a 3-pod cluster; the reported scenario (3 device clients in one shared subscription; disconnect one → group stops receiving) is no longer reproducible.

## General checklist

- [x] You have reviewed the guidelines [document](https://docs.google.com/document/d/1A4Vc3wrHsY_159b9RG5LOtCryoH6VPwgOhrFEzJKwbI/edit?usp=sharing).
- [x] [Labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels#about-labels) that classify your pull request have been added.
- [x] The [milestone](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones) is specified and corresponds to fix version.
- [x] Description references specific [issue](https://github.com/thingsboard/tbmq/issues).
- [x] Description contains human-readable scope of changes.
- [x] Description contains brief notes about what needs to be added to the documentation. _(no documentation changes required)_
- [x] No merge conflicts, commented blocks of code, code formatting issues.
- [x] Changes are backward compatible or upgrade script is provided. _(no API/schema/config changes)_

## Front-End feature checklist

_N/A — no front-end changes._

## Back-End feature checklist

- [x] Added corresponding unit and/or integration test(s).
- [x] If new dependency was added: the dependency tree is checked for conflicts. _(no new dependencies)_
