### PR TITLE
Wrap long payloads in WebSocket client payload dialog

### DIFF
--- a/ui-ngx/src/app/modules/home/components/event/event-content-dialog.component.ts
+++ b/ui-ngx/src/app/modules/home/components/event/event-content-dialog.component.ts
@@ -142,11 +142,12 @@ export class EventContentDialogComponent extends DialogComponent<EventContentDia
         getAce().subscribe(
           (ace) => {
             this.aceEditor = ace.edit(editorElement, editorOptions);
-            this.aceEditor.session.setUseWrapMode(this.contentType === ContentType.TEXT);
-            if (this.contentType === ContentType.TEXT) {
-              this.aceEditor.session.setWrapLimitRange(0, this.wrapLimit);
-              this.aceEditor.setOption('indentedSoftWrap', false);
-            }
+            // Soft-wrap every content type so long unbreakable strings (e.g. a single
+            // JSON value with no spaces) wrap onto new lines instead of stretching the
+            // editor to its max width and forcing horizontal scrolling.
+            this.aceEditor.session.setUseWrapMode(true);
+            this.aceEditor.session.setWrapLimitRange(0, this.wrapLimit);
+            this.aceEditor.setOption('indentedSoftWrap', false);
             this.aceEditor.setValue(processedContent, -1);
             this.updateEditorSize(editorElement, processedContent, this.aceEditor);
           }
@@ -160,20 +161,22 @@ export class EventContentDialogComponent extends DialogComponent<EventContentDia
     let newWidth = 400;
     if (content && content.length > 0) {
       const lines = content.split('\n');
-      newHeight = 16 * lines.length + 24;
       let maxLineLength = 0;
+      let screenRows = 0;
       lines.forEach((row) => {
         const line = row.replace(/\t/g, '    ').replace(/\n/g, '');
-        const lineLength = line.length;
-        maxLineLength = Math.max(maxLineLength, lineLength);
+        maxLineLength = Math.max(maxLineLength, line.length);
+        // Each logical line occupies one visual row per wrapLimit chars (at least one).
+        screenRows += Math.max(1, Math.ceil(line.length / this.wrapLimit));
       });
-      // In wrap mode (plain TEXT) lines wrap at the configured limit, so the editor
-      // never needs to be wider than that — otherwise long single-line strings would
+      // Soft-wrap is always on, so lines wrap at the configured limit — the editor
+      // never needs to be wider than that. Otherwise long single-line strings would
       // stretch the dialog to its max width with empty space on the right.
-      if (this.contentType === ContentType.TEXT) {
-        maxLineLength = Math.min(maxLineLength, this.wrapLimit);
-      }
+      maxLineLength = Math.min(maxLineLength, this.wrapLimit);
       newWidth = 8 * maxLineLength + 16;
+      // Size the height from the wrapped row count (not the raw line count) so a value
+      // that wraps over many visual rows is fully shown and scrolls vertically.
+      newHeight = 16 * screenRows + 24;
     }
     // Cap to the viewport so the dialog never overflows; ACE renders its own
     // scrollbars (pinned at the editor edges) when the content exceeds these bounds.


### PR DESCRIPTION
## Problem

In the WebSocket client, opening the **Payload** dialog for a message whose payload is JSON containing a long unbreakable string (no spaces) renders poorly: the text stretches the ACE editor to its max width, forcing horizontal scrolling and leaving large empty vertical space, with no useful vertical scrolling.

Root cause: soft-wrap in the shared `EventContentDialogComponent` was only enabled for plain `TEXT` content. JSON payloads (detected via `isValidObjectString`) had wrap mode off.

## Fix

- Enable soft-wrap for **all** content types so long unbreakable strings wrap at the configured limit instead of stretching the editor horizontally.
- Size the editor height from the **wrapped row count** rather than the raw line count, so content that wraps over many visual rows is fully shown and scrolls vertically within the dialog.
- Apply the width cap uniformly so the dialog no longer balloons to full width for a single long line.

## Before / After

Before: long single-line value → horizontal scroll, wasted vertical space.
After: value wraps within the bounded editor width; tall content scrolls vertically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)