### PR TITLE
fix(cache): apply TLS (and username) to Redis/Valkey Sentinel client config (GH#331)

### DIFF
--- a/application/src/main/resources/thingsboard-mqtt-broker.yml
+++ b/application/src/main/resources/thingsboard-mqtt-broker.yml
@@ -1124,6 +1124,8 @@ redis:
     master: "${REDIS_MASTER:}"
     # Comma-separated list of "host:port" pairs of sentinels.
     sentinels: "${REDIS_SENTINELS:}"
+    # Optional. Username to authenticate with the Sentinel (Sentinel ACL).
+    username: "${REDIS_SENTINEL_USERNAME:}"
     # Password to authenticate with the Sentinel.
     password: "${REDIS_SENTINEL_PASSWORD:}"
     # Enables or disables use of the default pool config. When false, the pool config is built from the 'pool_config' section values.

--- a/common/cache/src/main/java/org/thingsboard/mqtt/broker/cache/TBRedisSentinelConfiguration.java
+++ b/common/cache/src/main/java/org/thingsboard/mqtt/broker/cache/TBRedisSentinelConfiguration.java
@@ -25,6 +25,7 @@ import org.thingsboard.mqtt.broker.common.data.util.StringUtils;
 import redis.clients.jedis.ConnectionPoolConfig;
 import redis.clients.jedis.DefaultJedisClientConfig;
 import redis.clients.jedis.DefaultJedisClientConfig.Builder;
+import redis.clients.jedis.JedisClientConfig;
 import redis.clients.jedis.JedisSentineled;
 import redis.clients.jedis.UnifiedJedis;
 
@@ -41,6 +42,9 @@ public class TBRedisSentinelConfiguration extends TBRedisCacheConfiguration<Redi
 
     @Value("${redis.sentinel.sentinels:}")
     private String sentinels;
+
+    @Value("${redis.sentinel.username:}")
+    private String sentinelUsername;
 
     @Value("${redis.sentinel.password:}")
     private String sentinelPassword;
@@ -69,12 +73,22 @@ public class TBRedisSentinelConfiguration extends TBRedisCacheConfiguration<Redi
         if (sslEnabled) {
             masterClientConfigBuilder.ssl(true).sslSocketFactory(createSslSocketFactory());
         }
+        ConnectionPoolConfig connectionPoolConfig = useDefaultPoolConfig ? new ConnectionPoolConfig() : buildConnectionPoolConfig();
+        return new JedisSentineled(master, masterClientConfigBuilder.build(), connectionPoolConfig, toHostAndPort(sentinels), buildSentinelClientConfig());
+    }
+
+    JedisClientConfig buildSentinelClientConfig() {
         Builder sentinelClientConfigBuilder = DefaultJedisClientConfig.builder();
+        if (StringUtils.isNotEmpty(sentinelUsername)) {
+            sentinelClientConfigBuilder.user(sentinelUsername);
+        }
         if (StringUtils.isNotEmpty(sentinelPassword)) {
             sentinelClientConfigBuilder.password(sentinelPassword);
         }
-        ConnectionPoolConfig connectionPoolConfig = useDefaultPoolConfig ? new ConnectionPoolConfig() : buildConnectionPoolConfig();
-        return new JedisSentineled(master, masterClientConfigBuilder.build(), connectionPoolConfig, toHostAndPort(sentinels), sentinelClientConfigBuilder.build());
+        if (sslEnabled) {
+            sentinelClientConfigBuilder.ssl(true).sslSocketFactory(createSslSocketFactory());
+        }
+        return sentinelClientConfigBuilder.build();
     }
 
     @Override
@@ -103,6 +117,7 @@ public class TBRedisSentinelConfiguration extends TBRedisCacheConfiguration<Redi
         var redisSentinelConfiguration = new RedisSentinelConfiguration();
         redisSentinelConfiguration.setMaster(master);
         redisSentinelConfiguration.setSentinels(getNodes(sentinels));
+        redisSentinelConfiguration.setSentinelUsername(sentinelUsername);
         redisSentinelConfiguration.setSentinelPassword(sentinelPassword);
         redisSentinelConfiguration.setUsername(username);
         redisSentinelConfiguration.setPassword(password);

--- a/common/cache/src/test/java/org/thingsboard/mqtt/broker/cache/TBRedisSentinelSslConfigurationTest.java
+++ b/common/cache/src/test/java/org/thingsboard/mqtt/broker/cache/TBRedisSentinelSslConfigurationTest.java
@@ -1,0 +1,83 @@
+/**
+ * Copyright © 2016-2026 The Thingsboard Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.thingsboard.mqtt.broker.cache;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+import redis.clients.jedis.JedisClientConfig;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.KeyPair;
+import java.security.cert.X509Certificate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit tests for the Sentinel client configuration built by {@link TBRedisSentinelConfiguration}.
+ * <p>
+ * Regression guard for GH#331: when {@code redis.ssl.enabled=true}, the connection to the Redis/Valkey
+ * Sentinel itself must use TLS. Previously SSL was applied only to the master/data-node client config,
+ * so {@code JedisSentineled} attempted the Sentinel handshake in plaintext against a TLS Sentinel and
+ * failed at startup with "Could not get master address ... java.net.SocketException: Connection reset".
+ */
+public class TBRedisSentinelSslConfigurationTest {
+
+    static String caCertPath;
+
+    @BeforeAll
+    static void generateCa() throws Exception {
+        Path certsDir = Files.createTempDirectory("tbmq-redis-sentinel-ssl-test-");
+        KeyPair caKeyPair = RedisTlsCertGenerator.generateKeyPair();
+        X509Certificate caCert = RedisTlsCertGenerator.generateCaCert(caKeyPair);
+        Path ca = certsDir.resolve("ca.pem");
+        RedisTlsCertGenerator.writePem(ca, caCert);
+        caCertPath = ca.toString();
+    }
+
+    private TBRedisSentinelConfiguration newConfig(boolean sslEnabled) {
+        TBRedisSentinelConfiguration cfg = new TBRedisSentinelConfiguration(null, null);
+        RedisSslCredentials creds = new RedisSslCredentials();
+        creds.setCertFile(caCertPath);
+        ReflectionTestUtils.setField(cfg, "redisSslCredentials", creds);
+        ReflectionTestUtils.setField(cfg, "sslEnabled", sslEnabled);
+        ReflectionTestUtils.setField(cfg, "sentinelUsername", "sentinel-user");
+        ReflectionTestUtils.setField(cfg, "sentinelPassword", "sentinel-pass");
+        return cfg;
+    }
+
+    @Test
+    void givenSslEnabled_whenBuildingSentinelClientConfig_thenSslIsApplied() {
+        JedisClientConfig sentinelConfig = newConfig(true).buildSentinelClientConfig();
+        assertThat(sentinelConfig.isSsl()).isTrue();
+        assertThat(sentinelConfig.getSslSocketFactory()).isNotNull();
+    }
+
+    @Test
+    void givenSslEnabled_whenBuildingSentinelClientConfig_thenSentinelCredentialsApplied() {
+        JedisClientConfig sentinelConfig = newConfig(true).buildSentinelClientConfig();
+        assertThat(sentinelConfig.getUser()).isEqualTo("sentinel-user");
+        assertThat(sentinelConfig.getPassword()).isEqualTo("sentinel-pass");
+    }
+
+    @Test
+    void givenSslDisabled_whenBuildingSentinelClientConfig_thenNoSsl() {
+        JedisClientConfig sentinelConfig = newConfig(false).buildSentinelClientConfig();
+        assertThat(sentinelConfig.isSsl()).isFalse();
+        assertThat(sentinelConfig.getSslSocketFactory()).isNull();
+    }
+}


### PR DESCRIPTION
## Pull Request description

Closes #331.

**Problem.** In **sentinel** mode with `redis.ssl.enabled=true`, the broker crashes at startup:

```
WARN  r.c.j.p.SentineledConnectionProvider - Could not get master address from mymaster:6390.
redis.clients.jedis.exceptions.JedisConnectionException: java.net.SocketException: Connection reset
  ... at redis.clients.jedis.Connection.initializeFromClientConfig
  ... at redis.clients.jedis.providers.SentineledConnectionProvider.initSentinels
  ... at o.t.m.b.cache.TBRedisSentinelConfiguration.loadUnifiedJedis(TBRedisSentinelConfiguration.java:77)
  ... at o.t.m.b.cache.TBRedisCacheConfiguration.jedisBasedProxyManager(TBRedisCacheConfiguration.java:162)
Caused by: java.net.SocketException: Connection reset
```

**Root cause.** `TBRedisSentinelConfiguration#loadUnifiedJedis()` applied SSL to the **master/data-node** client config but **not** to the **Sentinel** client config. `JedisSentineled` contacts the Sentinel first (to discover the master), so it opened a **plaintext** socket to a TLS Sentinel → the Sentinel reset the connection during the handshake → the eagerly-initialized `jedisBasedProxyManager` bean failed → context refresh aborted → broker would not boot. Standalone and Cluster modes were unaffected (single client config, SSL applied correctly).

**Scope of changes.**
- `TBRedisSentinelConfiguration`: extracted `buildSentinelClientConfig()` and apply `ssl(true).sslSocketFactory(...)` to the Sentinel config, mirroring the master config.
- Added `redis.sentinel.username` / `REDIS_SENTINEL_USERNAME` for Sentinel ACL authentication, wired into both the raw `UnifiedJedis` path and the Spring Data `RedisSentinelConfiguration` path (`setSentinelUsername`). Previously only a sentinel *password* could be configured.
- `thingsboard-mqtt-broker.yml`: documented the new `redis.sentinel.username` property.

The Spring Data paths (`cacheManager` / `redisTemplate` via Jedis `JedisConnectionFactory`, and `lettuceConnectionFactory`) already applied SSL to the Sentinel connection (Jedis via `createSentinelClientConfig()`); only the raw `UnifiedJedis` path used by `jedisBasedProxyManager` was broken — but since that bean is eagerly initialized, it crashed the entire startup. The new sentinel username flows through those Spring Data paths via `setSentinelUsername(...)`.

**Documentation notes.** The Redis/Valkey **sentinel** cache configuration docs should: (1) document the new `REDIS_SENTINEL_USERNAME` env var alongside `REDIS_SENTINEL_PASSWORD`, and (2) clarify that `REDIS_SSL_ENABLED=true` now also secures the connection to the Sentinel itself (TLS-enabled Sentinels are supported).

**Verification.**
- New `TBRedisSentinelSslConfigurationTest` (test-first: failed RED, passes GREEN) asserts the Sentinel client config gets SSL + sentinel credentials when enabled, and no SSL when disabled.
- `mvn -pl common/cache test` (non-Docker classes): 16/16 pass, no regressions.
- Reproduced end-to-end against a Valkey 9 TLS master+sentinel in Docker: the pre-fix logic throws the exact stacktrace above; the post-fix logic discovers the master and `PING → PONG` over TLS.
- Full matrix re-verified end-to-end against **TLS + ACL** Valkey 9 (default user disabled, so a successful operation proves the username was applied; Sentinel guarded by a *distinct* ACL user): all four Redis beans — `cacheManager`, `redisTemplate`, `jedisBasedProxyManager`, and **`lettuceConnectionFactory`** — work over TLS + username for **standalone, cluster, and sentinel**. For the Lettuce sentinel path, an isolated check confirmed the Sentinel connection is `rediss://` (TLS) and carries the configured `redis.sentinel.username` (wrong sentinel user → `WRONGPASS`). These were exploratory checks against Dockerized Valkey, not committed tests.

## General checklist

- [x] You have reviewed the guidelines [document](https://docs.google.com/document/d/1A4Vc3wrHsY_159b9RG5LOtCryoH6VPwgOhrFEzJKwbI/edit?usp=sharing).
- [x] [Labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels#about-labels) that classify your pull request have been added.
- [x] The [milestone](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones) is specified and corresponds to fix version.
- [x] Description references specific [issue](https://github.com/thingsboard/tbmq/issues).
- [x] Description contains human-readable scope of changes.
- [x] Description contains brief notes about what needs to be added to the documentation.
- [x] No merge conflicts, commented blocks of code, code formatting issues.
- [x] Changes are backward compatible or upgrade script is provided.

## Front-End feature checklist

_N/A — no front-end changes._

- [x] Screenshots with affected component(s) are added. The best option is to provide 2 screens: before and after changes;
- [x] If you change the widget or other API, ensure it is backward-compatible or upgrade script is present.

## Back-End feature checklist

- [x] Added corresponding unit and/or integration test(s). Provide written explanation in the PR description if you have failed to add tests.
- [x] If new dependency was added: the dependency tree is checked for conflicts. _(No new dependencies added.)_

