### PR TITLE
fix(stats): deregister appProcessor per-client meters on clear to stop registry leak

### DIFF
--- a/application/src/main/java/org/thingsboard/mqtt/broker/service/stats/DefaultApplicationProcessorStats.java
+++ b/application/src/main/java/org/thingsboard/mqtt/broker/service/stats/DefaultApplicationProcessorStats.java
@@ -36,6 +36,22 @@ import static org.thingsboard.mqtt.broker.common.stats.StatsConstantNames.TIMEOU
 import static org.thingsboard.mqtt.broker.common.stats.StatsConstantNames.TMP_TIMEOUT_PUBLISH;
 import static org.thingsboard.mqtt.broker.common.stats.StatsConstantNames.TMP_TIMEOUT_PUBREL;
 
+/**
+ * Per-application-client processing stats.
+ * <p>
+ * The 8 {@link StatsCounter}s are tagged with the {@code clientId} (or the shared-subscription
+ * compound id), so each application client gets its own Micrometer series. They are deregistered
+ * from the registry when the client is cleared (see
+ * {@code StatsManagerImpl#printAndRemoveApplicationStatsOnClear}) to bound cardinality on churn.
+ * <p>
+ * The 3 {@code appProcessor.latency} timers, by contrast, carry <b>no</b> {@code clientId} tag —
+ * they are keyed only by {@code packetType}, so Micrometer registers a single shared set that
+ * aggregates latency across all application clients. This is intentional: per-client latency
+ * would add an unbounded {@code clientId} dimension on a broker targeting 100M+ connections.
+ * <b>Do not add a {@code clientId} tag to these timers</b> (cardinality trap); per-client latency
+ * remains available in the periodic log line only. Because they are shared, they are also
+ * intentionally <b>not</b> deregistered when a single client is cleared.
+ */
 @Slf4j
 public class DefaultApplicationProcessorStats implements ApplicationProcessorStats {
 

--- a/application/src/main/java/org/thingsboard/mqtt/broker/service/stats/StatsManagerImpl.java
+++ b/application/src/main/java/org/thingsboard/mqtt/broker/service/stats/StatsManagerImpl.java
@@ -204,7 +204,7 @@ public class StatsManagerImpl implements StatsManager, ActorStatsManager, SqlQue
     @Override
     public void clearApplicationProcessorStats(String clientId) {
         log.trace("Clearing ApplicationProcessorStats, clientId - {}", clientId);
-        printApplicationStatsOnClear(managedApplicationProcessorStats.remove(clientId));
+        printAndRemoveApplicationStatsOnClear(managedApplicationProcessorStats.remove(clientId));
     }
 
     @Override
@@ -215,7 +215,7 @@ public class StatsManagerImpl implements StatsManager, ActorStatsManager, SqlQue
             return;
         }
         for (String compoundClientId : clientIds) {
-            printApplicationStatsOnClear(managedApplicationProcessorStats.remove(compoundClientId));
+            printAndRemoveApplicationStatsOnClear(managedApplicationProcessorStats.remove(compoundClientId));
         }
     }
 
@@ -231,16 +231,21 @@ public class StatsManagerImpl implements StatsManager, ActorStatsManager, SqlQue
         }
         clientIds.remove(compoundClientId);
 
-        printApplicationStatsOnClear(managedApplicationProcessorStats.remove(compoundClientId));
+        printAndRemoveApplicationStatsOnClear(managedApplicationProcessorStats.remove(compoundClientId));
         if (clientIds.isEmpty()) {
             sharedSubscriptionCompoundClientIds.remove(clientId);
         }
     }
 
-    private void printApplicationStatsOnClear(ApplicationProcessorStats stats) {
+    private void printAndRemoveApplicationStatsOnClear(ApplicationProcessorStats stats) {
         if (stats != null) {
             log.info("[{}][{}] Stats on clear", StatsType.APP_PROCESSOR.getPrintName(), stats.getClientId());
             printApplicationProcessorStats(stats);
+            // Deregister the per-client counters so they stop being scraped and don't leak the
+            // Micrometer registry on client/shared-subscription churn. The appProcessor.latency
+            // timers carry no clientId tag (one shared set across all clients), so they are
+            // intentionally left registered.
+            stats.getStatsCounters().forEach(statsFactory::remove);
         }
     }
 

--- a/application/src/main/resources/thingsboard-mqtt-broker.yml
+++ b/application/src/main/resources/thingsboard-mqtt-broker.yml
@@ -1182,7 +1182,10 @@ stats:
     # Metrics percentiles returned by actuator for timer metrics. List of comma-separated double values.
     percentiles: "${STATS_TIMER_PERCENTILES:0.5}"
   application-processor:
-    # Enables or disables specific Application clients stats.
+    # Enables or disables per-Application-client processing stats. When enabled, each Application client gets its own set
+    # of counters tagged with 'clientId' (deregistered when the client disconnects); the appProcessor.latency timers are
+    # aggregated globally (keyed only by packetType, with no per-client tag). On a broker with very many Application
+    # clients the per-client counter cardinality can be high, so enable only when per-client stats are needed.
     enabled: "${APPLICATION_PROCESSOR_STATS_ENABLED:true}"
   system-info:
     # Persistence frequency of system info such as CPU and memory usage (in s).

--- a/application/src/test/java/org/thingsboard/mqtt/broker/service/stats/StatsManagerImplTest.java
+++ b/application/src/test/java/org/thingsboard/mqtt/broker/service/stats/StatsManagerImplTest.java
@@ -1,0 +1,86 @@
+/**
+ * Copyright © 2016-2026 The Thingsboard Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.thingsboard.mqtt.broker.service.stats;
+
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.thingsboard.mqtt.broker.common.stats.DefaultStatsFactory;
+import org.thingsboard.mqtt.broker.common.stats.StatsFactory;
+import org.thingsboard.mqtt.broker.common.stats.StatsType;
+import org.thingsboard.mqtt.broker.service.subscription.shared.TopicSharedSubscription;
+
+import static org.junit.Assert.assertEquals;
+import static org.thingsboard.mqtt.broker.common.stats.StatsConstantNames.CLIENT_ID_TAG;
+
+public class StatsManagerImplTest {
+
+    private static final String APP_PROCESSOR = StatsType.APP_PROCESSOR.getPrintName();
+    private static final String APP_PROCESSOR_LATENCY = APP_PROCESSOR + ".latency";
+
+    private SimpleMeterRegistry meterRegistry;
+    private StatsManagerImpl statsManager;
+
+    @Before
+    public void setUp() {
+        meterRegistry = new SimpleMeterRegistry();
+        StatsFactory statsFactory = new DefaultStatsFactory(meterRegistry);
+        statsManager = new StatsManagerImpl(statsFactory);
+        ReflectionTestUtils.setField(statsManager, "applicationProcessorStatsEnabled", true);
+    }
+
+    private int appProcessorCounters(String clientId) {
+        return meterRegistry.find(APP_PROCESSOR).tag(CLIENT_ID_TAG, clientId).counters().size();
+    }
+
+    @Test
+    public void givenApplicationProcessorStats_whenClear_thenPerClientCountersRemovedFromRegistry() {
+        String clientId = "app-client-1";
+        statsManager.createApplicationProcessorStats(clientId);
+        assertEquals(8, appProcessorCounters(clientId));
+
+        statsManager.clearApplicationProcessorStats(clientId);
+
+        assertEquals(0, appProcessorCounters(clientId));
+    }
+
+    @Test
+    public void givenSharedApplicationProcessorStats_whenClearShared_thenCompoundCountersRemovedFromRegistry() {
+        String clientId = "app-client-1";
+        TopicSharedSubscription subscription = new TopicSharedSubscription("my/topic", "group1");
+        statsManager.createSharedApplicationProcessorStats(clientId, subscription);
+        String compoundClientId = clientId + "_group1_my/topic";
+        assertEquals(8, appProcessorCounters(compoundClientId));
+
+        statsManager.clearSharedApplicationProcessorStats(clientId);
+
+        assertEquals(0, appProcessorCounters(compoundClientId));
+    }
+
+    @Test
+    public void givenApplicationProcessorStats_whenClear_thenSharedLatencyTimersRetained() {
+        String clientId = "app-client-1";
+        statsManager.createApplicationProcessorStats(clientId);
+        assertEquals(3, meterRegistry.find(APP_PROCESSOR_LATENCY).timers().size());
+
+        statsManager.clearApplicationProcessorStats(clientId);
+
+        // The 3 latency timers carry no clientId tag, so Micrometer shares one set across all
+        // application clients. Clearing one client must NOT deregister them.
+        assertEquals(3, meterRegistry.find(APP_PROCESSOR_LATENCY).timers().size());
+    }
+}

--- a/application/src/test/java/org/thingsboard/mqtt/broker/service/stats/StatsManagerImplTest.java
+++ b/application/src/test/java/org/thingsboard/mqtt/broker/service/stats/StatsManagerImplTest.java
@@ -24,7 +24,12 @@ import org.thingsboard.mqtt.broker.common.stats.StatsFactory;
 import org.thingsboard.mqtt.broker.common.stats.StatsType;
 import org.thingsboard.mqtt.broker.service.subscription.shared.TopicSharedSubscription;
 
+import java.util.Map;
+import java.util.Set;
+
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.thingsboard.mqtt.broker.common.stats.StatsConstantNames.CLIENT_ID_TAG;
 
 public class StatsManagerImplTest {
@@ -45,6 +50,11 @@ public class StatsManagerImplTest {
 
     private int appProcessorCounters(String clientId) {
         return meterRegistry.find(APP_PROCESSOR).tag(CLIENT_ID_TAG, clientId).counters().size();
+    }
+
+    @SuppressWarnings("unchecked")
+    private Map<String, Set<String>> sharedSubscriptionCompoundClientIds() {
+        return (Map<String, Set<String>>) ReflectionTestUtils.getField(statsManager, "sharedSubscriptionCompoundClientIds");
     }
 
     @Test
@@ -69,6 +79,33 @@ public class StatsManagerImplTest {
         statsManager.clearSharedApplicationProcessorStats(clientId);
 
         assertEquals(0, appProcessorCounters(compoundClientId));
+    }
+
+    @Test
+    public void givenTwoSharedSubscriptionsForOneClient_whenClearOneBySubscription_thenOnlyThatCompoundRemovedAndOuterEntrySurvivesUntilLast() {
+        String clientId = "app-client-1";
+        TopicSharedSubscription subscription1 = new TopicSharedSubscription("topic/a", "group1");
+        TopicSharedSubscription subscription2 = new TopicSharedSubscription("topic/b", "group2");
+        statsManager.createSharedApplicationProcessorStats(clientId, subscription1);
+        statsManager.createSharedApplicationProcessorStats(clientId, subscription2);
+        String compoundClientId1 = clientId + "_group1_topic/a";
+        String compoundClientId2 = clientId + "_group2_topic/b";
+        assertEquals(8, appProcessorCounters(compoundClientId1));
+        assertEquals(8, appProcessorCounters(compoundClientId2));
+
+        statsManager.clearSharedApplicationProcessorStats(clientId, subscription1);
+
+        // Only the cleared subscription's counters are deregistered; the other subscription's remain.
+        assertEquals(0, appProcessorCounters(compoundClientId1));
+        assertEquals(8, appProcessorCounters(compoundClientId2));
+        // The outer per-client set entry survives while the client still has a tracked subscription.
+        assertTrue(sharedSubscriptionCompoundClientIds().containsKey(clientId));
+
+        statsManager.clearSharedApplicationProcessorStats(clientId, subscription2);
+
+        // Clearing the last subscription deregisters its counters and drops the outer set entry.
+        assertEquals(0, appProcessorCounters(compoundClientId2));
+        assertFalse(sharedSubscriptionCompoundClientIds().containsKey(clientId));
     }
 
     @Test

--- a/common/stats/src/main/java/org/thingsboard/mqtt/broker/common/stats/DefaultCounter.java
+++ b/common/stats/src/main/java/org/thingsboard/mqtt/broker/common/stats/DefaultCounter.java
@@ -28,6 +28,10 @@ public class DefaultCounter {
         this.micrometerCounter = micrometerCounter;
     }
 
+    public Counter getMicrometerCounter() {
+        return micrometerCounter;
+    }
+
     public void increment() {
         aiCounter.incrementAndGet();
         micrometerCounter.increment();

--- a/common/stats/src/main/java/org/thingsboard/mqtt/broker/common/stats/DefaultCounter.java
+++ b/common/stats/src/main/java/org/thingsboard/mqtt/broker/common/stats/DefaultCounter.java
@@ -28,7 +28,8 @@ public class DefaultCounter {
         this.micrometerCounter = micrometerCounter;
     }
 
-    public Counter getMicrometerCounter() {
+    // Package-private: only DefaultStatsFactory (same package) needs the backing meter, to deregister it.
+    Counter getMicrometerCounter() {
         return micrometerCounter;
     }
 

--- a/common/stats/src/main/java/org/thingsboard/mqtt/broker/common/stats/DefaultStatsFactory.java
+++ b/common/stats/src/main/java/org/thingsboard/mqtt/broker/common/stats/DefaultStatsFactory.java
@@ -97,6 +97,11 @@ public class DefaultStatsFactory implements StatsFactory {
     }
 
     @Override
+    public void remove(DefaultCounter counter) {
+        meterRegistry.remove(counter.getMicrometerCounter());
+    }
+
+    @Override
     public Timer createTimer(String key, String... tags) {
         Timer.Builder timerBuilder = Timer.builder(key)
                 .tags(tags)

--- a/common/stats/src/main/java/org/thingsboard/mqtt/broker/common/stats/StatsFactory.java
+++ b/common/stats/src/main/java/org/thingsboard/mqtt/broker/common/stats/StatsFactory.java
@@ -32,4 +32,11 @@ public interface StatsFactory {
     MessagesStats createMessagesStats(String key, String... tags);
 
     Timer createTimer(String key, String... tags);
+
+    /**
+     * Deregisters the counter's backing Micrometer meter from the registry so it stops being
+     * scraped. Use when the entity a per-entity counter belongs to (e.g. an application client
+     * or an integration) is gone, to avoid unbounded registry/cardinality growth on churn.
+     */
+    void remove(DefaultCounter counter);
 }


### PR DESCRIPTION
## Pull Request description

**Problem.** The per-Application-client processing counters (`appProcessor.*` — 8 counters tagged with `clientId`, plus the same set under the shared-subscription compound id `clientId_shareName_topicFilter`) are registered in the Micrometer registry but were never removed when a client disconnected. `clearApplicationProcessorStats` / `clearSharedApplicationProcessorStats` only dropped the local `managedApplicationProcessorStats` map entry, and `DefaultCounter.clear()` only zeroes the local `AtomicInteger`. As a result, every Application client / shared subscription that ever connected left its counters permanently in the registry, so both the Micrometer registry (heap) and the `/actuator/prometheus` scrape grew without bound under client churn.

**Fix.** Added `StatsFactory.remove(DefaultCounter)` (implemented in `DefaultStatsFactory` via `MeterRegistry.remove(...)`), and the clear paths in `StatsManagerImpl` now deregister each of the cleared client's 8 counters. The 3 `appProcessor.latency` timers are intentionally left registered: they carry no `clientId` tag, so Micrometer keeps a single shared set aggregated across all Application clients — removing them on one client's disconnect would deregister timers still used by the others.

**Scope of changes:**
- `common/stats`: new `StatsFactory.remove(DefaultCounter)` + `DefaultStatsFactory` implementation; `DefaultCounter.getMicrometerCounter()` accessor.
- `application`: `StatsManagerImpl` clear paths deregister the per-client counters; class javadoc on `DefaultApplicationProcessorStats` documenting that the latency timers are intentionally global (no `clientId` tag — do not add one, cardinality trap); `thingsboard-mqtt-broker.yml` comment on `stats.application-processor.enabled` clarifying the per-client cardinality and the global latency aggregation.

The `APPLICATION_PROCESSOR_STATS_ENABLED` default is unchanged (`true`).

**Documentation notes.** No user-facing configuration keys changed. The `stats.application-processor.enabled` yml comment was expanded. If broker metrics are documented externally, it is worth reflecting that `appProcessor.latency` is a global aggregate (not per-client) and that the per-client `appProcessor.*` counters are deregistered on client disconnect.

## General checklist

- [x] You have reviewed the guidelines [document](https://docs.google.com/document/d/1A4Vc3wrHsY_159b9RG5LOtCryoH6VPwgOhrFEzJKwbI/edit?usp=sharing).
- [x] [Labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels#about-labels) that classify your pull request have been added.
- [x] The [milestone](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones) is specified and corresponds to fix version.
- [x] Description references specific [issue](https://github.com/thingsboard/tbmq/issues).
- [x] Description contains human-readable scope of changes.
- [x] Description contains brief notes about what needs to be added to the documentation.
- [x] No merge conflicts, commented blocks of code, code formatting issues.
- [x] Changes are backward compatible or upgrade script is provided.

## Front-End feature checklist

- [x] Screenshots with affected component(s) are added. The best option is to provide 2 screens: before and after changes;
- [x] If you change the widget or other API, ensure it is backward-compatible or upgrade script is present.

_Not applicable — back-end only, no UI/API changes._

## Back-End feature checklist

- [x] Added corresponding unit and/or integration test(s). Provide written explanation in the PR description if you have failed to add tests.
- [x] If new dependency was added: the dependency tree is checked for conflicts. _(No new dependency.)_

New tests (`StatsManagerImplTest`): per-client counters removed from the registry on clear; shared-subscription compound counters removed on shared clear; the global `appProcessor.latency` timers are retained after clear.
