### PR TITLE
fix(stats): deregister integration processor meters on clear to stop registry leak

### DIFF
--- a/common/integration/cluster-integration-api/src/main/java/org/thingsboard/mqtt/broker/service/DefaultIntegrationStatisticsService.java
+++ b/common/integration/cluster-integration-api/src/main/java/org/thingsboard/mqtt/broker/service/DefaultIntegrationStatisticsService.java
@@ -201,20 +201,29 @@ public class DefaultIntegrationStatisticsService implements IntegrationStatistic
                     .map(statsCounter -> statsCounter.getName() + " = [" + statsCounter.get() + "]")
                     .collect(Collectors.joining(" "));
             log.info("[{}][{}] {}: {}", printName, stats.getIntegrationUuid(), label, msgStatsStr);
-            if (!stats.isActive()) {
-                log.trace("[{}] Clearing inactive Integration stats", stats.getIntegrationUuid());
-                boolean removed = managed.computeIfPresent(stats.getIntegrationUuid(),
-                        (id, oldStats) -> oldStats.isActive() ? oldStats : null) == null;
-                if (removed) {
-                    // Deregister the per-integration counters so they stop being scraped and don't leak the
-                    // Micrometer registry on integration create/delete churn. Tied to the atomic map removal
-                    // above so a same-id re-enable in the meantime keeps its freshly-registered meters.
-                    stats.getStatsCounters().forEach(statsFactory::remove);
-                }
-            } else {
+            if (stats.isActive()) {
                 stats.reset();
+            } else {
+                removeInactiveStats(managed, stats);
             }
         }
+    }
+
+    private void removeInactiveStats(Map<UUID, IntegrationProcessorStats> managed, IntegrationProcessorStats stats) {
+        log.trace("[{}] Clearing inactive Integration stats", stats.getIntegrationUuid());
+        // Drop the entry and deregister its per-integration counters together, inside the remap so both
+        // happen atomically under the map's per-key lock. This stops the counters being scraped and bounds
+        // the Micrometer registry on integration create/delete churn, while keeping the meters of a same-id
+        // integration that was re-enabled in the meantime (seen active here) instead of stranding them.
+        // Removal is deferred to this print cycle (not eager on clear, as StatsManagerImpl does for the
+        // application-processor stats) so an inactive integration still emits one final stats line above.
+        managed.computeIfPresent(stats.getIntegrationUuid(), (id, oldStats) -> {
+            if (oldStats.isActive()) {
+                return oldStats;
+            }
+            oldStats.getStatsCounters().forEach(statsFactory::remove);
+            return null;
+        });
     }
 
     @Override

--- a/common/integration/cluster-integration-api/src/main/java/org/thingsboard/mqtt/broker/service/DefaultIntegrationStatisticsService.java
+++ b/common/integration/cluster-integration-api/src/main/java/org/thingsboard/mqtt/broker/service/DefaultIntegrationStatisticsService.java
@@ -211,19 +211,18 @@ public class DefaultIntegrationStatisticsService implements IntegrationStatistic
 
     private void removeInactiveStats(Map<UUID, IntegrationProcessorStats> managed, IntegrationProcessorStats stats) {
         log.trace("[{}] Clearing inactive Integration stats", stats.getIntegrationUuid());
-        // Drop the entry and deregister its per-integration counters together, inside the remap so both
-        // happen atomically under the map's per-key lock. This stops the counters being scraped and bounds
-        // the Micrometer registry on integration create/delete churn, while keeping the meters of a same-id
-        // integration that was re-enabled in the meantime (seen active here) instead of stranding them.
-        // Removal is deferred to this print cycle (not eager on clear, as StatsManagerImpl does for the
-        // application-processor stats) so an inactive integration still emits one final stats line above.
-        managed.computeIfPresent(stats.getIntegrationUuid(), (id, oldStats) -> {
-            if (oldStats.isActive()) {
-                return oldStats;
-            }
-            oldStats.getStatsCounters().forEach(statsFactory::remove);
-            return null;
-        });
+        // Drop the entry only while it is still inactive: a same-id re-enable that already replaced it with an
+        // active entry is kept (the remap returns that value, so removed == false), so its meters aren't touched.
+        // Keep the remap trivial and deregister the counters afterwards, outside the per-key lock: MeterRegistry
+        // #remove takes the registry lock and fires removed-listeners, which is more than a ConcurrentHashMap
+        // remap should do while holding the bin lock. This mirrors how StatsManagerImpl deregisters its
+        // per-client counters. Removal is deferred to this print cycle (not eager on clear) so an inactive
+        // integration still emits one final stats line above.
+        boolean removed = managed.computeIfPresent(stats.getIntegrationUuid(),
+                (id, oldStats) -> oldStats.isActive() ? oldStats : null) == null;
+        if (removed) {
+            stats.getStatsCounters().forEach(statsFactory::remove);
+        }
     }
 
     @Override

--- a/common/integration/cluster-integration-api/src/main/java/org/thingsboard/mqtt/broker/service/DefaultIntegrationStatisticsService.java
+++ b/common/integration/cluster-integration-api/src/main/java/org/thingsboard/mqtt/broker/service/DefaultIntegrationStatisticsService.java
@@ -203,7 +203,14 @@ public class DefaultIntegrationStatisticsService implements IntegrationStatistic
             log.info("[{}][{}] {}: {}", printName, stats.getIntegrationUuid(), label, msgStatsStr);
             if (!stats.isActive()) {
                 log.trace("[{}] Clearing inactive Integration stats", stats.getIntegrationUuid());
-                managed.computeIfPresent(stats.getIntegrationUuid(), (clientId, oldStats) -> oldStats.isActive() ? oldStats : null);
+                boolean removed = managed.computeIfPresent(stats.getIntegrationUuid(),
+                        (id, oldStats) -> oldStats.isActive() ? oldStats : null) == null;
+                if (removed) {
+                    // Deregister the per-integration counters so they stop being scraped and don't leak the
+                    // Micrometer registry on integration create/delete churn. Tied to the atomic map removal
+                    // above so a same-id re-enable in the meantime keeps its freshly-registered meters.
+                    stats.getStatsCounters().forEach(statsFactory::remove);
+                }
             } else {
                 stats.reset();
             }

--- a/common/integration/cluster-integration-api/src/test/java/org/thingsboard/mqtt/broker/service/DefaultIntegrationStatisticsServiceTest.java
+++ b/common/integration/cluster-integration-api/src/test/java/org/thingsboard/mqtt/broker/service/DefaultIntegrationStatisticsServiceTest.java
@@ -1,0 +1,103 @@
+/**
+ * Copyright © 2016-2026 The Thingsboard Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.thingsboard.mqtt.broker.service;
+
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.thingsboard.mqtt.broker.common.stats.DefaultStatsFactory;
+import org.thingsboard.mqtt.broker.common.stats.StatsFactory;
+import org.thingsboard.mqtt.broker.common.stats.StatsType;
+
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.thingsboard.mqtt.broker.common.stats.StatsConstantNames.INTEGRATION_ID_TAG;
+
+class DefaultIntegrationStatisticsServiceTest {
+
+    private static final String INTEGRATION_PROCESSOR = StatsType.INTEGRATION_PROCESSOR.getPrintName();
+    private static final String INTEGRATION_EVENT_PROCESSOR = StatsType.INTEGRATION_EVENT_PROCESSOR.getPrintName();
+
+    private SimpleMeterRegistry meterRegistry;
+    private DefaultIntegrationStatisticsService service;
+
+    @BeforeEach
+    void setUp() {
+        meterRegistry = new SimpleMeterRegistry();
+        StatsFactory statsFactory = new DefaultStatsFactory(meterRegistry);
+        service = new DefaultIntegrationStatisticsService(statsFactory);
+    }
+
+    @AfterEach
+    void tearDown() {
+        service.shutdown();
+    }
+
+    private int counters(String key, UUID integrationId) {
+        return meterRegistry.find(key).tag(INTEGRATION_ID_TAG, integrationId.toString()).counters().size();
+    }
+
+    @Test
+    void givenIntegrationProcessorStats_whenClearedAndPrinted_thenPerIntegrationCountersRemovedFromRegistry() {
+        UUID integrationId = UUID.fromString("00000000-0000-0000-0000-000000000001");
+        service.createIntegrationProcessorStats(integrationId);
+        assertThat(counters(INTEGRATION_PROCESSOR, integrationId)).isEqualTo(8);
+
+        service.clearIntegrationProcessorStats(integrationId);
+        service.printStats();
+
+        assertThat(counters(INTEGRATION_PROCESSOR, integrationId)).isZero();
+    }
+
+    @Test
+    void givenIntegrationEventProcessorStats_whenClearedAndPrinted_thenPerIntegrationCountersRemovedFromRegistry() {
+        UUID integrationId = UUID.fromString("00000000-0000-0000-0000-000000000002");
+        service.createIntegrationEventProcessorStats(integrationId);
+        assertThat(counters(INTEGRATION_EVENT_PROCESSOR, integrationId)).isEqualTo(8);
+
+        service.clearIntegrationEventProcessorStats(integrationId);
+        service.printStats();
+
+        assertThat(counters(INTEGRATION_EVENT_PROCESSOR, integrationId)).isZero();
+    }
+
+    @Test
+    void givenActiveIntegrationProcessorStats_whenPrinted_thenCountersRetained() {
+        UUID integrationId = UUID.fromString("00000000-0000-0000-0000-000000000003");
+        service.createIntegrationProcessorStats(integrationId);
+
+        // No clear -> stats stay active -> printStats resets the local counts but must NOT deregister.
+        service.printStats();
+
+        assertThat(counters(INTEGRATION_PROCESSOR, integrationId)).isEqualTo(8);
+    }
+
+    @Test
+    void givenTwoIntegrations_whenOneCleared_thenOnlyThatIntegrationsCountersRemoved() {
+        UUID cleared = UUID.fromString("00000000-0000-0000-0000-000000000004");
+        UUID retained = UUID.fromString("00000000-0000-0000-0000-000000000005");
+        service.createIntegrationProcessorStats(cleared);
+        service.createIntegrationProcessorStats(retained);
+
+        service.clearIntegrationProcessorStats(cleared);
+        service.printStats();
+
+        assertThat(counters(INTEGRATION_PROCESSOR, cleared)).isZero();
+        assertThat(counters(INTEGRATION_PROCESSOR, retained)).isEqualTo(8);
+    }
+}

--- a/common/integration/cluster-integration-api/src/test/java/org/thingsboard/mqtt/broker/service/DefaultIntegrationStatisticsServiceTest.java
+++ b/common/integration/cluster-integration-api/src/test/java/org/thingsboard/mqtt/broker/service/DefaultIntegrationStatisticsServiceTest.java
@@ -37,8 +37,6 @@ import static org.thingsboard.mqtt.broker.common.stats.StatsConstantNames.INTEGR
 
 class DefaultIntegrationStatisticsServiceTest {
 
-    private static final String INTEGRATION_PROCESSOR = StatsType.INTEGRATION_PROCESSOR.getPrintName();
-
     private SimpleMeterRegistry meterRegistry;
     private DefaultIntegrationStatisticsService service;
 
@@ -59,7 +57,7 @@ class DefaultIntegrationStatisticsServiceTest {
      * metric name they register under, but both flow through the same {@code printProcessorStats}
      * cleanup — so the behavioural tests below are parameterized over both to keep them in lockstep.
      */
-    private enum Stream {
+    private enum StatStream {
         MESSAGE(StatsType.INTEGRATION_PROCESSOR.getPrintName()) {
             @Override
             IntegrationProcessorStats create(DefaultIntegrationStatisticsService service, UUID integrationId) {
@@ -85,7 +83,7 @@ class DefaultIntegrationStatisticsServiceTest {
 
         final String key;
 
-        Stream(String key) {
+        StatStream(String key) {
             this.key = key;
         }
 
@@ -104,8 +102,8 @@ class DefaultIntegrationStatisticsServiceTest {
     }
 
     @ParameterizedTest
-    @EnumSource(Stream.class)
-    void givenProcessorStats_whenClearedAndPrinted_thenPerIntegrationCountersRemovedFromRegistry(Stream stream) {
+    @EnumSource(StatStream.class)
+    void givenProcessorStats_whenClearedAndPrinted_thenPerIntegrationCountersRemovedFromRegistry(StatStream stream) {
         UUID integrationId = UUID.randomUUID();
         IntegrationProcessorStats created = stream.create(service, integrationId);
         int registeredCounters = created.getStatsCounters().size();
@@ -118,8 +116,8 @@ class DefaultIntegrationStatisticsServiceTest {
     }
 
     @ParameterizedTest
-    @EnumSource(Stream.class)
-    void givenActiveProcessorStats_whenPrinted_thenCountersRetained(Stream stream) {
+    @EnumSource(StatStream.class)
+    void givenActiveProcessorStats_whenPrinted_thenCountersRetained(StatStream stream) {
         UUID integrationId = UUID.randomUUID();
         IntegrationProcessorStats created = stream.create(service, integrationId);
         int registeredCounters = created.getStatsCounters().size();
@@ -131,8 +129,8 @@ class DefaultIntegrationStatisticsServiceTest {
     }
 
     @ParameterizedTest
-    @EnumSource(Stream.class)
-    void givenTwoIntegrations_whenOneCleared_thenOnlyThatIntegrationsCountersRemoved(Stream stream) {
+    @EnumSource(StatStream.class)
+    void givenTwoIntegrations_whenOneCleared_thenOnlyThatIntegrationsCountersRemoved(StatStream stream) {
         UUID cleared = UUID.randomUUID();
         UUID retained = UUID.randomUUID();
         stream.create(service, cleared);
@@ -151,19 +149,22 @@ class DefaultIntegrationStatisticsServiceTest {
         // Register the real per-integration counters for this id.
         IntegrationProcessorStats registered = service.createIntegrationProcessorStats(integrationId);
         int registeredCounters = registered.getStatsCounters().size();
-        assertThat(counters(INTEGRATION_PROCESSOR, integrationId)).isEqualTo(registeredCounters);
+        assertThat(counters(StatStream.MESSAGE.key, integrationId)).isEqualTo(registeredCounters);
 
-        // Simulate a concurrent re-enable landing between printStats' values() snapshot and the atomic
-        // remap: the entry reports inactive on the snapshot-loop check (so cleanup runs), but by the time
-        // the remap re-reads it the entry is active again, so its meters must be kept, not deregistered.
+        // Simulate a concurrent re-enable landing between printStats' values() snapshot and the remap: the
+        // entry reports inactive on the snapshot-loop check (so cleanup runs), but by the time the remap
+        // re-reads it the entry is active again, so its meters must be kept, not deregistered.
         IntegrationProcessorStats reEnabling = mock(IntegrationProcessorStats.class);
         when(reEnabling.getIntegrationUuid()).thenReturn(integrationId);
+        // isActive() is read twice per entry: first the snapshot-loop check in printProcessorStats, then the
+        // remap re-read in removeInactiveStats. Returning false then true drives the "inactive at snapshot,
+        // active at remap" branch — keep this call count in sync with printProcessorStats.
         when(reEnabling.isActive()).thenReturn(false, true);
         when(reEnabling.getStatsCounters()).thenReturn(registered.getStatsCounters());
         managedProcessorStats().put(integrationId, reEnabling);
 
         service.printStats();
 
-        assertThat(counters(INTEGRATION_PROCESSOR, integrationId)).isEqualTo(registeredCounters);
+        assertThat(counters(StatStream.MESSAGE.key, integrationId)).isEqualTo(registeredCounters);
     }
 }

--- a/common/integration/cluster-integration-api/src/test/java/org/thingsboard/mqtt/broker/service/DefaultIntegrationStatisticsServiceTest.java
+++ b/common/integration/cluster-integration-api/src/test/java/org/thingsboard/mqtt/broker/service/DefaultIntegrationStatisticsServiceTest.java
@@ -19,19 +19,25 @@ import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.springframework.test.util.ReflectionTestUtils;
 import org.thingsboard.mqtt.broker.common.stats.DefaultStatsFactory;
 import org.thingsboard.mqtt.broker.common.stats.StatsFactory;
 import org.thingsboard.mqtt.broker.common.stats.StatsType;
+import org.thingsboard.mqtt.broker.integration.api.stats.IntegrationProcessorStats;
 
+import java.util.Map;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 import static org.thingsboard.mqtt.broker.common.stats.StatsConstantNames.INTEGRATION_ID_TAG;
 
 class DefaultIntegrationStatisticsServiceTest {
 
     private static final String INTEGRATION_PROCESSOR = StatsType.INTEGRATION_PROCESSOR.getPrintName();
-    private static final String INTEGRATION_EVENT_PROCESSOR = StatsType.INTEGRATION_EVENT_PROCESSOR.getPrintName();
 
     private SimpleMeterRegistry meterRegistry;
     private DefaultIntegrationStatisticsService service;
@@ -48,56 +54,116 @@ class DefaultIntegrationStatisticsServiceTest {
         service.shutdown();
     }
 
+    /**
+     * The two per-integration stat streams differ only by which create/clear pair feeds them and the
+     * metric name they register under, but both flow through the same {@code printProcessorStats}
+     * cleanup — so the behavioural tests below are parameterized over both to keep them in lockstep.
+     */
+    private enum Stream {
+        MESSAGE(StatsType.INTEGRATION_PROCESSOR.getPrintName()) {
+            @Override
+            IntegrationProcessorStats create(DefaultIntegrationStatisticsService service, UUID integrationId) {
+                return service.createIntegrationProcessorStats(integrationId);
+            }
+
+            @Override
+            void clear(DefaultIntegrationStatisticsService service, UUID integrationId) {
+                service.clearIntegrationProcessorStats(integrationId);
+            }
+        },
+        EVENT(StatsType.INTEGRATION_EVENT_PROCESSOR.getPrintName()) {
+            @Override
+            IntegrationProcessorStats create(DefaultIntegrationStatisticsService service, UUID integrationId) {
+                return service.createIntegrationEventProcessorStats(integrationId);
+            }
+
+            @Override
+            void clear(DefaultIntegrationStatisticsService service, UUID integrationId) {
+                service.clearIntegrationEventProcessorStats(integrationId);
+            }
+        };
+
+        final String key;
+
+        Stream(String key) {
+            this.key = key;
+        }
+
+        abstract IntegrationProcessorStats create(DefaultIntegrationStatisticsService service, UUID integrationId);
+
+        abstract void clear(DefaultIntegrationStatisticsService service, UUID integrationId);
+    }
+
     private int counters(String key, UUID integrationId) {
         return meterRegistry.find(key).tag(INTEGRATION_ID_TAG, integrationId.toString()).counters().size();
     }
 
-    @Test
-    void givenIntegrationProcessorStats_whenClearedAndPrinted_thenPerIntegrationCountersRemovedFromRegistry() {
-        UUID integrationId = UUID.fromString("00000000-0000-0000-0000-000000000001");
-        service.createIntegrationProcessorStats(integrationId);
-        assertThat(counters(INTEGRATION_PROCESSOR, integrationId)).isEqualTo(8);
-
-        service.clearIntegrationProcessorStats(integrationId);
-        service.printStats();
-
-        assertThat(counters(INTEGRATION_PROCESSOR, integrationId)).isZero();
+    @SuppressWarnings("unchecked")
+    private Map<UUID, IntegrationProcessorStats> managedProcessorStats() {
+        return (Map<UUID, IntegrationProcessorStats>) ReflectionTestUtils.getField(service, "managedIntegrationProcessorStats");
     }
 
-    @Test
-    void givenIntegrationEventProcessorStats_whenClearedAndPrinted_thenPerIntegrationCountersRemovedFromRegistry() {
-        UUID integrationId = UUID.fromString("00000000-0000-0000-0000-000000000002");
-        service.createIntegrationEventProcessorStats(integrationId);
-        assertThat(counters(INTEGRATION_EVENT_PROCESSOR, integrationId)).isEqualTo(8);
+    @ParameterizedTest
+    @EnumSource(Stream.class)
+    void givenProcessorStats_whenClearedAndPrinted_thenPerIntegrationCountersRemovedFromRegistry(Stream stream) {
+        UUID integrationId = UUID.randomUUID();
+        IntegrationProcessorStats created = stream.create(service, integrationId);
+        int registeredCounters = created.getStatsCounters().size();
+        assertThat(counters(stream.key, integrationId)).isEqualTo(registeredCounters);
 
-        service.clearIntegrationEventProcessorStats(integrationId);
+        stream.clear(service, integrationId);
         service.printStats();
 
-        assertThat(counters(INTEGRATION_EVENT_PROCESSOR, integrationId)).isZero();
+        assertThat(counters(stream.key, integrationId)).isZero();
     }
 
-    @Test
-    void givenActiveIntegrationProcessorStats_whenPrinted_thenCountersRetained() {
-        UUID integrationId = UUID.fromString("00000000-0000-0000-0000-000000000003");
-        service.createIntegrationProcessorStats(integrationId);
+    @ParameterizedTest
+    @EnumSource(Stream.class)
+    void givenActiveProcessorStats_whenPrinted_thenCountersRetained(Stream stream) {
+        UUID integrationId = UUID.randomUUID();
+        IntegrationProcessorStats created = stream.create(service, integrationId);
+        int registeredCounters = created.getStatsCounters().size();
 
         // No clear -> stats stay active -> printStats resets the local counts but must NOT deregister.
         service.printStats();
 
-        assertThat(counters(INTEGRATION_PROCESSOR, integrationId)).isEqualTo(8);
+        assertThat(counters(stream.key, integrationId)).isEqualTo(registeredCounters);
+    }
+
+    @ParameterizedTest
+    @EnumSource(Stream.class)
+    void givenTwoIntegrations_whenOneCleared_thenOnlyThatIntegrationsCountersRemoved(Stream stream) {
+        UUID cleared = UUID.randomUUID();
+        UUID retained = UUID.randomUUID();
+        stream.create(service, cleared);
+        IntegrationProcessorStats retainedStats = stream.create(service, retained);
+
+        stream.clear(service, cleared);
+        service.printStats();
+
+        assertThat(counters(stream.key, cleared)).isZero();
+        assertThat(counters(stream.key, retained)).isEqualTo(retainedStats.getStatsCounters().size());
     }
 
     @Test
-    void givenTwoIntegrations_whenOneCleared_thenOnlyThatIntegrationsCountersRemoved() {
-        UUID cleared = UUID.fromString("00000000-0000-0000-0000-000000000004");
-        UUID retained = UUID.fromString("00000000-0000-0000-0000-000000000005");
-        service.createIntegrationProcessorStats(cleared);
-        service.createIntegrationProcessorStats(retained);
+    void givenSameIdReEnabledBetweenSnapshotAndRemap_whenPrinted_thenCountersRetained() {
+        UUID integrationId = UUID.randomUUID();
+        // Register the real per-integration counters for this id.
+        IntegrationProcessorStats registered = service.createIntegrationProcessorStats(integrationId);
+        int registeredCounters = registered.getStatsCounters().size();
+        assertThat(counters(INTEGRATION_PROCESSOR, integrationId)).isEqualTo(registeredCounters);
 
-        service.clearIntegrationProcessorStats(cleared);
+        // Simulate a concurrent re-enable landing between printStats' values() snapshot and the atomic
+        // remap: the entry reports inactive on the snapshot-loop check (so cleanup runs), but by the time
+        // the remap re-reads it the entry is active again, so its meters must be kept, not deregistered.
+        IntegrationProcessorStats reEnabling = mock(IntegrationProcessorStats.class);
+        when(reEnabling.getIntegrationUuid()).thenReturn(integrationId);
+        when(reEnabling.isActive()).thenReturn(false, true);
+        when(reEnabling.getStatsCounters()).thenReturn(registered.getStatsCounters());
+        managedProcessorStats().put(integrationId, reEnabling);
+
         service.printStats();
 
-        assertThat(counters(INTEGRATION_PROCESSOR, cleared)).isZero();
-        assertThat(counters(INTEGRATION_PROCESSOR, retained)).isEqualTo(8);
+        assertThat(counters(INTEGRATION_PROCESSOR, integrationId)).isEqualTo(registeredCounters);
     }
 }


### PR DESCRIPTION
## Pull Request description

**Problem.** The per-integration processing counters — `integrationProcessor.*` and `integrationEventProcessor.*` (8 `StatsCounter`s each, tagged with `integrationId`) — are registered in the Micrometer registry but never removed. `clearIntegrationProcessorStats` / `clearIntegrationEventProcessorStats` only flip `active = false` (`disable(...)`); the next `printStats()` logs a final line and drops the entry from the managed map, but `meterRegistry.remove(...)` is never called. So on integration create/delete churn (each recreate mints a fresh UUID) the per-integration Micrometer series accumulate for the process lifetime — a registry/cardinality leak on the integration-executor, doubled by the event-processor stream (16 series per integration).

This is the same class of leak fixed for the application-processor counters in #335, and reuses the `StatsFactory.remove(DefaultCounter)` primitive added there.

**Fix.** `printProcessorStats` now deregisters the counters at the point the inactive entry is atomically dropped from the managed map. Removal is tied to the map removal outcome (`computeIfPresent(...) == null`), so if the same integration id is re-enabled during the ≤ one-print-interval window between clear and the next print, its freshly-registered meters are kept rather than stranded:

```java
if (!stats.isActive()) {
    boolean removed = managed.computeIfPresent(stats.getIntegrationUuid(),
            (id, oldStats) -> oldStats.isActive() ? oldStats : null) == null;
    if (removed) {
        stats.getStatsCounters().forEach(statsFactory::remove);
    }
}
```

Applies to both the message stream (`integrationProcessor.*`) and the event stream (`integrationEventProcessor.*`).

**Scope of changes:**
- `common/integration/cluster-integration-api`: `DefaultIntegrationStatisticsService.printProcessorStats` deregisters per-integration counters on the inactive-clear drop.
- New unit tests (`DefaultIntegrationStatisticsServiceTest`).

**A related item that turned out NOT to need a change.** A metrics audit flagged a possible broker-side `stats.ie.enabled` gating gap (the `integration_stats_counter`/`_gauge` lifecycle metrics not materializing on a broker node). On investigation this is correct by design: those metrics are emitted only via the integration lifecycle state machine (`handleIntegrationLifecycleMsg` → `processStart`/`processStop` → `onIntegrationStateUpdate`/`onIntegrationsCountUpdate`), whose only non-test caller runs on the integration-executor — exactly where `stats.ie.enabled` is defined. The broker only performs integration validation/CRUD and never emits these metrics. No gating/config change is made.

**Documentation notes.** No user-facing configuration keys changed; no documentation update required.

## General checklist

- [x] You have reviewed the guidelines [document](https://docs.google.com/document/d/1A4Vc3wrHsY_159b9RG5LOtCryoH6VPwgOhrFEzJKwbI/edit?usp=sharing).
- [x] [Labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels#about-labels) that classify your pull request have been added.
- [x] The [milestone](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones) is specified and corresponds to fix version.
- [x] Description references specific [issue](https://github.com/thingsboard/tbmq/issues).
- [x] Description contains human-readable scope of changes.
- [x] Description contains brief notes about what needs to be added to the documentation.
- [x] No merge conflicts, commented blocks of code, code formatting issues.
- [x] Changes are backward compatible or upgrade script is provided.

## Front-End feature checklist

_Not applicable — back-end only, no UI/API changes._

## Back-End feature checklist

- [x] Added corresponding unit and/or integration test(s). Provide written explanation in the PR description if you have failed to add tests.
- [x] If new dependency was added: the dependency tree is checked for conflicts. _(No new dependency.)_

New tests (`DefaultIntegrationStatisticsServiceTest`): per-integration counters removed from the registry after clear + print for both the message and event streams; active (uncleared) integration counters retained after print; clearing one integration leaves another's counters intact.
