### PR TITLE
fix(mqtt): return per-filter UNSUBACK reason codes

### DIFF
--- a/application/src/main/java/org/thingsboard/mqtt/broker/actors/client/service/handlers/MqttUnsubscribeHandler.java
+++ b/application/src/main/java/org/thingsboard/mqtt/broker/actors/client/service/handlers/MqttUnsubscribeHandler.java
@@ -81,14 +81,10 @@ public class MqttUnsubscribeHandler {
                 .map(TopicSubscription::getTopicFilter)
                 .collect(Collectors.toSet());
         return requestedTopics.stream()
-                .map(topic -> removedTopicFilters.contains(toTopicFilter(topic))
+                .map(topic -> removedTopicFilters.contains(NettyMqttConverter.getTopicFilter(topic))
                         ? MqttReasonCodeResolver.unsubAckSuccess(ctx)
                         : MqttReasonCodeResolver.unsubAckNoSubscriptionExisted(ctx))
                 .collect(Collectors.toList());
-    }
-
-    private static String toTopicFilter(String topic) {
-        return NettyMqttConverter.isSharedTopic(topic) ? NettyMqttConverter.getTopicFilter(topic) : topic;
     }
 
     private void stopProcessingApplicationSharedSubscriptions(ClientSessionCtx ctx, List<String> topics) {

--- a/application/src/main/java/org/thingsboard/mqtt/broker/actors/client/service/handlers/MqttUnsubscribeHandler.java
+++ b/application/src/main/java/org/thingsboard/mqtt/broker/actors/client/service/handlers/MqttUnsubscribeHandler.java
@@ -50,7 +50,7 @@ public class MqttUnsubscribeHandler {
     public void process(ClientSessionCtx ctx, MqttUnsubscribeMsg msg) {
         log.trace("[{}][{}] Processing unsubscribe, messageId - {}, topic filters - {}", ctx.getClientId(), ctx.getSessionId(), msg.getMessageId(), msg.getTopics());
 
-        clientSubscriptionService.unsubscribeAndPersist(ctx.getClientId(), msg.getTopics(),
+        clientSubscriptionService.unsubscribeAndPersistReportingRemoved(ctx.getClientId(), msg.getTopics(),
                 new UnsubscribeCallback() {
                     @Override
                     public void onSuccess(List<TopicSubscription> removedSubscriptions) {

--- a/application/src/main/java/org/thingsboard/mqtt/broker/actors/client/service/handlers/MqttUnsubscribeHandler.java
+++ b/application/src/main/java/org/thingsboard/mqtt/broker/actors/client/service/handlers/MqttUnsubscribeHandler.java
@@ -33,6 +33,7 @@ import org.thingsboard.mqtt.broker.service.subscription.shared.TopicSharedSubscr
 import org.thingsboard.mqtt.broker.session.ClientSessionCtx;
 import org.thingsboard.mqtt.broker.util.MqttReasonCodeResolver;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -67,6 +68,11 @@ public class MqttUnsubscribeHandler {
                     @Override
                     public void onFailure(Throwable t) {
                         log.warn("[{}][{}] Failed to process client unsubscription", ctx.getClientId(), ctx.getSessionId(), t);
+                        // The Server MUST still respond with an UNSUBACK (MQTT-3.10.4-5). The persist failed, so the removed
+                        // set is unknown: every requested filter gets an error code (null => codeless UNSUBACK on MQTT 3.1.1).
+                        MqttMessage unSubAckMessage = mqttMessageGenerator.createUnSubAckMessage(
+                                msg.getMessageId(), getFailureCodes(ctx, msg.getTopics()));
+                        ctx.getChannel().writeAndFlush(unSubAckMessage);
                     }
                 });
 
@@ -85,6 +91,12 @@ public class MqttUnsubscribeHandler {
                         ? MqttReasonCodeResolver.unsubAckSuccess(ctx)
                         : MqttReasonCodeResolver.unsubAckNoSubscriptionExisted(ctx))
                 .collect(Collectors.toList());
+    }
+
+    // On persist failure the removed set is unknown, so every requested filter gets the same error code
+    // (UNSPECIFIED_ERROR on MQTT 5, null => codeless UNSUBACK on MQTT 3.1.1).
+    private List<UnsubAck> getFailureCodes(ClientSessionCtx ctx, List<String> requestedTopics) {
+        return Collections.nCopies(requestedTopics.size(), MqttReasonCodeResolver.unsubAckError(ctx));
     }
 
     private void stopProcessingApplicationSharedSubscriptions(ClientSessionCtx ctx, List<String> topics) {

--- a/application/src/main/java/org/thingsboard/mqtt/broker/actors/client/service/handlers/MqttUnsubscribeHandler.java
+++ b/application/src/main/java/org/thingsboard/mqtt/broker/actors/client/service/handlers/MqttUnsubscribeHandler.java
@@ -23,9 +23,9 @@ import org.springframework.stereotype.Service;
 import org.springframework.util.CollectionUtils;
 import org.thingsboard.mqtt.broker.actors.client.messages.mqtt.MqttUnsubscribeMsg;
 import org.thingsboard.mqtt.broker.actors.client.service.subscription.ClientSubscriptionService;
+import org.thingsboard.mqtt.broker.actors.client.service.subscription.UnsubscribeCallback;
 import org.thingsboard.mqtt.broker.adaptor.NettyMqttConverter;
 import org.thingsboard.mqtt.broker.common.data.subscription.TopicSubscription;
-import org.thingsboard.mqtt.broker.common.data.util.CallbackUtil;
 import org.thingsboard.mqtt.broker.service.integration.IntegrationLifecycleEventPublisher;
 import org.thingsboard.mqtt.broker.service.mqtt.MqttMessageGenerator;
 import org.thingsboard.mqtt.broker.service.mqtt.persistence.application.ApplicationPersistenceProcessor;
@@ -33,10 +33,7 @@ import org.thingsboard.mqtt.broker.service.subscription.shared.TopicSharedSubscr
 import org.thingsboard.mqtt.broker.session.ClientSessionCtx;
 import org.thingsboard.mqtt.broker.util.MqttReasonCodeResolver;
 
-import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -53,60 +50,45 @@ public class MqttUnsubscribeHandler {
     public void process(ClientSessionCtx ctx, MqttUnsubscribeMsg msg) {
         log.trace("[{}][{}] Processing unsubscribe, messageId - {}, topic filters - {}", ctx.getClientId(), ctx.getSessionId(), msg.getMessageId(), msg.getTopics());
 
-        MqttMessage unSubAckMessage = mqttMessageGenerator.createUnSubAckMessage(msg.getMessageId(), getCodes(ctx, msg));
-        // MQTT allows UNSUBSCRIBE for filters the client never subscribed to. Emit CLIENT_UNSUBSCRIBED only for
-        // the subscriptions actually removed (symmetric with CLIENT_SUBSCRIBED, which emits only the granted ones).
-        List<TopicSubscription> removedSubscriptions = getRemovedSubscriptions(ctx.getClientId(), msg.getTopics());
         clientSubscriptionService.unsubscribeAndPersist(ctx.getClientId(), msg.getTopics(),
-                CallbackUtil.createCallback(
-                        () -> {
-                            ctx.getChannel().writeAndFlush(unSubAckMessage);
-                            if (!removedSubscriptions.isEmpty()) {
-                                integrationLifecycleEventPublisher.publishUnsubscribed(ctx, removedSubscriptions);
-                            }
-                        },
-                        t -> log.warn("[{}][{}] Failed to process client unsubscription", ctx.getClientId(), ctx.getSessionId(), t)
-                ));
+                new UnsubscribeCallback() {
+                    @Override
+                    public void onSuccess(List<TopicSubscription> removedSubscriptions) {
+                        MqttMessage unSubAckMessage = mqttMessageGenerator.createUnSubAckMessage(
+                                msg.getMessageId(), getCodes(ctx, msg.getTopics(), removedSubscriptions));
+                        ctx.getChannel().writeAndFlush(unSubAckMessage);
+                        // MQTT allows UNSUBSCRIBE for filters the client never subscribed to. Emit CLIENT_UNSUBSCRIBED only for
+                        // the subscriptions actually removed (symmetric with CLIENT_SUBSCRIBED, which emits only the granted ones).
+                        if (!removedSubscriptions.isEmpty()) {
+                            integrationLifecycleEventPublisher.publishUnsubscribed(ctx, removedSubscriptions);
+                        }
+                    }
+
+                    @Override
+                    public void onFailure(Throwable t) {
+                        log.warn("[{}][{}] Failed to process client unsubscription", ctx.getClientId(), ctx.getSessionId(), t);
+                    }
+                });
 
         stopProcessingApplicationSharedSubscriptions(ctx, msg.getTopics());
     }
 
-    private List<TopicSubscription> getRemovedSubscriptions(String clientId, List<String> requestedTopics) {
-        Set<TopicSubscription> currentSubscriptions = clientSubscriptionService.getClientSubscriptions(clientId);
-        if (CollectionUtils.isEmpty(currentSubscriptions)) {
-            return List.of();
-        }
-        // Index current subscriptions by (shareName, bare topic filter) so a requested $share/<group>/<filter>
-        // resolves to that exact shared subscription (carrying its shareName), and a bare filter to the regular one.
-        Map<SubKey, TopicSubscription> byKey = new HashMap<>();
-        for (TopicSubscription sub : currentSubscriptions) {
-            byKey.putIfAbsent(new SubKey(sub.getShareName(), sub.getTopicFilter()), sub);
-        }
-        List<TopicSubscription> removed = new ArrayList<>();
-        for (String requested : requestedTopics) {
-            String shareName = NettyMqttConverter.isSharedTopic(requested) ? NettyMqttConverter.getShareName(requested) : null;
-            TopicSubscription sub = byKey.get(new SubKey(shareName, toTopicFilter(requested)));
-            if (sub != null) {
-                removed.add(sub);
-            }
-        }
-        return removed;
-    }
-
-    // Composite lookup key; shareName is null for a regular subscription, the group name for a shared one.
-    private record SubKey(String shareName, String topicFilter) {
+    // A requested filter that matched a removed subscription gets SUCCESS; one the client was not subscribed to gets
+    // NO_SUBSCRIPTION_EXISTED (both null on MQTT 3.1.1 => no reason codes). Matching is by bare topic filter, mirroring
+    // how the removal itself matches, so codes always agree with what was actually removed.
+    private List<UnsubAck> getCodes(ClientSessionCtx ctx, List<String> requestedTopics, List<TopicSubscription> removedSubscriptions) {
+        Set<String> removedTopicFilters = removedSubscriptions.stream()
+                .map(TopicSubscription::getTopicFilter)
+                .collect(Collectors.toSet());
+        return requestedTopics.stream()
+                .map(topic -> removedTopicFilters.contains(toTopicFilter(topic))
+                        ? MqttReasonCodeResolver.unsubAckSuccess(ctx)
+                        : MqttReasonCodeResolver.unsubAckNoSubscriptionExisted(ctx))
+                .collect(Collectors.toList());
     }
 
     private static String toTopicFilter(String topic) {
         return NettyMqttConverter.isSharedTopic(topic) ? NettyMqttConverter.getTopicFilter(topic) : topic;
-    }
-
-    private List<UnsubAck> getCodes(ClientSessionCtx ctx, MqttUnsubscribeMsg msg) {
-        return msg
-                .getTopics()
-                .stream()
-                .map(s -> MqttReasonCodeResolver.unsubAckSuccess(ctx))
-                .collect(Collectors.toList());
     }
 
     private void stopProcessingApplicationSharedSubscriptions(ClientSessionCtx ctx, List<String> topics) {

--- a/application/src/main/java/org/thingsboard/mqtt/broker/actors/client/service/subscription/ClientSubscriptionService.java
+++ b/application/src/main/java/org/thingsboard/mqtt/broker/actors/client/service/subscription/ClientSubscriptionService.java
@@ -43,6 +43,8 @@ public interface ClientSubscriptionService extends ClientSubscriptionCache {
 
     void unsubscribeAndPersist(String clientId, Collection<String> topicFilters, BasicCallback callback);
 
+    void unsubscribeAndPersist(String clientId, Collection<String> topicFilters, UnsubscribeCallback callback);
+
     void unsubscribeInternally(String clientId, Collection<String> topicFilters);
 
     void clearSubscriptionsAndPersist(String clientId);

--- a/application/src/main/java/org/thingsboard/mqtt/broker/actors/client/service/subscription/ClientSubscriptionService.java
+++ b/application/src/main/java/org/thingsboard/mqtt/broker/actors/client/service/subscription/ClientSubscriptionService.java
@@ -43,7 +43,7 @@ public interface ClientSubscriptionService extends ClientSubscriptionCache {
 
     void unsubscribeAndPersist(String clientId, Collection<String> topicFilters, BasicCallback callback);
 
-    void unsubscribeAndPersist(String clientId, Collection<String> topicFilters, UnsubscribeCallback callback);
+    void unsubscribeAndPersistReportingRemoved(String clientId, Collection<String> topicFilters, UnsubscribeCallback callback);
 
     void unsubscribeInternally(String clientId, Collection<String> topicFilters);
 

--- a/application/src/main/java/org/thingsboard/mqtt/broker/actors/client/service/subscription/ClientSubscriptionServiceImpl.java
+++ b/application/src/main/java/org/thingsboard/mqtt/broker/actors/client/service/subscription/ClientSubscriptionServiceImpl.java
@@ -67,7 +67,7 @@ public class ClientSubscriptionServiceImpl implements ClientSubscriptionService 
     @Override
     public void init(Map<SubscriptionsSourceKey, Set<TopicSubscription>> clientTopicSubscriptions) {
         clientSubscriptionsMap = new ConcurrentHashMap<>();
-        clientTopicSubscriptions.forEach((key, value) -> clientSubscriptionsMap.put(key.getId(), value));
+        clientTopicSubscriptions.forEach((key, val) -> clientSubscriptionsMap.put(key.getId(), val));
         statsManager.registerClientSubscriptionsStats(clientSubscriptionsMap);
 
         clientSubscriptionsMap.forEach((clientId, topicSubscriptions) -> {
@@ -183,7 +183,7 @@ public class ClientSubscriptionServiceImpl implements ClientSubscriptionService 
 
     private List<String> extractTopicFilterFromSharedTopic(Collection<String> topicFilters) {
         return topicFilters.stream()
-                .map(tf -> NettyMqttConverter.isSharedTopic(tf) ? NettyMqttConverter.getTopicFilter(tf) : tf)
+                .map(NettyMqttConverter::getTopicFilter)
                 .collect(Collectors.toList());
     }
 

--- a/application/src/main/java/org/thingsboard/mqtt/broker/actors/client/service/subscription/ClientSubscriptionServiceImpl.java
+++ b/application/src/main/java/org/thingsboard/mqtt/broker/actors/client/service/subscription/ClientSubscriptionServiceImpl.java
@@ -137,9 +137,9 @@ public class ClientSubscriptionServiceImpl implements ClientSubscriptionService 
     @Override
     public void unsubscribeAndPersist(String clientId, Collection<String> topicFilters, BasicCallback callback) {
         log.trace("[{}] Unsubscribe and persist {}.", clientId, topicFilters);
-        Set<TopicSubscription> updatedClientSubscriptions = unsubscribe(clientId, topicFilters).updatedSubscriptions();
+        Set<TopicSubscription> survivingClientSubscriptions = unsubscribe(clientId, topicFilters).survivingSubscriptions();
 
-        subscriptionPersistenceService.persistClientSubscriptionsAsync(clientId, updatedClientSubscriptions, callback);
+        subscriptionPersistenceService.persistClientSubscriptionsAsync(clientId, survivingClientSubscriptions, callback);
     }
 
     @Override
@@ -147,7 +147,7 @@ public class ClientSubscriptionServiceImpl implements ClientSubscriptionService 
         log.trace("[{}] Unsubscribing from {} and reporting removed.", clientId, topicFilters);
         UnsubscribeResult result = unsubscribe(clientId, topicFilters);
 
-        subscriptionPersistenceService.persistClientSubscriptionsAsync(clientId, result.updatedSubscriptions(),
+        subscriptionPersistenceService.persistClientSubscriptionsAsync(clientId, result.survivingSubscriptions(),
                 createCallback(
                         () -> callback.onSuccess(result.removedSubscriptions()),
                         callback::onFailure));
@@ -176,8 +176,8 @@ public class ClientSubscriptionServiceImpl implements ClientSubscriptionService 
         return new UnsubscribeResult(clientSubscriptions, removedSubscriptions);
     }
 
-    // Surviving subscriptions to persist, plus the ones actually removed (for UNSUBACK codes and lifecycle events).
-    private record UnsubscribeResult(Set<TopicSubscription> updatedSubscriptions,
+    // survivingSubscriptions are persisted; removedSubscriptions feed the UNSUBACK codes and lifecycle events.
+    private record UnsubscribeResult(Set<TopicSubscription> survivingSubscriptions,
                                      List<TopicSubscription> removedSubscriptions) {
     }
 

--- a/application/src/main/java/org/thingsboard/mqtt/broker/actors/client/service/subscription/ClientSubscriptionServiceImpl.java
+++ b/application/src/main/java/org/thingsboard/mqtt/broker/actors/client/service/subscription/ClientSubscriptionServiceImpl.java
@@ -136,15 +136,15 @@ public class ClientSubscriptionServiceImpl implements ClientSubscriptionService 
 
     @Override
     public void unsubscribeAndPersist(String clientId, Collection<String> topicFilters, BasicCallback callback) {
-        log.trace("[{}] Unsubscribing from {}.", clientId, topicFilters);
+        log.trace("[{}] Unsubscribe and persist {}.", clientId, topicFilters);
         Set<TopicSubscription> updatedClientSubscriptions = unsubscribe(clientId, topicFilters).updatedSubscriptions();
 
         subscriptionPersistenceService.persistClientSubscriptionsAsync(clientId, updatedClientSubscriptions, callback);
     }
 
     @Override
-    public void unsubscribeAndPersist(String clientId, Collection<String> topicFilters, UnsubscribeCallback callback) {
-        log.trace("[{}] Unsubscribing from {}.", clientId, topicFilters);
+    public void unsubscribeAndPersistReportingRemoved(String clientId, Collection<String> topicFilters, UnsubscribeCallback callback) {
+        log.trace("[{}] Unsubscribing from {} and reporting removed.", clientId, topicFilters);
         UnsubscribeResult result = unsubscribe(clientId, topicFilters);
 
         subscriptionPersistenceService.persistClientSubscriptionsAsync(clientId, result.updatedSubscriptions(),

--- a/application/src/main/java/org/thingsboard/mqtt/broker/actors/client/service/subscription/ClientSubscriptionServiceImpl.java
+++ b/application/src/main/java/org/thingsboard/mqtt/broker/actors/client/service/subscription/ClientSubscriptionServiceImpl.java
@@ -31,6 +31,7 @@ import org.thingsboard.mqtt.broker.service.subscription.shared.SharedSubscriptio
 import org.thingsboard.mqtt.broker.service.subscription.shared.TopicSharedSubscription;
 import org.thingsboard.mqtt.broker.session.ClientMqttActorManager;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -136,9 +137,20 @@ public class ClientSubscriptionServiceImpl implements ClientSubscriptionService 
     @Override
     public void unsubscribeAndPersist(String clientId, Collection<String> topicFilters, BasicCallback callback) {
         log.trace("[{}] Unsubscribing from {}.", clientId, topicFilters);
-        Set<TopicSubscription> updatedClientSubscriptions = unsubscribe(clientId, topicFilters);
+        Set<TopicSubscription> updatedClientSubscriptions = unsubscribe(clientId, topicFilters).updatedSubscriptions();
 
         subscriptionPersistenceService.persistClientSubscriptionsAsync(clientId, updatedClientSubscriptions, callback);
+    }
+
+    @Override
+    public void unsubscribeAndPersist(String clientId, Collection<String> topicFilters, UnsubscribeCallback callback) {
+        log.trace("[{}] Unsubscribing from {}.", clientId, topicFilters);
+        UnsubscribeResult result = unsubscribe(clientId, topicFilters);
+
+        subscriptionPersistenceService.persistClientSubscriptionsAsync(clientId, result.updatedSubscriptions(),
+                createCallback(
+                        () -> callback.onSuccess(result.removedSubscriptions()),
+                        callback::onFailure));
     }
 
     @Override
@@ -147,19 +159,26 @@ public class ClientSubscriptionServiceImpl implements ClientSubscriptionService 
         unsubscribe(clientId, topicFilters);
     }
 
-    private Set<TopicSubscription> unsubscribe(String clientId, Collection<String> topicFilters) {
+    private UnsubscribeResult unsubscribe(String clientId, Collection<String> topicFilters) {
         List<String> topics = extractTopicFilterFromSharedTopic(topicFilters);
         subscriptionService.unsubscribe(clientId, topics);
 
         Set<TopicSubscription> clientSubscriptions = clientSubscriptionsMap.computeIfAbsent(clientId, s -> new HashSet<>());
+        List<TopicSubscription> removedSubscriptions = new ArrayList<>();
         clientSubscriptions.removeIf(topicSubscription -> {
             boolean unsubscribe = topics.contains(topicSubscription.getTopicFilter());
             if (unsubscribe) {
                 processSharedUnsubscribe(clientId, topicSubscription);
+                removedSubscriptions.add(topicSubscription);
             }
             return unsubscribe;
         });
-        return clientSubscriptions;
+        return new UnsubscribeResult(clientSubscriptions, removedSubscriptions);
+    }
+
+    // Surviving subscriptions to persist, plus the ones actually removed (for UNSUBACK codes and lifecycle events).
+    private record UnsubscribeResult(Set<TopicSubscription> updatedSubscriptions,
+                                     List<TopicSubscription> removedSubscriptions) {
     }
 
     private List<String> extractTopicFilterFromSharedTopic(Collection<String> topicFilters) {

--- a/application/src/main/java/org/thingsboard/mqtt/broker/actors/client/service/subscription/UnsubscribeCallback.java
+++ b/application/src/main/java/org/thingsboard/mqtt/broker/actors/client/service/subscription/UnsubscribeCallback.java
@@ -1,0 +1,32 @@
+/**
+ * Copyright © 2016-2026 The Thingsboard Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.thingsboard.mqtt.broker.actors.client.service.subscription;
+
+import org.thingsboard.mqtt.broker.common.data.subscription.TopicSubscription;
+
+import java.util.List;
+
+/**
+ * Callback for {@link ClientSubscriptionService#unsubscribeAndPersist(String, java.util.Collection, UnsubscribeCallback)}
+ * that reports the subscriptions actually removed by the operation, so callers can derive the correct
+ * UNSUBACK reason codes and emit lifecycle events without re-deriving what was removed.
+ */
+public interface UnsubscribeCallback {
+
+    void onSuccess(List<TopicSubscription> removedSubscriptions);
+
+    void onFailure(Throwable t);
+}

--- a/application/src/main/java/org/thingsboard/mqtt/broker/actors/client/service/subscription/UnsubscribeCallback.java
+++ b/application/src/main/java/org/thingsboard/mqtt/broker/actors/client/service/subscription/UnsubscribeCallback.java
@@ -20,7 +20,7 @@ import org.thingsboard.mqtt.broker.common.data.subscription.TopicSubscription;
 import java.util.List;
 
 /**
- * Callback for {@link ClientSubscriptionService#unsubscribeAndPersist(String, java.util.Collection, UnsubscribeCallback)}
+ * Callback for {@link ClientSubscriptionService#unsubscribeAndPersistReportingRemoved(String, java.util.Collection, UnsubscribeCallback)}
  * that reports the subscriptions actually removed by the operation, so callers can derive the correct
  * UNSUBACK reason codes and emit lifecycle events without re-deriving what was removed.
  */

--- a/application/src/main/java/org/thingsboard/mqtt/broker/util/MqttReasonCodeResolver.java
+++ b/application/src/main/java/org/thingsboard/mqtt/broker/util/MqttReasonCodeResolver.java
@@ -99,6 +99,10 @@ public final class MqttReasonCodeResolver {
         return ctx.getMqttVersion() == MqttVersion.MQTT_5 ? UnsubAck.NO_SUBSCRIPTION_EXISTED : null;
     }
 
+    public static UnsubAck unsubAckError(ClientSessionCtx ctx) {
+        return ctx.getMqttVersion() == MqttVersion.MQTT_5 ? UnsubAck.UNSPECIFIED_ERROR : null;
+    }
+
     public static PubAck pubAckTopicNameInvalid() {
         return PubAck.TOPIC_NAME_INVALID;
     }

--- a/application/src/main/java/org/thingsboard/mqtt/broker/util/MqttReasonCodeResolver.java
+++ b/application/src/main/java/org/thingsboard/mqtt/broker/util/MqttReasonCodeResolver.java
@@ -95,6 +95,10 @@ public final class MqttReasonCodeResolver {
         return ctx.getMqttVersion() == MqttVersion.MQTT_5 ? UnsubAck.SUCCESS : null;
     }
 
+    public static UnsubAck unsubAckNoSubscriptionExisted(ClientSessionCtx ctx) {
+        return ctx.getMqttVersion() == MqttVersion.MQTT_5 ? UnsubAck.NO_SUBSCRIPTION_EXISTED : null;
+    }
+
     public static PubAck pubAckTopicNameInvalid() {
         return PubAck.TOPIC_NAME_INVALID;
     }

--- a/application/src/test/java/org/thingsboard/mqtt/broker/actors/client/service/handlers/MqttUnsubscribeHandlerTest.java
+++ b/application/src/test/java/org/thingsboard/mqtt/broker/actors/client/service/handlers/MqttUnsubscribeHandlerTest.java
@@ -80,7 +80,7 @@ public class MqttUnsubscribeHandlerTest {
     private UnsubscribeCallback process(MqttUnsubscribeMsg msg) {
         mqttUnsubscribeHandler.process(ctx, msg);
         ArgumentCaptor<UnsubscribeCallback> callbackCaptor = ArgumentCaptor.forClass(UnsubscribeCallback.class);
-        verify(clientSubscriptionService).unsubscribeAndPersist(eq("client-1"), eq(msg.getTopics()), callbackCaptor.capture());
+        verify(clientSubscriptionService).unsubscribeAndPersistReportingRemoved(eq("client-1"), eq(msg.getTopics()), callbackCaptor.capture());
         return callbackCaptor.getValue();
     }
 

--- a/application/src/test/java/org/thingsboard/mqtt/broker/actors/client/service/handlers/MqttUnsubscribeHandlerTest.java
+++ b/application/src/test/java/org/thingsboard/mqtt/broker/actors/client/service/handlers/MqttUnsubscribeHandlerTest.java
@@ -25,7 +25,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.thingsboard.mqtt.broker.actors.client.messages.mqtt.MqttUnsubscribeMsg;
 import org.thingsboard.mqtt.broker.actors.client.service.subscription.ClientSubscriptionService;
-import org.thingsboard.mqtt.broker.common.data.BasicCallback;
+import org.thingsboard.mqtt.broker.actors.client.service.subscription.UnsubscribeCallback;
 import org.thingsboard.mqtt.broker.common.data.SessionInfo;
 import org.thingsboard.mqtt.broker.common.data.subscription.ClientTopicSubscription;
 import org.thingsboard.mqtt.broker.common.data.subscription.TopicSubscription;
@@ -43,8 +43,8 @@ import java.util.UUID;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -71,70 +71,87 @@ public class MqttUnsubscribeHandlerTest {
 
         ctx = mock(ClientSessionCtx.class);
         sessionInfo = mock(SessionInfo.class);
+        when(ctx.getClientId()).thenReturn("client-1");
+        when(ctx.getChannel()).thenReturn(mock(ChannelHandlerContext.class));
         when(ctx.getSessionInfo()).thenReturn(sessionInfo);
         when(sessionInfo.isPersistentAppClient()).thenReturn(false);
     }
 
+    private UnsubscribeCallback process(MqttUnsubscribeMsg msg) {
+        mqttUnsubscribeHandler.process(ctx, msg);
+        ArgumentCaptor<UnsubscribeCallback> callbackCaptor = ArgumentCaptor.forClass(UnsubscribeCallback.class);
+        verify(clientSubscriptionService).unsubscribeAndPersist(eq("client-1"), eq(msg.getTopics()), callbackCaptor.capture());
+        return callbackCaptor.getValue();
+    }
+
     @Test
-    public void testProcess_MQTT5() {
+    public void givenMqtt5AndRemovedFilter_whenProcess_thenSuccessCodeAndEvent() {
         when(ctx.getMqttVersion()).thenReturn(MqttVersion.MQTT_5);
 
-        mqttUnsubscribeHandler.process(ctx, new MqttUnsubscribeMsg(UUID.randomUUID(), 1, List.of("topic")));
+        UnsubscribeCallback callback = process(new MqttUnsubscribeMsg(UUID.randomUUID(), 1, List.of("topic")));
+        TopicSubscription removed = new ClientTopicSubscription("topic", 1);
+        callback.onSuccess(List.of(removed));
 
         verify(mqttMessageGenerator).createUnSubAckMessage(eq(1), eq(List.of(MqttReasonCodes.UnsubAck.SUCCESS)));
-        verify(clientSubscriptionService).unsubscribeAndPersist(any(), any(), any());
+        verify(integrationLifecycleEventPublisher).publishUnsubscribed(ctx, List.of(removed));
     }
 
     @Test
-    public void testProcess_MQTT3() {
-        mqttUnsubscribeHandler.process(ctx, new MqttUnsubscribeMsg(UUID.randomUUID(), 1, List.of("topic")));
+    public void givenMqtt5AndNeverSubscribedFilter_whenProcess_thenNoSubscriptionExistedCodeAndNoEvent() {
+        when(ctx.getMqttVersion()).thenReturn(MqttVersion.MQTT_5);
 
-        verify(mqttMessageGenerator).createUnSubAckMessage(eq(1), eq(Collections.singletonList(null)));
-        verify(clientSubscriptionService).unsubscribeAndPersist(any(), any(), any());
+        UnsubscribeCallback callback = process(new MqttUnsubscribeMsg(UUID.randomUUID(), 1, List.of("never/subscribed")));
+        callback.onSuccess(List.of());
+
+        verify(mqttMessageGenerator).createUnSubAckMessage(eq(1), eq(List.of(MqttReasonCodes.UnsubAck.NO_SUBSCRIPTION_EXISTED)));
+        verify(integrationLifecycleEventPublisher, never()).publishUnsubscribed(any(), any());
     }
 
     @Test
-    public void testProcess_MQTT3AppClient() {
-        when(sessionInfo.isPersistentAppClient()).thenReturn(true);
-        mqttUnsubscribeHandler.process(ctx, new MqttUnsubscribeMsg(UUID.randomUUID(), 1, List.of("$share/group/topic")));
+    public void givenMqtt5AndMixedFilters_whenProcess_thenPerFilterCodesInRequestOrder() {
+        when(ctx.getMqttVersion()).thenReturn(MqttVersion.MQTT_5);
 
-        verify(mqttMessageGenerator).createUnSubAckMessage(eq(1), eq(Collections.singletonList(null)));
-        verify(clientSubscriptionService).unsubscribeAndPersist(any(), any(), any());
-        verify(applicationPersistenceProcessor).stopProcessingSharedSubscriptions(any(), eq(Set.of(new TopicSharedSubscription("topic", "group"))));
-    }
+        UnsubscribeCallback callback = process(new MqttUnsubscribeMsg(UUID.randomUUID(), 1, List.of("a/b", "never/subscribed")));
+        callback.onSuccess(List.of(new ClientTopicSubscription("a/b", 1)));
 
-    @Test
-    public void givenSubscribedAndNeverSubscribedFilters_whenProcess_thenEmitOnlyRemovedFilters() {
-        String clientId = "client-1";
-        when(ctx.getClientId()).thenReturn(clientId);
-        when(ctx.getChannel()).thenReturn(mock(ChannelHandlerContext.class));
-        lenient().when(clientSubscriptionService.getClientSubscriptions(clientId))
-                .thenReturn(Set.of(new ClientTopicSubscription("a/b", 1), new ClientTopicSubscription("c/d", 1)));
-
-        mqttUnsubscribeHandler.process(ctx, new MqttUnsubscribeMsg(UUID.randomUUID(), 1, List.of("a/b", "never/subscribed")));
-
-        ArgumentCaptor<BasicCallback> callbackCaptor = ArgumentCaptor.forClass(BasicCallback.class);
-        verify(clientSubscriptionService).unsubscribeAndPersist(eq(clientId), eq(List.of("a/b", "never/subscribed")), callbackCaptor.capture());
-        callbackCaptor.getValue().onSuccess();
-
-        // "never/subscribed" was never subscribed; only the actually-removed "a/b" should produce a CLIENT_UNSUBSCRIBED event
+        // Codes must line up positionally with the requested topics: removed -> SUCCESS, never subscribed -> NO_SUBSCRIPTION_EXISTED
+        verify(mqttMessageGenerator).createUnSubAckMessage(eq(1),
+                eq(List.of(MqttReasonCodes.UnsubAck.SUCCESS, MqttReasonCodes.UnsubAck.NO_SUBSCRIPTION_EXISTED)));
         verify(integrationLifecycleEventPublisher).publishUnsubscribed(ctx, List.of(new ClientTopicSubscription("a/b", 1)));
     }
 
     @Test
+    public void givenMqtt3_whenProcess_thenSingleNullCodeRegardlessOfRemoval() {
+        // MQTT 3.1.1 (version not stubbed) -> no reason codes on the wire
+        UnsubscribeCallback callback = process(new MqttUnsubscribeMsg(UUID.randomUUID(), 1, List.of("topic")));
+        callback.onSuccess(List.of());
+
+        verify(mqttMessageGenerator).createUnSubAckMessage(eq(1), eq(Collections.singletonList(null)));
+    }
+
+    @Test
+    public void givenMqtt3AppClient_whenProcessSharedUnsubscribe_thenStopsSharedProcessingAndAcks() {
+        when(sessionInfo.isPersistentAppClient()).thenReturn(true);
+
+        UnsubscribeCallback callback = process(new MqttUnsubscribeMsg(UUID.randomUUID(), 1, List.of("$share/group/topic")));
+
+        // Application shared-subscription processing is stopped synchronously, independent of the persist callback
+        verify(applicationPersistenceProcessor).stopProcessingSharedSubscriptions(any(), eq(Set.of(new TopicSharedSubscription("topic", "group"))));
+
+        callback.onSuccess(List.of());
+        verify(mqttMessageGenerator).createUnSubAckMessage(eq(1), eq(Collections.singletonList(null)));
+    }
+
+    @Test
     @SuppressWarnings("unchecked")
-    public void givenSharedSubscription_whenUnsubscribe_thenEmitsSubscriptionWithShareName() {
-        String clientId = "client-1";
-        when(ctx.getClientId()).thenReturn(clientId);
-        when(ctx.getChannel()).thenReturn(mock(ChannelHandlerContext.class));
-        lenient().when(clientSubscriptionService.getClientSubscriptions(clientId))
-                .thenReturn(Set.of(new ClientTopicSubscription("topic", 1, "group")));
+    public void givenSharedSubscriptionRemoved_whenProcess_thenSuccessCodeAndEmitsSubscriptionWithShareName() {
+        when(ctx.getMqttVersion()).thenReturn(MqttVersion.MQTT_5);
 
-        mqttUnsubscribeHandler.process(ctx, new MqttUnsubscribeMsg(UUID.randomUUID(), 1, List.of("$share/group/topic")));
+        UnsubscribeCallback callback = process(new MqttUnsubscribeMsg(UUID.randomUUID(), 1, List.of("$share/group/topic")));
+        callback.onSuccess(List.of(new ClientTopicSubscription("topic", 1, "group")));
 
-        ArgumentCaptor<BasicCallback> callbackCaptor = ArgumentCaptor.forClass(BasicCallback.class);
-        verify(clientSubscriptionService).unsubscribeAndPersist(eq(clientId), eq(List.of("$share/group/topic")), callbackCaptor.capture());
-        callbackCaptor.getValue().onSuccess();
+        // The shared request resolves to its bare filter for the code: removed -> SUCCESS
+        verify(mqttMessageGenerator).createUnSubAckMessage(eq(1), eq(List.of(MqttReasonCodes.UnsubAck.SUCCESS)));
 
         // The removed shared subscription must carry its shareName so $share/group/topic can be reconstructed downstream
         ArgumentCaptor<List<TopicSubscription>> captor = ArgumentCaptor.forClass(List.class);
@@ -143,6 +160,16 @@ public class MqttUnsubscribeHandlerTest {
         assertEquals(1, removed.size());
         assertEquals("topic", removed.get(0).getTopicFilter());
         assertEquals("group", removed.get(0).getShareName());
+    }
+
+    @Test
+    public void givenNothingRemoved_whenProcess_thenNoEventPublished() {
+        when(ctx.getMqttVersion()).thenReturn(MqttVersion.MQTT_5);
+
+        UnsubscribeCallback callback = process(new MqttUnsubscribeMsg(UUID.randomUUID(), 1, List.of("a/b")));
+        callback.onSuccess(List.of());
+
+        verify(integrationLifecycleEventPublisher, never()).publishUnsubscribed(any(), any());
     }
 
     @Test

--- a/application/src/test/java/org/thingsboard/mqtt/broker/actors/client/service/handlers/MqttUnsubscribeHandlerTest.java
+++ b/application/src/test/java/org/thingsboard/mqtt/broker/actors/client/service/handlers/MqttUnsubscribeHandlerTest.java
@@ -173,6 +173,42 @@ public class MqttUnsubscribeHandlerTest {
     }
 
     @Test
+    public void givenMqtt5AndPersistFailure_whenOnFailure_thenErrorUnsubAckAndNoEvent() {
+        when(ctx.getMqttVersion()).thenReturn(MqttVersion.MQTT_5);
+
+        UnsubscribeCallback callback = process(new MqttUnsubscribeMsg(UUID.randomUUID(), 1, List.of("topic")));
+        callback.onFailure(new RuntimeException("persist failed"));
+
+        // The Server MUST still send an UNSUBACK on failure; MQTT 5 carries an error code per requested filter,
+        // and no CLIENT_UNSUBSCRIBED lifecycle event is published.
+        verify(mqttMessageGenerator).createUnSubAckMessage(eq(1), eq(List.of(MqttReasonCodes.UnsubAck.UNSPECIFIED_ERROR)));
+        verify(ctx.getChannel()).writeAndFlush(any());
+        verify(integrationLifecycleEventPublisher, never()).publishUnsubscribed(any(), any());
+    }
+
+    @Test
+    public void givenMqtt5AndPersistFailureMultipleFilters_whenOnFailure_thenErrorCodePerFilterInOrder() {
+        when(ctx.getMqttVersion()).thenReturn(MqttVersion.MQTT_5);
+
+        UnsubscribeCallback callback = process(new MqttUnsubscribeMsg(UUID.randomUUID(), 1, List.of("a/b", "c/d")));
+        callback.onFailure(new RuntimeException("persist failed"));
+
+        // One error code per requested topic filter, in request order (we do not know which filters were removed).
+        verify(mqttMessageGenerator).createUnSubAckMessage(eq(1),
+                eq(List.of(MqttReasonCodes.UnsubAck.UNSPECIFIED_ERROR, MqttReasonCodes.UnsubAck.UNSPECIFIED_ERROR)));
+    }
+
+    @Test
+    public void givenMqtt3AndPersistFailure_whenOnFailure_thenCodelessUnsubAck() {
+        // MQTT 3.1.1 (version not stubbed) UNSUBACK carries no reason codes -> codeless packet even on failure.
+        UnsubscribeCallback callback = process(new MqttUnsubscribeMsg(UUID.randomUUID(), 1, List.of("topic")));
+        callback.onFailure(new RuntimeException("persist failed"));
+
+        verify(mqttMessageGenerator).createUnSubAckMessage(eq(1), eq(Collections.singletonList(null)));
+        verify(ctx.getChannel()).writeAndFlush(any());
+    }
+
+    @Test
     public void testCollectUniqueSharedSubscriptions() {
         List<String> topics = List.of(
                 "test/topic",

--- a/application/src/test/java/org/thingsboard/mqtt/broker/actors/client/service/subscription/ClientSubscriptionServiceImplTest.java
+++ b/application/src/test/java/org/thingsboard/mqtt/broker/actors/client/service/subscription/ClientSubscriptionServiceImplTest.java
@@ -20,7 +20,9 @@ import lombok.extern.slf4j.Slf4j;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.junit.MockitoJUnitRunner;
+import org.thingsboard.mqtt.broker.common.data.BasicCallback;
 import org.thingsboard.mqtt.broker.common.data.subscription.ClientTopicSubscription;
 import org.thingsboard.mqtt.broker.common.data.subscription.TopicSubscription;
 import org.thingsboard.mqtt.broker.queue.cluster.ServiceInfoProvider;
@@ -33,6 +35,7 @@ import org.thingsboard.mqtt.broker.service.subscription.shared.TopicSharedSubscr
 import org.thingsboard.mqtt.broker.session.ClientMqttActorManager;
 
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -206,6 +209,77 @@ public class ClientSubscriptionServiceImplTest {
 
         int clientSubscriptionsCount = clientSubscriptionService.getClientSubscriptionsCount();
         assertThat(clientSubscriptionsCount).isEqualTo(7);
+    }
+
+    @Test
+    public void givenSubscriptions_whenUnsubscribeAndPersistWithCallback_thenDeliversRemovedSubscriptionsOnSuccess() {
+        String clientId = "clientId1"; // seeded with topic1
+        clientSubscriptionService.subscribeInternally(clientId, Set.of(getTopicSubscription("topic11")));
+
+        UnsubscribeCallback callback = mock(UnsubscribeCallback.class);
+        clientSubscriptionService.unsubscribeAndPersist(clientId, Set.of("topic1"), callback);
+
+        Set<TopicSubscription> survivors = getAndVerifyClientSubscriptionsForClient(clientId, 1);
+        assertTrue(survivors.contains(getTopicSubscription("topic11")));
+
+        ArgumentCaptor<BasicCallback> persistCallback = ArgumentCaptor.forClass(BasicCallback.class);
+        verify(subscriptionPersistenceService).persistClientSubscriptionsAsync(eq(clientId), eq(survivors), persistCallback.capture());
+        persistCallback.getValue().onSuccess();
+
+        ArgumentCaptor<List<TopicSubscription>> removedCaptor = ArgumentCaptor.forClass(List.class);
+        verify(callback).onSuccess(removedCaptor.capture());
+        assertThat(removedCaptor.getValue()).containsExactly(getTopicSubscription("topic1"));
+    }
+
+    @Test
+    public void givenSharedSubscription_whenUnsubscribeAndPersistWithCallback_thenRemovedCarriesShareName() {
+        String clientId = "sharedClientId";
+        clientSubscriptionService.subscribeInternally(clientId, Set.of(getSharedTopicSubscription("topic11")));
+
+        UnsubscribeCallback callback = mock(UnsubscribeCallback.class);
+        clientSubscriptionService.unsubscribeAndPersist(clientId, Set.of("$share/sharedGroup/topic11"), callback);
+
+        ArgumentCaptor<BasicCallback> persistCallback = ArgumentCaptor.forClass(BasicCallback.class);
+        verify(subscriptionPersistenceService).persistClientSubscriptionsAsync(eq(clientId), any(), persistCallback.capture());
+        persistCallback.getValue().onSuccess();
+
+        ArgumentCaptor<List<TopicSubscription>> removedCaptor = ArgumentCaptor.forClass(List.class);
+        verify(callback).onSuccess(removedCaptor.capture());
+        List<TopicSubscription> removed = removedCaptor.getValue();
+        assertEquals(1, removed.size());
+        assertEquals("topic11", removed.get(0).getTopicFilter());
+        assertEquals("sharedGroup", removed.get(0).getShareName());
+    }
+
+    @Test
+    public void givenNeverSubscribedFilter_whenUnsubscribeAndPersistWithCallback_thenRemovedIsEmpty() {
+        String clientId = "clientId1"; // seeded with topic1
+
+        UnsubscribeCallback callback = mock(UnsubscribeCallback.class);
+        clientSubscriptionService.unsubscribeAndPersist(clientId, Set.of("never/subscribed"), callback);
+
+        ArgumentCaptor<BasicCallback> persistCallback = ArgumentCaptor.forClass(BasicCallback.class);
+        verify(subscriptionPersistenceService).persistClientSubscriptionsAsync(eq(clientId), any(), persistCallback.capture());
+        persistCallback.getValue().onSuccess();
+
+        ArgumentCaptor<List<TopicSubscription>> removedCaptor = ArgumentCaptor.forClass(List.class);
+        verify(callback).onSuccess(removedCaptor.capture());
+        assertTrue(removedCaptor.getValue().isEmpty());
+    }
+
+    @Test
+    public void givenPersistFailure_whenUnsubscribeAndPersistWithCallback_thenPropagatesFailure() {
+        String clientId = "clientId1"; // seeded with topic1
+
+        UnsubscribeCallback callback = mock(UnsubscribeCallback.class);
+        clientSubscriptionService.unsubscribeAndPersist(clientId, Set.of("topic1"), callback);
+
+        ArgumentCaptor<BasicCallback> persistCallback = ArgumentCaptor.forClass(BasicCallback.class);
+        verify(subscriptionPersistenceService).persistClientSubscriptionsAsync(eq(clientId), any(), persistCallback.capture());
+        RuntimeException failure = new RuntimeException("boom");
+        persistCallback.getValue().onFailure(failure);
+
+        verify(callback).onFailure(failure);
     }
 
     private Set<TopicSubscription> getAndVerifyClientSubscriptionsForClient(String clientId, int expected) {

--- a/application/src/test/java/org/thingsboard/mqtt/broker/actors/client/service/subscription/ClientSubscriptionServiceImplTest.java
+++ b/application/src/test/java/org/thingsboard/mqtt/broker/actors/client/service/subscription/ClientSubscriptionServiceImplTest.java
@@ -217,7 +217,7 @@ public class ClientSubscriptionServiceImplTest {
         clientSubscriptionService.subscribeInternally(clientId, Set.of(getTopicSubscription("topic11")));
 
         UnsubscribeCallback callback = mock(UnsubscribeCallback.class);
-        clientSubscriptionService.unsubscribeAndPersist(clientId, Set.of("topic1"), callback);
+        clientSubscriptionService.unsubscribeAndPersistReportingRemoved(clientId, Set.of("topic1"), callback);
 
         Set<TopicSubscription> survivors = getAndVerifyClientSubscriptionsForClient(clientId, 1);
         assertTrue(survivors.contains(getTopicSubscription("topic11")));
@@ -237,7 +237,7 @@ public class ClientSubscriptionServiceImplTest {
         clientSubscriptionService.subscribeInternally(clientId, Set.of(getSharedTopicSubscription("topic11")));
 
         UnsubscribeCallback callback = mock(UnsubscribeCallback.class);
-        clientSubscriptionService.unsubscribeAndPersist(clientId, Set.of("$share/sharedGroup/topic11"), callback);
+        clientSubscriptionService.unsubscribeAndPersistReportingRemoved(clientId, Set.of("$share/sharedGroup/topic11"), callback);
 
         ArgumentCaptor<BasicCallback> persistCallback = ArgumentCaptor.forClass(BasicCallback.class);
         verify(subscriptionPersistenceService).persistClientSubscriptionsAsync(eq(clientId), any(), persistCallback.capture());
@@ -256,7 +256,7 @@ public class ClientSubscriptionServiceImplTest {
         String clientId = "clientId1"; // seeded with topic1
 
         UnsubscribeCallback callback = mock(UnsubscribeCallback.class);
-        clientSubscriptionService.unsubscribeAndPersist(clientId, Set.of("never/subscribed"), callback);
+        clientSubscriptionService.unsubscribeAndPersistReportingRemoved(clientId, Set.of("never/subscribed"), callback);
 
         ArgumentCaptor<BasicCallback> persistCallback = ArgumentCaptor.forClass(BasicCallback.class);
         verify(subscriptionPersistenceService).persistClientSubscriptionsAsync(eq(clientId), any(), persistCallback.capture());
@@ -272,7 +272,7 @@ public class ClientSubscriptionServiceImplTest {
         String clientId = "clientId1"; // seeded with topic1
 
         UnsubscribeCallback callback = mock(UnsubscribeCallback.class);
-        clientSubscriptionService.unsubscribeAndPersist(clientId, Set.of("topic1"), callback);
+        clientSubscriptionService.unsubscribeAndPersistReportingRemoved(clientId, Set.of("topic1"), callback);
 
         ArgumentCaptor<BasicCallback> persistCallback = ArgumentCaptor.forClass(BasicCallback.class);
         verify(subscriptionPersistenceService).persistClientSubscriptionsAsync(eq(clientId), any(), persistCallback.capture());

--- a/application/src/test/java/org/thingsboard/mqtt/broker/util/MqttReasonCodeResolverTest.java
+++ b/application/src/test/java/org/thingsboard/mqtt/broker/util/MqttReasonCodeResolverTest.java
@@ -57,4 +57,20 @@ public class MqttReasonCodeResolverTest {
 
         assertThat(MqttReasonCodeResolver.unsubAckNoSubscriptionExisted(ctx)).isNull();
     }
+
+    @Test
+    public void givenMqtt5_whenUnsubAckError_thenReturnsUnspecifiedError() {
+        ClientSessionCtx ctx = mock(ClientSessionCtx.class);
+        when(ctx.getMqttVersion()).thenReturn(MqttVersion.MQTT_5);
+
+        assertThat(MqttReasonCodeResolver.unsubAckError(ctx)).isEqualTo(UnsubAck.UNSPECIFIED_ERROR);
+    }
+
+    @Test
+    public void givenMqtt311_whenUnsubAckError_thenReturnsNull() {
+        ClientSessionCtx ctx = mock(ClientSessionCtx.class);
+        when(ctx.getMqttVersion()).thenReturn(MqttVersion.MQTT_3_1_1);
+
+        assertThat(MqttReasonCodeResolver.unsubAckError(ctx)).isNull();
+    }
 }

--- a/application/src/test/java/org/thingsboard/mqtt/broker/util/MqttReasonCodeResolverTest.java
+++ b/application/src/test/java/org/thingsboard/mqtt/broker/util/MqttReasonCodeResolverTest.java
@@ -1,0 +1,60 @@
+/**
+ * Copyright © 2016-2026 The Thingsboard Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.thingsboard.mqtt.broker.util;
+
+import io.netty.handler.codec.mqtt.MqttReasonCodes.UnsubAck;
+import io.netty.handler.codec.mqtt.MqttVersion;
+import org.junit.Test;
+import org.thingsboard.mqtt.broker.session.ClientSessionCtx;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class MqttReasonCodeResolverTest {
+
+    @Test
+    public void givenMqtt5_whenUnsubAckSuccess_thenReturnsSuccess() {
+        ClientSessionCtx ctx = mock(ClientSessionCtx.class);
+        when(ctx.getMqttVersion()).thenReturn(MqttVersion.MQTT_5);
+
+        assertThat(MqttReasonCodeResolver.unsubAckSuccess(ctx)).isEqualTo(UnsubAck.SUCCESS);
+    }
+
+    @Test
+    public void givenMqtt311_whenUnsubAckSuccess_thenReturnsNull() {
+        ClientSessionCtx ctx = mock(ClientSessionCtx.class);
+        when(ctx.getMqttVersion()).thenReturn(MqttVersion.MQTT_3_1_1);
+
+        assertThat(MqttReasonCodeResolver.unsubAckSuccess(ctx)).isNull();
+    }
+
+    @Test
+    public void givenMqtt5_whenUnsubAckNoSubscriptionExisted_thenReturnsNoSubscriptionExisted() {
+        ClientSessionCtx ctx = mock(ClientSessionCtx.class);
+        when(ctx.getMqttVersion()).thenReturn(MqttVersion.MQTT_5);
+
+        assertThat(MqttReasonCodeResolver.unsubAckNoSubscriptionExisted(ctx)).isEqualTo(UnsubAck.NO_SUBSCRIPTION_EXISTED);
+    }
+
+    @Test
+    public void givenMqtt311_whenUnsubAckNoSubscriptionExisted_thenReturnsNull() {
+        ClientSessionCtx ctx = mock(ClientSessionCtx.class);
+        when(ctx.getMqttVersion()).thenReturn(MqttVersion.MQTT_3_1_1);
+
+        assertThat(MqttReasonCodeResolver.unsubAckNoSubscriptionExisted(ctx)).isNull();
+    }
+}


### PR DESCRIPTION
## Pull Request description

Fixes the UNSUBACK reason codes on the MQTT UNSUBSCRIBE path and removes redundant work in `MqttUnsubscribeHandler`.

**Problem**
- Every UNSUBACK reason code was hardcoded to `SUCCESS`. MQTT 5 requires `NO_SUBSCRIPTION_EXISTED (0x11)` for a topic filter the client was not subscribed to.
- `getRemovedSubscriptions()` ran on **every** UNSUBSCRIBE — copying the client's entire subscription set and rebuilding an index — even though that result is only needed when an integration listens for `CLIENT_UNSUBSCRIBED`. The subscriptions actually removed were derived twice, using two different matching rules.

**Change**
- The removal is now the single source of truth. `ClientSubscriptionService.unsubscribeAndPersist(...)` gains an overload that reports the removed subscriptions through a new `UnsubscribeCallback`, collected as a by-product of the existing removal loop (no extra pass, no full-set copy). The existing `BasicCallback`/no-arg overloads are unchanged.
- `MqttUnsubscribeHandler` builds both the per-filter UNSUBACK codes and the `CLIENT_UNSUBSCRIBED` lifecycle events from that single result: a requested filter that matched a removed subscription gets `SUCCESS`, one the client was not subscribed to gets `NO_SUBSCRIPTION_EXISTED`.
- `getRemovedSubscriptions()` and its lookup helper are removed. Added `MqttReasonCodeResolver.unsubAckNoSubscriptionExisted(ctx)`.

**Compatibility**
- MQTT 3.1.1 is unchanged: no reason codes are sent on the wire.
- MQTT 5 clients unsubscribing a filter they were not subscribed to now receive `NO_SUBSCRIPTION_EXISTED (0x11)` instead of `SUCCESS`. Both are success-class reason codes (`< 0x80`), so no client treats this as an error.

**Documentation**
- No documentation changes required.

## General checklist

- [x] You have reviewed the guidelines [document](https://docs.google.com/document/d/1A4Vc3wrHsY_159b9RG5LOtCryoH6VPwgOhrFEzJKwbI/edit?usp=sharing).
- [x] [Labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels#about-labels) that classify your pull request have been added.
- [x] The [milestone](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones) is specified and corresponds to fix version.
- [x] Description references specific [issue](https://github.com/thingsboard/tbmq/issues).
- [x] Description contains human-readable scope of changes.
- [x] Description contains brief notes about what needs to be added to the documentation.
- [x] No merge conflicts, commented blocks of code, code formatting issues.
- [x] Changes are backward compatible or upgrade script is provided.

## Front-End feature checklist

No front-end changes.

## Back-End feature checklist

- [x] Added corresponding unit and/or integration test(s). Provide written explanation in the PR description if you have failed to add tests.
- [x] If new dependency was added: the dependency tree is checked for conflicts. _(No new dependencies.)_
