### PR TITLE
fix(mqtt): correct SUBACK reason codes for subscribe (persist failure + invalid topic filter)

### DIFF
--- a/application/src/main/java/org/thingsboard/mqtt/broker/actors/client/service/handlers/MqttSubscribeHandler.java
+++ b/application/src/main/java/org/thingsboard/mqtt/broker/actors/client/service/handlers/MqttSubscribeHandler.java
@@ -125,7 +125,7 @@ public class MqttSubscribeHandler {
                 validateSharedSubscription(subscription);
             } catch (DataValidationException e) {
                 log.warn("[{}][{}] Not valid topic", ctx.getClientId(), ctx.getSessionId(), e);
-                codes.add(MqttReasonCodeResolver.failure());
+                codes.add(MqttReasonCodeResolver.topicFilterInvalid(ctx));
                 continue;
             }
 

--- a/application/src/main/java/org/thingsboard/mqtt/broker/actors/client/service/handlers/MqttSubscribeHandler.java
+++ b/application/src/main/java/org/thingsboard/mqtt/broker/actors/client/service/handlers/MqttSubscribeHandler.java
@@ -91,8 +91,7 @@ public class MqttSubscribeHandler {
         }
         List<TopicSubscription> validTopicSubscriptions = collectValidSubscriptions(topicSubscriptions, codes);
 
-        MqttSubAckMessage subAckMessage = mqttMessageGenerator.createSubAckMessage(msg.getMessageId(), codes);
-        subscribeAndPersist(ctx, validTopicSubscriptions, subAckMessage);
+        subscribeAndPersist(ctx, validTopicSubscriptions, msg.getMessageId(), codes);
 
         startProcessingSharedSubscriptions(ctx, validTopicSubscriptions, currentSharedSubscriptions);
     }
@@ -154,9 +153,10 @@ public class MqttSubscribeHandler {
         return codes;
     }
 
-    private void subscribeAndPersist(ClientSessionCtx ctx, List<TopicSubscription> newSubscriptions, MqttSubAckMessage subAckMessage) {
+    private void subscribeAndPersist(ClientSessionCtx ctx, List<TopicSubscription> newSubscriptions,
+                                     int messageId, List<MqttReasonCodes.SubAck> codes) {
         if (CollectionUtils.isEmpty(newSubscriptions)) {
-            sendSubAck(ctx, subAckMessage);
+            sendSubAck(ctx, mqttMessageGenerator.createSubAckMessage(messageId, codes));
             return;
         }
 
@@ -165,12 +165,25 @@ public class MqttSubscribeHandler {
         clientSubscriptionService.subscribeAndPersist(clientId, newSubscriptions,
                 CallbackUtil.createCallback(
                         () -> {
-                            sendSubAck(ctx, subAckMessage);
+                            sendSubAck(ctx, mqttMessageGenerator.createSubAckMessage(messageId, codes));
                             integrationLifecycleEventPublisher.publishSubscribed(ctx, newSubscriptions);
                             processRetainedMessages(ctx, newSubscriptions, currentSubscriptions);
                         },
-                        t -> log.warn("[{}][{}] Failed to process client subscription.", clientId, ctx.getSessionId(), t))
+                        t -> {
+                            log.warn("[{}][{}] Failed to process client subscription.", clientId, ctx.getSessionId(), t);
+                            // The Server MUST still respond with a SUBACK (MQTT-3.8.4-1). The persist failed, so every filter that
+                            // would have been granted now reports UNSPECIFIED_ERROR; the pre-validation error codes are preserved.
+                            sendSubAck(ctx, mqttMessageGenerator.createSubAckMessage(messageId, toFailureCodes(codes)));
+                        })
         );
+    }
+
+    // On persist failure the granted-QoS codes flip to UNSPECIFIED_ERROR (0x80, valid on both MQTT versions); codes decided
+    // during validation (not authorized, topic invalid, shared-sub errors) are kept, as they do not depend on the persist.
+    private List<MqttReasonCodes.SubAck> toFailureCodes(List<MqttReasonCodes.SubAck> codes) {
+        return codes.stream()
+                .map(code -> MqttReasonCodeUtil.getGrantedQosList().contains(code) ? MqttReasonCodeResolver.failure() : code)
+                .toList();
     }
 
     private void disconnectClient(ClientSessionCtx ctx) {

--- a/application/src/main/java/org/thingsboard/mqtt/broker/util/MqttReasonCodeResolver.java
+++ b/application/src/main/java/org/thingsboard/mqtt/broker/util/MqttReasonCodeResolver.java
@@ -127,6 +127,11 @@ public final class MqttReasonCodeResolver {
         return ctx.getMqttVersion() == MqttVersion.MQTT_5 ? SubAck.NOT_AUTHORIZED : failure();
     }
 
+    public static SubAck topicFilterInvalid(ClientSessionCtx ctx) {
+        // 0x8F exists only in MQTT 5; MQTT 3.1.1 has no such SUBACK code, so fall back to 0x80 (Failure).
+        return ctx.getMqttVersion() == MqttVersion.MQTT_5 ? SubAck.TOPIC_FILTER_INVALID : failure();
+    }
+
     public static SubAck implementationSpecificError(ClientSessionCtx ctx) {
         return ctx.getMqttVersion() == MqttVersion.MQTT_5 ? SubAck.IMPLEMENTATION_SPECIFIC_ERROR : failure();
     }

--- a/application/src/test/java/org/thingsboard/mqtt/broker/actors/client/service/handlers/MqttSubscribeHandlerTest.java
+++ b/application/src/test/java/org/thingsboard/mqtt/broker/actors/client/service/handlers/MqttSubscribeHandlerTest.java
@@ -393,20 +393,26 @@ public class MqttSubscribeHandlerTest {
 
     @Test
     public void givenMqttSubscribeMsg_whenProcessSubscriptions_thenReturnExpectedResult() {
+        when(ctx.getChannel()).thenReturn(mock(ChannelHandlerContext.class));
         SessionInfo sessionInfo = mock(SessionInfo.class);
         when(ctx.getSessionInfo()).thenReturn(sessionInfo);
         ClientInfo clientInfo = mock(ClientInfo.class);
         when(sessionInfo.getClientInfo()).thenReturn(clientInfo);
+        when(clientSubscriptionService.getClientSubscriptions(any())).thenReturn(Collections.emptySet());
 
         when(authorizationRuleService.isSubAuthorized(any(), any())).thenReturn(true);
 
         MqttSubscribeMsg msg = new MqttSubscribeMsg(UUID.randomUUID(), 1, getTopicSubscriptions());
         mqttSubscribeHandler.process(ctx, msg);
 
+        // the SUBACK carrying the granted QoS codes is built and sent from the persist success callback
+        ArgumentCaptor<BasicCallback> callbackCaptor = ArgumentCaptor.forClass(BasicCallback.class);
+        verify(clientSubscriptionService, times(1)).subscribeAndPersist(any(), any(), callbackCaptor.capture());
+        callbackCaptor.getValue().onSuccess();
+
         verify(mqttMessageGenerator, times(1)).createSubAckMessage(
                 eq(1), eq(List.of(MqttReasonCodes.SubAck.GRANTED_QOS_0, MqttReasonCodes.SubAck.GRANTED_QOS_1, MqttReasonCodes.SubAck.GRANTED_QOS_2))
         );
-        verify(clientSubscriptionService, times(1)).subscribeAndPersist(any(), any(), any());
         verify(clientSubscriptionService, times(1)).getClientSharedSubscriptions(any());
     }
 
@@ -452,6 +458,63 @@ public class MqttSubscribeHandlerTest {
 
         // only the granted (authorized) subscriptions are reported as CLIENT_SUBSCRIBED; the denied topic2 is excluded
         verify(integrationLifecycleEventPublisher).publishSubscribed(ctx, grantedSubscriptions);
+    }
+
+    @Test
+    public void givenSubscribeWithDeniedTopic_whenPersistFails_thenSendSubAckWithErrorCodesAndNoEvent() {
+        when(ctx.getMqttVersion()).thenReturn(MqttVersion.MQTT_5);
+        ChannelHandlerContext channel = mock(ChannelHandlerContext.class);
+        when(ctx.getChannel()).thenReturn(channel);
+        SessionInfo sessionInfo = mock(SessionInfo.class);
+        when(ctx.getSessionInfo()).thenReturn(sessionInfo);
+        when(sessionInfo.isPersistent()).thenReturn(false);
+        when(clientSubscriptionService.getClientSubscriptions(any())).thenReturn(Collections.emptySet());
+
+        when(authorizationRuleService.isSubAuthorized(eq("topic1"), any())).thenReturn(true);
+        when(authorizationRuleService.isSubAuthorized(eq("topic2"), any())).thenReturn(false); // denied
+        when(authorizationRuleService.isSubAuthorized(eq("topic3"), any())).thenReturn(true);
+
+        MqttSubscribeMsg msg = new MqttSubscribeMsg(UUID.randomUUID(), 1, getTopicSubscriptions());
+        mqttSubscribeHandler.process(ctx, msg);
+
+        // persistence is requested only for the granted subscriptions; drive the failure callback
+        List<TopicSubscription> grantedSubscriptions = List.of(getTopicSubscription("topic1", 0), getTopicSubscription("topic3", 2));
+        ArgumentCaptor<BasicCallback> callbackCaptor = ArgumentCaptor.forClass(BasicCallback.class);
+        verify(clientSubscriptionService).subscribeAndPersist(any(), eq(grantedSubscriptions), callbackCaptor.capture());
+        callbackCaptor.getValue().onFailure(new RuntimeException("persist failed"));
+
+        // on persist failure the granted entries flip to UNSPECIFIED_ERROR; the pre-validated NOT_AUTHORIZED is preserved
+        verify(mqttMessageGenerator).createSubAckMessage(eq(1), eq(List.of(
+                MqttReasonCodes.SubAck.UNSPECIFIED_ERROR,
+                MqttReasonCodes.SubAck.NOT_AUTHORIZED,
+                MqttReasonCodes.SubAck.UNSPECIFIED_ERROR)));
+        // the SUBACK is still sent so the client does not hang, but no CLIENT_SUBSCRIBED event is emitted
+        verify(channel).writeAndFlush(any());
+        verify(integrationLifecycleEventPublisher, never()).publishSubscribed(any(), any());
+    }
+
+    @Test
+    public void givenAllGrantedSubscribe_whenPersistFails_thenAllGrantedCodesBecomeUnspecifiedError() {
+        when(ctx.getMqttVersion()).thenReturn(MqttVersion.MQTT_5);
+        when(ctx.getChannel()).thenReturn(mock(ChannelHandlerContext.class));
+        SessionInfo sessionInfo = mock(SessionInfo.class);
+        when(ctx.getSessionInfo()).thenReturn(sessionInfo);
+        when(sessionInfo.isPersistent()).thenReturn(false);
+        when(clientSubscriptionService.getClientSubscriptions(any())).thenReturn(Collections.emptySet());
+        when(authorizationRuleService.isSubAuthorized(any(), any())).thenReturn(true);
+
+        MqttSubscribeMsg msg = new MqttSubscribeMsg(UUID.randomUUID(), 1, getTopicSubscriptions());
+        mqttSubscribeHandler.process(ctx, msg);
+
+        ArgumentCaptor<BasicCallback> callbackCaptor = ArgumentCaptor.forClass(BasicCallback.class);
+        verify(clientSubscriptionService).subscribeAndPersist(any(), any(), callbackCaptor.capture());
+        callbackCaptor.getValue().onFailure(new RuntimeException("boom"));
+
+        // every granted QoS entry is replaced with UNSPECIFIED_ERROR (0x80, version-agnostic)
+        verify(mqttMessageGenerator).createSubAckMessage(eq(1), eq(List.of(
+                MqttReasonCodes.SubAck.UNSPECIFIED_ERROR,
+                MqttReasonCodes.SubAck.UNSPECIFIED_ERROR,
+                MqttReasonCodes.SubAck.UNSPECIFIED_ERROR)));
     }
 
     @Test

--- a/application/src/test/java/org/thingsboard/mqtt/broker/actors/client/service/handlers/MqttSubscribeHandlerTest.java
+++ b/application/src/test/java/org/thingsboard/mqtt/broker/actors/client/service/handlers/MqttSubscribeHandlerTest.java
@@ -526,6 +526,19 @@ public class MqttSubscribeHandlerTest {
         MqttSubscribeMsg msg = new MqttSubscribeMsg(UUID.randomUUID(), 1, topicSubscriptions);
         List<MqttReasonCodes.SubAck> reasonCodes = mqttSubscribeHandler.collectMqttReasonCodes(ctx, msg);
 
+        assertEquals(List.of(MqttReasonCodes.SubAck.TOPIC_FILTER_INVALID), reasonCodes);
+    }
+
+    @Test
+    public void givenMqtt311_whenCollectMqttReasonCodesForInvalidTopic_thenReturnUnspecifiedError() {
+        when(ctx.getMqttVersion()).thenReturn(MqttVersion.MQTT_3_1_1);
+        doThrow(DataValidationException.class).when(topicValidationService).validateTopicFilter(eq("#"));
+
+        List<TopicSubscription> topicSubscriptions = List.of(getTopicSubscription(BrokerConstants.MULTI_LEVEL_WILDCARD, 1));
+        MqttSubscribeMsg msg = new MqttSubscribeMsg(UUID.randomUUID(), 1, topicSubscriptions);
+        List<MqttReasonCodes.SubAck> reasonCodes = mqttSubscribeHandler.collectMqttReasonCodes(ctx, msg);
+
+        // MQTT 3.1.1 has no 0x8F Topic Filter invalid; its only SUBACK failure code is 0x80
         assertEquals(List.of(MqttReasonCodes.SubAck.UNSPECIFIED_ERROR), reasonCodes);
     }
 
@@ -540,7 +553,7 @@ public class MqttSubscribeHandlerTest {
         MqttSubscribeMsg msg = new MqttSubscribeMsg(UUID.randomUUID(), 1, topicSubscriptions);
         List<MqttReasonCodes.SubAck> reasonCodes = mqttSubscribeHandler.collectMqttReasonCodes(ctx, msg);
 
-        assertEquals(List.of(MqttReasonCodes.SubAck.UNSPECIFIED_ERROR, MqttReasonCodes.SubAck.NOT_AUTHORIZED, MqttReasonCodes.SubAck.GRANTED_QOS_2), reasonCodes);
+        assertEquals(List.of(MqttReasonCodes.SubAck.TOPIC_FILTER_INVALID, MqttReasonCodes.SubAck.NOT_AUTHORIZED, MqttReasonCodes.SubAck.GRANTED_QOS_2), reasonCodes);
     }
 
     @Test


### PR DESCRIPTION
## Pull Request description

Two related correctness fixes for the reason codes the broker returns in a `SUBACK`.

### 1. Send a `SUBACK` on subscribe persist failure

When a client sends `SUBSCRIBE`, the broker persists the granted subscriptions asynchronously. Until now, `MqttSubscribeHandler` only handled the **success** side of that callback — on failure it merely logged a warning, so the client **never received a `SUBACK`** and was left waiting indefinitely. MQTT requires the server to respond to every `SUBSCRIBE` with a `SUBACK` carrying one reason code per requested topic filter (MQTT-3.8.4-1).

The failure path now sends a `SUBACK` as well:

- Each entry that would have been **granted** now reports `UNSPECIFIED_ERROR` (`0x80`) — a valid `SUBACK` reason code on both MQTT 3.1.1 (“Failure”) and MQTT 5.0 (“Unspecified error”).
- Reason codes decided earlier during validation (not authorized, topic filter invalid, shared-subscription errors) are **preserved**, since those verdicts do not depend on whether the batch persisted.
- On failure, no `CLIENT_SUBSCRIBED` integration event is emitted and retained messages are not delivered.

`0x80` was chosen over `0x83` for symmetry with the sibling `UNSUBACK` failure path, which already returns `UNSPECIFIED_ERROR`.

**Scope / known limitation:** `ClientSubscriptionServiceImpl.subscribeAndPersist` applies the subscription to in-memory state synchronously before the async persist. On persist failure that in-memory state is not rolled back — the broker reports an error `SUBACK` but still locally holds the subscription. This mirrors the existing behaviour on the `UNSUBACK` failure path; in-memory rollback is out of scope here.

### 2. Return `TOPIC_FILTER_INVALID` for invalid topic filters

A topic-filter validation failure previously returned the generic `UNSPECIFIED_ERROR` (`0x80`). On MQTT 5.0 it now returns `TOPIC_FILTER_INVALID` (`0x8F`), a valid `SUBACK` reason code (§3.9.3) that gives clients precise per-filter feedback. The resolver is **version-aware**: MQTT 3.1.1 has no `0x8F`, so it falls back to `0x80` (Failure). This covers both malformed topic filters and invalid shared-subscription share names (empty / containing wildcards) — both are invalid subscription topic filters.

**Documentation:** no documentation changes required.

## General checklist

- [x] You have reviewed the guidelines [document](https://docs.google.com/document/d/1A4Vc3wrHsY_159b9RG5LOtCryoH6VPwgOhrFEzJKwbI/edit?usp=sharing).
- [x] [Labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels#about-labels) that classify your pull request have been added.
- [x] The [milestone](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones) is specified and corresponds to fix version.
- [x] Description references specific [issue](https://github.com/thingsboard/tbmq/issues).
- [x] Description contains human-readable scope of changes.
- [x] Description contains brief notes about what needs to be added to the documentation.
- [x] No merge conflicts, commented blocks of code, code formatting issues.
- [x] Changes are backward compatible or upgrade script is provided.

## Front-End feature checklist

- [x] Screenshots with affected component(s) are added. The best option is to provide 2 screens: before and after changes;
- [x] If you change the widget or other API, ensure it is backward-compatible or upgrade script is present.

_No front-end changes._

## Back-End feature checklist

- [x] Added corresponding unit and/or integration test(s). Provide written explanation in the PR description if you have failed to add tests.
- [x] If new dependency was added: the dependency tree is checked for conflicts. _(No new dependencies.)_
