### PR TITLE
fix(stats): measure delivery on write completion and actors.processing in nanoseconds

### DIFF
--- a/application/src/main/java/org/thingsboard/mqtt/broker/actors/service/ContextAwareActor.java
+++ b/application/src/main/java/org/thingsboard/mqtt/broker/actors/service/ContextAwareActor.java
@@ -46,7 +46,7 @@ public abstract class ContextAwareActor extends AbstractTbActor {
             }
         } finally {
             stopWatch.stop();
-            actorProcessingMetricService.logMsgProcessingTime(msg.getMsgType(), stopWatch.getTime());
+            actorProcessingMetricService.logMsgProcessingTime(msg.getMsgType(), stopWatch.getNanoTime());
             stopWatch.reset();
         }
     }

--- a/application/src/main/java/org/thingsboard/mqtt/broker/actors/service/MsgTypeActorProcessingMetricService.java
+++ b/application/src/main/java/org/thingsboard/mqtt/broker/actors/service/MsgTypeActorProcessingMetricService.java
@@ -43,6 +43,6 @@ public class MsgTypeActorProcessingMetricService implements ActorProcessingMetri
     public void logMsgProcessingTime(MsgType msgType, long time) {
         Timer timer = timers.computeIfAbsent(msgType, t -> statsFactory.createTimer(ACTOR_MSG_PROCESSING_STATS_NAME,
                 StatsConstantNames.MSG_TYPE, msgType.toString()));
-        timer.record(time, TimeUnit.MILLISECONDS);
+        timer.record(time, TimeUnit.NANOSECONDS);
     }
 }

--- a/application/src/main/java/org/thingsboard/mqtt/broker/service/mqtt/delivery/DefaultMqttPublishMsgDeliveryService.java
+++ b/application/src/main/java/org/thingsboard/mqtt/broker/service/mqtt/delivery/DefaultMqttPublishMsgDeliveryService.java
@@ -15,6 +15,7 @@
  */
 package org.thingsboard.mqtt.broker.service.mqtt.delivery;
 
+import io.netty.channel.ChannelFuture;
 import io.netty.handler.codec.mqtt.MqttPublishMessage;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -25,6 +26,7 @@ import org.thingsboard.mqtt.broker.service.stats.timer.DeliveryTimerStats;
 import org.thingsboard.mqtt.broker.session.ClientSessionCtx;
 
 import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
 
 @Service
 @Slf4j
@@ -32,12 +34,14 @@ public class DefaultMqttPublishMsgDeliveryService implements MqttPublishMsgDeliv
 
     private final TbMessageStatsReportClient tbMessageStatsReportClient;
     private final DeliveryTimerStats deliveryTimerStats;
+    private final boolean statsEnabled;
 
     @Autowired
     public DefaultMqttPublishMsgDeliveryService(TbMessageStatsReportClient tbMessageStatsReportClient,
                                                 StatsManager statsManager) {
         this.tbMessageStatsReportClient = tbMessageStatsReportClient;
         this.deliveryTimerStats = statsManager.getDeliveryTimerStats();
+        this.statsEnabled = statsManager.isEnabled();
     }
 
     @Override
@@ -54,8 +58,8 @@ public class DefaultMqttPublishMsgDeliveryService implements MqttPublishMsgDeliv
     public void sendAlreadyTrackedPublishMsgToClient(ClientSessionCtx ctx, MqttPublishMessage msg) {
         try {
             long startTime = System.nanoTime();
-            ctx.getChannel().writeAndFlush(msg);
-            deliveryTimerStats.logDelivery(startTime, TimeUnit.NANOSECONDS);
+            ChannelFuture future = ctx.getChannel().writeAndFlush(msg);
+            recordDeliveryOnSuccess(future, startTime);
         } catch (Exception e) {
             log.warn("[{}][{}] Failed to send PUBLISH msg to MQTT client", ctx.getClientId(), ctx.getSessionId(), e);
             if (!msg.fixedHeader().isRetain()) {
@@ -64,13 +68,13 @@ public class DefaultMqttPublishMsgDeliveryService implements MqttPublishMsgDeliv
         }
     }
 
-    private void processSendPublish(ClientSessionCtx ctx, MqttPublishMessage msg, Runnable processor) {
+    private void processSendPublish(ClientSessionCtx ctx, MqttPublishMessage msg, Supplier<ChannelFuture> processor) {
         try {
             boolean added = ctx.addInFlightMsg(msg);
             if (added) {
                 long startTime = System.nanoTime();
-                processor.run();
-                deliveryTimerStats.logDelivery(startTime, TimeUnit.NANOSECONDS);
+                ChannelFuture future = processor.get();
+                recordDeliveryOnSuccess(future, startTime);
             }
         } catch (Exception e) {
             log.warn("[{}][{}] Failed to send PUBLISH msg to MQTT client", ctx.getClientId(), ctx.getSessionId(), e);
@@ -78,6 +82,24 @@ public class DefaultMqttPublishMsgDeliveryService implements MqttPublishMsgDeliv
                 tbMessageStatsReportClient.reportDroppedMsgs();
             }
         }
+    }
+
+    /**
+     * Records the delivery latency when the write {@link ChannelFuture} completes successfully, i.e. once the
+     * PUBLISH bytes have been written to the socket — not the synchronous cost of handing the write off to the
+     * Netty event loop, which the surrounding {@code writeAndFlush}/{@code write} calls return before completing.
+     * The listener is attached only when stats are enabled, so that a per-message listener allocation and an
+     * event-loop callback are not paid on the hot delivery path when metrics are turned off.
+     */
+    private void recordDeliveryOnSuccess(ChannelFuture future, long startTime) {
+        if (!statsEnabled) {
+            return;
+        }
+        future.addListener(f -> {
+            if (f.isSuccess()) {
+                deliveryTimerStats.logDelivery(startTime, TimeUnit.NANOSECONDS);
+            }
+        });
     }
 
 }

--- a/application/src/test/java/org/thingsboard/mqtt/broker/actors/service/ContextAwareActorTest.java
+++ b/application/src/test/java/org/thingsboard/mqtt/broker/actors/service/ContextAwareActorTest.java
@@ -1,0 +1,60 @@
+/**
+ * Copyright © 2016-2026 The Thingsboard Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.thingsboard.mqtt.broker.actors.service;
+
+import org.junit.Test;
+import org.thingsboard.mqtt.broker.actors.ActorSystemContext;
+import org.thingsboard.mqtt.broker.actors.msg.MsgType;
+import org.thingsboard.mqtt.broker.actors.msg.TbActorMsg;
+
+import java.util.concurrent.atomic.AtomicLong;
+
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class ContextAwareActorTest {
+
+    @Test
+    public void givenSubMillisecondWork_whenProcess_thenReportsProcessingTimeInNanoseconds() {
+        AtomicLong captured = new AtomicLong(-1);
+        ActorProcessingMetricService capturingService = (msgType, time) -> captured.set(time);
+
+        ActorSystemContext systemContext = mock(ActorSystemContext.class);
+        when(systemContext.getActorProcessingMetricService()).thenReturn(capturingService);
+
+        ContextAwareActor actor = new ContextAwareActor(systemContext) {
+            @Override
+            protected boolean doProcess(TbActorMsg msg) {
+                try {
+                    Thread.sleep(2);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
+                return true;
+            }
+        };
+
+        TbActorMsg msg = mock(TbActorMsg.class);
+        when(msg.getMsgType()).thenReturn(MsgType.INCOMING_PUBLISH_MSG);
+
+        actor.process(msg);
+
+        // A ~2 ms operation is ~2_000_000 ns but only ~2 ms. A value this large can only be nanoseconds,
+        // proving the actor reports StopWatch.getNanoTime() rather than the millisecond getTime().
+        assertTrue("expected nanosecond-scale processing time but got " + captured.get(), captured.get() > 100_000L);
+    }
+}

--- a/application/src/test/java/org/thingsboard/mqtt/broker/actors/service/MsgTypeActorProcessingMetricServiceTest.java
+++ b/application/src/test/java/org/thingsboard/mqtt/broker/actors/service/MsgTypeActorProcessingMetricServiceTest.java
@@ -1,0 +1,57 @@
+/**
+ * Copyright © 2016-2026 The Thingsboard Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.thingsboard.mqtt.broker.actors.service;
+
+import io.micrometer.core.instrument.Timer;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.Before;
+import org.junit.Test;
+import org.thingsboard.mqtt.broker.actors.msg.MsgType;
+import org.thingsboard.mqtt.broker.common.stats.DefaultStatsFactory;
+import org.thingsboard.mqtt.broker.common.stats.StatsConstantNames;
+import org.thingsboard.mqtt.broker.common.stats.StatsFactory;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+public class MsgTypeActorProcessingMetricServiceTest {
+
+    SimpleMeterRegistry meterRegistry;
+    MsgTypeActorProcessingMetricService service;
+
+    @Before
+    public void setUp() {
+        meterRegistry = new SimpleMeterRegistry();
+        StatsFactory statsFactory = new DefaultStatsFactory(meterRegistry);
+        service = new MsgTypeActorProcessingMetricService(statsFactory);
+    }
+
+    @Test
+    public void givenSubMillisNanoTime_whenLogMsgProcessingTime_thenTimerRecordsInNanoseconds() {
+        // 1.5 ms expressed in nanoseconds — the unit ContextAwareActor supplies via StopWatch.getNanoTime().
+        // If the timer records the value as MILLISECONDS, the recorded total is 1_500_000 ms, not 1.5 ms.
+        service.logMsgProcessingTime(MsgType.INCOMING_PUBLISH_MSG, 1_500_000L);
+
+        Timer timer = meterRegistry.find("actors.processing")
+                .tag(StatsConstantNames.MSG_TYPE, MsgType.INCOMING_PUBLISH_MSG.toString())
+                .timer();
+        assertNotNull(timer);
+        assertEquals(1, timer.count());
+        assertEquals(1.5, timer.totalTime(TimeUnit.MILLISECONDS), 0.001);
+    }
+}

--- a/application/src/test/java/org/thingsboard/mqtt/broker/service/mqtt/delivery/DefaultMqttPublishMsgDeliveryServiceTest.java
+++ b/application/src/test/java/org/thingsboard/mqtt/broker/service/mqtt/delivery/DefaultMqttPublishMsgDeliveryServiceTest.java
@@ -1,0 +1,192 @@
+/**
+ * Copyright © 2016-2026 The Thingsboard Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.thingsboard.mqtt.broker.service.mqtt.delivery;
+
+import io.micrometer.core.instrument.Timer;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.codec.mqtt.MqttFixedHeader;
+import io.netty.handler.codec.mqtt.MqttPublishMessage;
+import io.netty.util.concurrent.GenericFutureListener;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.thingsboard.mqtt.broker.common.stats.DefaultStatsFactory;
+import org.thingsboard.mqtt.broker.common.stats.StatsFactory;
+import org.thingsboard.mqtt.broker.common.stats.StatsType;
+import org.thingsboard.mqtt.broker.service.historical.stats.TbMessageStatsReportClient;
+import org.thingsboard.mqtt.broker.service.stats.StatsManager;
+import org.thingsboard.mqtt.broker.service.stats.timer.TimerStats;
+import org.thingsboard.mqtt.broker.session.ClientSessionCtx;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class DefaultMqttPublishMsgDeliveryServiceTest {
+
+    @Mock
+    ClientSessionCtx ctx;
+    @Mock
+    ChannelHandlerContext channel;
+    @Mock
+    ChannelFuture future;
+    @Mock
+    MqttPublishMessage msg;
+    @Mock
+    TbMessageStatsReportClient reportClient;
+
+    SimpleMeterRegistry meterRegistry;
+
+    @Before
+    public void setUp() {
+        lenient().when(ctx.getChannel()).thenReturn(channel);
+    }
+
+    private DefaultMqttPublishMsgDeliveryService buildService(boolean statsEnabled) {
+        meterRegistry = new SimpleMeterRegistry();
+        StatsFactory statsFactory = new DefaultStatsFactory(meterRegistry);
+        TimerStats timerStats = new TimerStats(statsFactory);
+        StatsManager statsManager = mock(StatsManager.class);
+        when(statsManager.isEnabled()).thenReturn(statsEnabled);
+        when(statsManager.getDeliveryTimerStats()).thenReturn(timerStats);
+        return new DefaultMqttPublishMsgDeliveryService(reportClient, statsManager);
+    }
+
+    private Timer deliveryTimer() {
+        return meterRegistry.find(StatsType.DELIVERY.getPrintName()).timer();
+    }
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    private GenericFutureListener captureListener() {
+        ArgumentCaptor<GenericFutureListener> captor = ArgumentCaptor.forClass(GenericFutureListener.class);
+        verify(future).addListener(captor.capture());
+        return captor.getValue();
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void givenStatsEnabled_whenSendPublish_thenDeliveryRecordedOnFutureCompletionNotSynchronously() throws Exception {
+        DefaultMqttPublishMsgDeliveryService service = buildService(true);
+        when(ctx.addInFlightMsg(msg)).thenReturn(true);
+        when(channel.writeAndFlush(msg)).thenReturn(future);
+        when(future.isSuccess()).thenReturn(true);
+
+        service.sendPublishMsgToClient(ctx, msg);
+
+        // Delivery must be recorded when the async write completes, not synchronously at submission.
+        assertEquals(0, deliveryTimer().count());
+        captureListener().operationComplete(future);
+        assertEquals(1, deliveryTimer().count());
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void givenStatsEnabled_whenWriteFutureFails_thenDeliveryNotRecorded() throws Exception {
+        DefaultMqttPublishMsgDeliveryService service = buildService(true);
+        when(ctx.addInFlightMsg(msg)).thenReturn(true);
+        when(channel.writeAndFlush(msg)).thenReturn(future);
+        when(future.isSuccess()).thenReturn(false);
+
+        service.sendPublishMsgToClient(ctx, msg);
+        captureListener().operationComplete(future);
+
+        assertEquals(0, deliveryTimer().count());
+    }
+
+    @Test
+    public void givenStatsDisabled_whenSendPublish_thenNoListenerAttachedButMessageStillWritten() {
+        DefaultMqttPublishMsgDeliveryService service = buildService(false);
+        when(ctx.addInFlightMsg(msg)).thenReturn(true);
+        when(channel.writeAndFlush(msg)).thenReturn(future);
+
+        service.sendPublishMsgToClient(ctx, msg);
+
+        verify(channel).writeAndFlush(msg);
+        verify(future, never()).addListener(any(GenericFutureListener.class));
+        assertNotNull(deliveryTimer());
+        assertEquals(0, deliveryTimer().count());
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void givenStatsEnabled_whenSendPublishWithoutFlush_thenWritesWithoutFlushAndRecordsOnCompletion() throws Exception {
+        DefaultMqttPublishMsgDeliveryService service = buildService(true);
+        when(ctx.addInFlightMsg(msg)).thenReturn(true);
+        when(channel.write(msg)).thenReturn(future);
+        when(future.isSuccess()).thenReturn(true);
+
+        service.sendPublishMsgToClientWithoutFlush(ctx, msg);
+
+        verify(channel).write(msg);
+        captureListener().operationComplete(future);
+        assertEquals(1, deliveryTimer().count());
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void givenStatsEnabled_whenSendAlreadyTracked_thenRecordsOnCompletion() throws Exception {
+        DefaultMqttPublishMsgDeliveryService service = buildService(true);
+        when(channel.writeAndFlush(msg)).thenReturn(future);
+        when(future.isSuccess()).thenReturn(true);
+
+        service.sendAlreadyTrackedPublishMsgToClient(ctx, msg);
+
+        assertEquals(0, deliveryTimer().count());
+        captureListener().operationComplete(future);
+        assertEquals(1, deliveryTimer().count());
+    }
+
+    @Test
+    public void givenInFlightSlotNotReserved_whenSendPublish_thenNothingWrittenOrRecorded() {
+        DefaultMqttPublishMsgDeliveryService service = buildService(true);
+        when(ctx.addInFlightMsg(msg)).thenReturn(false);
+
+        service.sendPublishMsgToClient(ctx, msg);
+
+        verify(channel, never()).writeAndFlush(any());
+        verify(future, never()).addListener(any(GenericFutureListener.class));
+        verify(reportClient, never()).reportDroppedMsgs();
+        assertEquals(0, deliveryTimer().count());
+    }
+
+    @Test
+    public void givenWriteThrowsSynchronously_whenSendPublishNonRetained_thenReportsDroppedAndRecordsNothing() {
+        DefaultMqttPublishMsgDeliveryService service = buildService(true);
+        MqttFixedHeader fixedHeader = mock(MqttFixedHeader.class);
+        when(fixedHeader.isRetain()).thenReturn(false);
+        when(msg.fixedHeader()).thenReturn(fixedHeader);
+        when(ctx.addInFlightMsg(msg)).thenReturn(true);
+        when(channel.writeAndFlush(msg)).thenThrow(new RuntimeException("boom"));
+
+        service.sendPublishMsgToClient(ctx, msg);
+
+        verify(reportClient, times(1)).reportDroppedMsgs();
+        verify(future, never()).addListener(any(GenericFutureListener.class));
+        assertEquals(0, deliveryTimer().count());
+    }
+}


### PR DESCRIPTION
## Pull Request description

Two timer-metric fixes on the `application` module stats surface. Both are **backward compatible** — no metric names change.

**1. Record the `actors.processing` timer in nanoseconds.**
`ContextAwareActor.process` timed each actor message with `StopWatch.getTime()` (milliseconds) and `MsgTypeActorProcessingMetricService` recorded `TimeUnit.MILLISECONDS`, so any sub-millisecond actor work rounded to `0` and the timer's mean/max were meaningless. It now uses `StopWatch.getNanoTime()` and records `TimeUnit.NANOSECONDS`, matching the always-on sibling `clientActor.processing.time`. Micrometer/Prometheus still export the timer in seconds — only the internal resolution improves. The metric stays gated behind `actors.system.processing-metrics.enabled` (default `false`).

**2. Measure the `delivery` timer on write completion instead of enqueue.**
The `delivery` timer bracketed the synchronous return of the Netty `writeAndFlush`/`write` calls, which are asynchronous — so it measured the cost of handing the write off to the event loop, not delivery. It is now recorded from a `ChannelFuture` listener when the write completes successfully (once the PUBLISH bytes are written to the socket), across all three send paths in `DefaultMqttPublishMsgDeliveryService`. For the batched no-flush path the `write()` future completes at the subsequent `flush()`, so the measurement is consistent across paths and now includes batch-wait latency. The listener is attached only when stats are enabled (`stats.enabled`), so no per-message listener allocation or event-loop callback is paid on the hot delivery path when metrics are off. The metric name `delivery` is intentionally kept.

**Operator note — re-baseline `delivery` after upgrade:** the timer now counts only successfully-completed writes (previously every enqueue) and includes batch-wait latency on the batched path, so dashboards/alerts on `delivery` count and latency should be re-checked.

## General checklist

- [x] You have reviewed the guidelines [document](https://docs.google.com/document/d/1A4Vc3wrHsY_159b9RG5LOtCryoH6VPwgOhrFEzJKwbI/edit?usp=sharing).
- [x] [Labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels#about-labels) that classify your pull request have been added.
- [x] The [milestone](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones) is specified and corresponds to fix version.
- [x] Description references specific [issue](https://github.com/thingsboard/tbmq/issues). — part of the broader Prometheus metrics-usability review; no single dedicated issue.
- [x] Description contains human-readable scope of changes.
- [x] Description contains brief notes about what needs to be added to the documentation.
- [x] No merge conflicts, commented blocks of code, code formatting issues.
- [x] Changes are backward compatible or upgrade script is provided.

## Front-End feature checklist

- N/A — no front-end changes.

## Back-End feature checklist

- [x] Added corresponding unit and/or integration test(s). New tests: `MsgTypeActorProcessingMetricServiceTest`, `ContextAwareActorTest`, and `DefaultMqttPublishMsgDeliveryServiceTest` (9 tests total) asserting against a `SimpleMeterRegistry`.
- [x] No new dependency was added.
