### PR TITLE
refactor(stats): remove dead msgDownlink counter and rename metrics for Prometheus

### DIFF
--- a/application/src/main/java/org/thingsboard/mqtt/broker/actors/client/service/channel/ChannelBackpressureManagerImpl.java
+++ b/application/src/main/java/org/thingsboard/mqtt/broker/actors/client/service/channel/ChannelBackpressureManagerImpl.java
@@ -48,7 +48,7 @@ public class ChannelBackpressureManagerImpl implements ChannelBackpressureManage
 
     @PostConstruct
     public void init() {
-        this.nonWritableClientsCount = statsManager.createNonWritableClientsCounter();
+        this.nonWritableClientsCount = statsManager.createNonWritableClientsGauge();
     }
 
     @Override

--- a/application/src/main/java/org/thingsboard/mqtt/broker/service/mqtt/retain/ConcurrentMapRetainMsgTrie.java
+++ b/application/src/main/java/org/thingsboard/mqtt/broker/service/mqtt/retain/ConcurrentMapRetainMsgTrie.java
@@ -52,8 +52,8 @@ public class ConcurrentMapRetainMsgTrie<T> implements RetainMsgTrie<T> {
     private int waitForClearLockMs;
 
     public ConcurrentMapRetainMsgTrie(StatsManager statsManager) {
-        this.size = statsManager.createRetainMsgSizeCounter();
-        this.nodesCount = statsManager.createRetainMsgTrieNodesCounter();
+        this.size = statsManager.createRetainMsgSizeGauge();
+        this.nodesCount = statsManager.createRetainMsgTrieNodesGauge();
     }
 
     @EqualsAndHashCode

--- a/application/src/main/java/org/thingsboard/mqtt/broker/service/stats/ClientSubscriptionConsumerStats.java
+++ b/application/src/main/java/org/thingsboard/mqtt/broker/service/stats/ClientSubscriptionConsumerStats.java
@@ -20,9 +20,9 @@ import org.thingsboard.mqtt.broker.common.stats.StatsCounter;
 import java.util.List;
 
 public interface ClientSubscriptionConsumerStats {
-    void logTotal(int totalSubscriptions);
+    void logTotal(int totalRecords);
 
-    void log(int acceptedSubscriptions, int ignoredSubscriptions);
+    void log(int acceptedRecords, int ignoredRecords);
 
     List<StatsCounter> getStatsCounters();
 

--- a/application/src/main/java/org/thingsboard/mqtt/broker/service/stats/DefaultClientSubscriptionConsumerStats.java
+++ b/application/src/main/java/org/thingsboard/mqtt/broker/service/stats/DefaultClientSubscriptionConsumerStats.java
@@ -21,35 +21,35 @@ import org.thingsboard.mqtt.broker.common.stats.StatsType;
 
 import java.util.List;
 
-import static org.thingsboard.mqtt.broker.common.stats.StatsConstantNames.ACCEPTED_SUBSCRIPTIONS;
-import static org.thingsboard.mqtt.broker.common.stats.StatsConstantNames.IGNORED_SUBSCRIPTIONS;
-import static org.thingsboard.mqtt.broker.common.stats.StatsConstantNames.TOTAL_SUBSCRIPTIONS;
+import static org.thingsboard.mqtt.broker.common.stats.StatsConstantNames.ACCEPTED_RECORDS;
+import static org.thingsboard.mqtt.broker.common.stats.StatsConstantNames.IGNORED_RECORDS;
+import static org.thingsboard.mqtt.broker.common.stats.StatsConstantNames.TOTAL_RECORDS;
 
 public class DefaultClientSubscriptionConsumerStats implements ClientSubscriptionConsumerStats {
     private final List<StatsCounter> counters;
 
-    private final StatsCounter totalSubscriptionCounter;
-    private final StatsCounter acceptedSubscriptionCounter;
-    private final StatsCounter ignoredSubscriptionCounter;
+    private final StatsCounter totalRecordCounter;
+    private final StatsCounter acceptedRecordCounter;
+    private final StatsCounter ignoredRecordCounter;
 
     public DefaultClientSubscriptionConsumerStats(StatsFactory statsFactory) {
         String statsKey = StatsType.CLIENT_SUBSCRIPTIONS_CONSUMER.getPrintName();
-        this.totalSubscriptionCounter = statsFactory.createStatsCounter(statsKey, TOTAL_SUBSCRIPTIONS);
-        this.acceptedSubscriptionCounter = statsFactory.createStatsCounter(statsKey, ACCEPTED_SUBSCRIPTIONS);
-        this.ignoredSubscriptionCounter = statsFactory.createStatsCounter(statsKey, IGNORED_SUBSCRIPTIONS);
+        this.totalRecordCounter = statsFactory.createStatsCounter(statsKey, TOTAL_RECORDS);
+        this.acceptedRecordCounter = statsFactory.createStatsCounter(statsKey, ACCEPTED_RECORDS);
+        this.ignoredRecordCounter = statsFactory.createStatsCounter(statsKey, IGNORED_RECORDS);
 
-        counters = List.of(totalSubscriptionCounter, acceptedSubscriptionCounter, ignoredSubscriptionCounter);
+        counters = List.of(totalRecordCounter, acceptedRecordCounter, ignoredRecordCounter);
     }
 
     @Override
-    public void logTotal(int totalSubscriptions) {
-        totalSubscriptionCounter.add(totalSubscriptions);
+    public void logTotal(int totalRecords) {
+        totalRecordCounter.add(totalRecords);
     }
 
     @Override
-    public void log(int acceptedSubscriptions, int ignoredSubscriptions) {
-        acceptedSubscriptionCounter.add(acceptedSubscriptions);
-        ignoredSubscriptionCounter.add(ignoredSubscriptions);
+    public void log(int acceptedRecords, int ignoredRecords) {
+        acceptedRecordCounter.add(acceptedRecords);
+        ignoredRecordCounter.add(ignoredRecords);
     }
 
     @Override

--- a/application/src/main/java/org/thingsboard/mqtt/broker/service/stats/StatsManager.java
+++ b/application/src/main/java/org/thingsboard/mqtt/broker/service/stats/StatsManager.java
@@ -68,15 +68,15 @@ public interface StatsManager {
 
     void clearSharedApplicationProcessorStats(String clientId, TopicSharedSubscription subscription);
 
-    AtomicInteger createNonWritableClientsCounter();
+    AtomicInteger createNonWritableClientsGauge();
 
-    AtomicInteger createSubscriptionSizeCounter();
+    AtomicInteger createSubscriptionSizeGauge();
 
-    AtomicInteger createRetainMsgSizeCounter();
+    AtomicInteger createRetainMsgSizeGauge();
 
-    AtomicLong createSubscriptionTrieNodesCounter();
+    AtomicLong createSubscriptionTrieNodesGauge();
 
-    AtomicLong createRetainMsgTrieNodesCounter();
+    AtomicLong createRetainMsgTrieNodesGauge();
 
     void registerLastWillStats(Map<?, ?> lastWillMsgsMap);
 

--- a/application/src/main/java/org/thingsboard/mqtt/broker/service/stats/StatsManagerImpl.java
+++ b/application/src/main/java/org/thingsboard/mqtt/broker/service/stats/StatsManagerImpl.java
@@ -364,9 +364,10 @@ public class StatsManagerImpl implements StatsManager, ActorStatsManager, SqlQue
         String statsKey = StatsType.SQL_QUEUE.getPrintName();
         // Carry the queue name as a `queueName` tag on a single `sqlQueue` metric rather than baking it into
         // the metric name (`sqlQueue.<queueName>`); a stable name with a bounded tag is the Prometheus-idiomatic
-        // shape and lets consumers aggregate across queues.
-        MessagesStats stats = statsFactory.createMessagesStats(statsKey,
-                "queueName", queueName, "queueIndex", String.valueOf(queueIndex));
+        // shape and lets consumers aggregate across queues. The counters and the queueSize gauge below must
+        // share the same tag set so consumers can correlate throughput with depth per queue, so build it once.
+        String[] tags = {"queueName", queueName, "queueIndex", String.valueOf(queueIndex)};
+        MessagesStats stats = statsFactory.createMessagesStats(statsKey, tags);
         managedStats.add(stats);
         // Export the live SQL queue depth as a Micrometer gauge (backpressure/durability signal that was
         // previously computed and logged but never scraped). The queue::size supplier is wired later by
@@ -374,7 +375,7 @@ public class StatsManagerImpl implements StatsManager, ActorStatsManager, SqlQue
         // weak reference to the gauge's state object, but the stats instance is strong-held by managedStats
         // above for the process lifetime, so it will not be GC'd (which would make the gauge report NaN).
         statsFactory.createGauge(statsKey + "." + StatsConstantNames.QUEUE_SIZE, stats,
-                MessagesStats::getCurrentQueueSize, "queueName", queueName, "queueIndex", String.valueOf(queueIndex));
+                MessagesStats::getCurrentQueueSize, tags);
         return stats;
     }
 

--- a/application/src/main/java/org/thingsboard/mqtt/broker/service/stats/StatsManagerImpl.java
+++ b/application/src/main/java/org/thingsboard/mqtt/broker/service/stats/StatsManagerImpl.java
@@ -251,24 +251,24 @@ public class StatsManagerImpl implements StatsManager, ActorStatsManager, SqlQue
     }
 
     @Override
-    public AtomicInteger createNonWritableClientsCounter() {
-        log.trace("Creating NonWritableClientsCounter");
+    public AtomicInteger createNonWritableClientsGauge() {
+        log.trace("Creating NonWritableClientsGauge");
         AtomicInteger sizeGauge = statsFactory.createGauge(StatsType.NON_WRITABLE_CLIENTS.getPrintName(), new AtomicInteger(0));
         gauges.add(new Gauge(StatsType.NON_WRITABLE_CLIENTS.getPrintName(), sizeGauge::get));
         return sizeGauge;
     }
 
     @Override
-    public AtomicInteger createSubscriptionSizeCounter() {
-        log.trace("Creating SubscriptionSizeCounter");
+    public AtomicInteger createSubscriptionSizeGauge() {
+        log.trace("Creating SubscriptionSizeGauge");
         AtomicInteger sizeGauge = statsFactory.createGauge(StatsType.SUBSCRIPTION_TOPIC_TRIE_SIZE.getPrintName(), new AtomicInteger(0));
         gauges.add(new Gauge(StatsType.SUBSCRIPTION_TOPIC_TRIE_SIZE.getPrintName(), sizeGauge::get));
         return sizeGauge;
     }
 
     @Override
-    public AtomicInteger createRetainMsgSizeCounter() {
-        log.trace("Creating RetainMsgSizeCounter");
+    public AtomicInteger createRetainMsgSizeGauge() {
+        log.trace("Creating RetainMsgSizeGauge");
         AtomicInteger sizeGauge = statsFactory.createGauge(StatsType.RETAIN_MSG_TRIE_SIZE.getPrintName(), new AtomicInteger(0));
         gauges.add(new Gauge(StatsType.RETAIN_MSG_TRIE_SIZE.getPrintName(), sizeGauge::get));
         return sizeGauge;
@@ -343,16 +343,16 @@ public class StatsManagerImpl implements StatsManager, ActorStatsManager, SqlQue
     }
 
     @Override
-    public AtomicLong createSubscriptionTrieNodesCounter() {
-        log.trace("Creating SubscriptionTrieNodesCounter");
+    public AtomicLong createSubscriptionTrieNodesGauge() {
+        log.trace("Creating SubscriptionTrieNodesGauge");
         AtomicLong sizeGauge = statsFactory.createGauge(StatsType.SUBSCRIPTION_TRIE_NODES.getPrintName(), new AtomicLong(0));
         gauges.add(new Gauge(StatsType.SUBSCRIPTION_TRIE_NODES.getPrintName(), sizeGauge::get));
         return sizeGauge;
     }
 
     @Override
-    public AtomicLong createRetainMsgTrieNodesCounter() {
-        log.trace("Creating RetainMsgTrieNodesCounter");
+    public AtomicLong createRetainMsgTrieNodesGauge() {
+        log.trace("Creating RetainMsgTrieNodesGauge");
         AtomicLong sizeGauge = statsFactory.createGauge(StatsType.RETAIN_MSG_TRIE_NODES.getPrintName(), new AtomicLong(0));
         gauges.add(new Gauge(StatsType.RETAIN_MSG_TRIE_NODES.getPrintName(), sizeGauge::get));
         return sizeGauge;

--- a/application/src/main/java/org/thingsboard/mqtt/broker/service/stats/StatsManagerImpl.java
+++ b/application/src/main/java/org/thingsboard/mqtt/broker/service/stats/StatsManagerImpl.java
@@ -361,8 +361,12 @@ public class StatsManagerImpl implements StatsManager, ActorStatsManager, SqlQue
     @Override
     public MessagesStats createSqlQueueStats(String queueName, int queueIndex) {
         log.trace("Creating SqlQueueStats, queueName - {}, queueIndex - {}", queueName, queueIndex);
-        String statsKey = StatsType.SQL_QUEUE.getPrintName() + "." + queueName;
-        MessagesStats stats = statsFactory.createMessagesStats(statsKey, "queueIndex", String.valueOf(queueIndex));
+        String statsKey = StatsType.SQL_QUEUE.getPrintName();
+        // Carry the queue name as a `queueName` tag on a single `sqlQueue` metric rather than baking it into
+        // the metric name (`sqlQueue.<queueName>`); a stable name with a bounded tag is the Prometheus-idiomatic
+        // shape and lets consumers aggregate across queues.
+        MessagesStats stats = statsFactory.createMessagesStats(statsKey,
+                "queueName", queueName, "queueIndex", String.valueOf(queueIndex));
         managedStats.add(stats);
         // Export the live SQL queue depth as a Micrometer gauge (backpressure/durability signal that was
         // previously computed and logged but never scraped). The queue::size supplier is wired later by
@@ -370,7 +374,7 @@ public class StatsManagerImpl implements StatsManager, ActorStatsManager, SqlQue
         // weak reference to the gauge's state object, but the stats instance is strong-held by managedStats
         // above for the process lifetime, so it will not be GC'd (which would make the gauge report NaN).
         statsFactory.createGauge(statsKey + "." + StatsConstantNames.QUEUE_SIZE, stats,
-                MessagesStats::getCurrentQueueSize, "queueIndex", String.valueOf(queueIndex));
+                MessagesStats::getCurrentQueueSize, "queueName", queueName, "queueIndex", String.valueOf(queueIndex));
         return stats;
     }
 
@@ -384,8 +388,7 @@ public class StatsManagerImpl implements StatsManager, ActorStatsManager, SqlQue
     @Override
     public Timer createCommitTimer(String clientId) {
         ResettableTimer timer = new ResettableTimer(statsFactory.createTimer(StatsType.QUEUE_CONSUMER.getPrintName(),
-                "consumerId", clientId,
-                "operation", "syncCommit"));
+                "consumerId", clientId));
         managedQueueConsumers.put(clientId, timer);
         return timer::logTime;
     }

--- a/application/src/main/java/org/thingsboard/mqtt/broker/service/stats/StatsManagerStub.java
+++ b/application/src/main/java/org/thingsboard/mqtt/broker/service/stats/StatsManagerStub.java
@@ -115,17 +115,17 @@ public class StatsManagerStub implements StatsManager, ActorStatsManager, Produc
     }
 
     @Override
-    public AtomicInteger createNonWritableClientsCounter() {
+    public AtomicInteger createNonWritableClientsGauge() {
         return new AtomicInteger(0);
     }
 
     @Override
-    public AtomicInteger createSubscriptionSizeCounter() {
+    public AtomicInteger createSubscriptionSizeGauge() {
         return new AtomicInteger(0);
     }
 
     @Override
-    public AtomicInteger createRetainMsgSizeCounter() {
+    public AtomicInteger createRetainMsgSizeGauge() {
         return new AtomicInteger(0);
     }
 
@@ -204,12 +204,12 @@ public class StatsManagerStub implements StatsManager, ActorStatsManager, Produc
     }
 
     @Override
-    public AtomicLong createSubscriptionTrieNodesCounter() {
+    public AtomicLong createSubscriptionTrieNodesGauge() {
         return new AtomicLong(0);
     }
 
     @Override
-    public AtomicLong createRetainMsgTrieNodesCounter() {
+    public AtomicLong createRetainMsgTrieNodesGauge() {
         return new AtomicLong(0);
     }
 

--- a/application/src/main/java/org/thingsboard/mqtt/broker/service/stats/StubClientSubscriptionConsumerStats.java
+++ b/application/src/main/java/org/thingsboard/mqtt/broker/service/stats/StubClientSubscriptionConsumerStats.java
@@ -27,12 +27,12 @@ public class StubClientSubscriptionConsumerStats implements ClientSubscriptionCo
     }
 
     @Override
-    public void logTotal(int totalSubscriptions) {
+    public void logTotal(int totalRecords) {
 
     }
 
     @Override
-    public void log(int acceptedSubscriptions, int ignoredSubscriptions) {
+    public void log(int acceptedRecords, int ignoredRecords) {
 
     }
 

--- a/application/src/main/java/org/thingsboard/mqtt/broker/service/subscription/ClientSubscriptionConsumerImpl.java
+++ b/application/src/main/java/org/thingsboard/mqtt/broker/service/subscription/ClientSubscriptionConsumerImpl.java
@@ -167,28 +167,28 @@ public class ClientSubscriptionConsumerImpl implements ClientSubscriptionConsume
     }
 
     void processPack(List<TbProtoQueueMsg<ClientSubscriptionsProto>> messages, ClientSubscriptionChangesCallback callback) {
-        int acceptedSubscriptions = 0;
-        int ignoredSubscriptions = 0;
+        int acceptedRecords = 0;
+        int ignoredRecords = 0;
         for (TbProtoQueueMsg<ClientSubscriptionsProto> msg : messages) {
             String clientId = msg.getKey();
             if (clientId.startsWith(BrokerConstants.SYSTEM_DUMMY_CLIENT_ID_PREFIX)) {
-                ignoredSubscriptions++;
+                ignoredRecords++;
                 continue;
             }
             String serviceId = bytesToString(msg.getHeaders().get(BrokerConstants.SERVICE_ID_HEADER));
             Set<TopicSubscription> clientSubscriptions = ProtoConverter.convertProtoToClientSubscriptions(msg.getValue()).getSubscriptions();
             boolean accepted = callback.accept(clientId, serviceId, clientSubscriptions);
             if (accepted) {
-                acceptedSubscriptions++;
+                acceptedRecords++;
             } else {
-                ignoredSubscriptions++;
+                ignoredRecords++;
             }
         }
         // Record all three counters only after the whole pack is processed and is about to be committed: a mid-pack
         // failure then leaves total/accepted/ignored unchanged, so the invariant total == accepted + ignored holds
         // and a rebalance re-delivery of the uncommitted pack does not double-count.
         stats.logTotal(messages.size());
-        stats.log(acceptedSubscriptions, ignoredSubscriptions);
+        stats.log(acceptedRecords, ignoredRecords);
     }
 
     private String persistDummyClientSubscriptions() throws QueuePersistenceException {

--- a/application/src/main/java/org/thingsboard/mqtt/broker/service/subscription/ConcurrentMapSubscriptionTrie.java
+++ b/application/src/main/java/org/thingsboard/mqtt/broker/service/subscription/ConcurrentMapSubscriptionTrie.java
@@ -56,8 +56,8 @@ public class ConcurrentMapSubscriptionTrie<T> implements SubscriptionTrie<T> {
     private int waitForClearLockMs;
 
     public ConcurrentMapSubscriptionTrie(StatsManager statsManager) {
-        this.size = statsManager.createSubscriptionSizeCounter();
-        this.nodesCount = statsManager.createSubscriptionTrieNodesCounter();
+        this.size = statsManager.createSubscriptionSizeGauge();
+        this.nodesCount = statsManager.createSubscriptionTrieNodesGauge();
     }
 
     @Override

--- a/application/src/test/java/org/thingsboard/mqtt/broker/actors/client/service/channel/ChannelBackpressureManagerImplTest.java
+++ b/application/src/test/java/org/thingsboard/mqtt/broker/actors/client/service/channel/ChannelBackpressureManagerImplTest.java
@@ -70,7 +70,7 @@ public class ChannelBackpressureManagerImplTest {
         when(ctx.isCleanSession()).thenReturn(false);
         when(ctx.getNonWritableCounted()).thenReturn(new AtomicBoolean());
 
-        when(statsManager.createNonWritableClientsCounter()).thenReturn(new AtomicInteger());
+        when(statsManager.createNonWritableClientsGauge()).thenReturn(new AtomicInteger());
         channelBackpressureManager.init();
     }
 

--- a/application/src/test/java/org/thingsboard/mqtt/broker/service/mqtt/retain/ConcurrentMapRetainMsgTrieTest.java
+++ b/application/src/test/java/org/thingsboard/mqtt/broker/service/mqtt/retain/ConcurrentMapRetainMsgTrieTest.java
@@ -45,8 +45,8 @@ public class ConcurrentMapRetainMsgTrieTest {
         this.retainedMsgCounter = new AtomicInteger(0);
         this.nodesCounter = new AtomicLong(0);
         StatsManager statsManagerMock = Mockito.mock(StatsManager.class);
-        Mockito.when(statsManagerMock.createRetainMsgSizeCounter()).thenReturn(retainedMsgCounter);
-        Mockito.when(statsManagerMock.createRetainMsgTrieNodesCounter()).thenReturn(nodesCounter);
+        Mockito.when(statsManagerMock.createRetainMsgSizeGauge()).thenReturn(retainedMsgCounter);
+        Mockito.when(statsManagerMock.createRetainMsgTrieNodesGauge()).thenReturn(nodesCounter);
         this.retainMsgTrie = new ConcurrentMapRetainMsgTrie<>(statsManagerMock);
     }
 

--- a/application/src/test/java/org/thingsboard/mqtt/broker/service/stats/DefaultClientSubscriptionConsumerStatsTest.java
+++ b/application/src/test/java/org/thingsboard/mqtt/broker/service/stats/DefaultClientSubscriptionConsumerStatsTest.java
@@ -1,0 +1,53 @@
+/**
+ * Copyright © 2016-2026 The Thingsboard Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.thingsboard.mqtt.broker.service.stats;
+
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.Before;
+import org.junit.Test;
+import org.thingsboard.mqtt.broker.common.stats.DefaultStatsFactory;
+import org.thingsboard.mqtt.broker.common.stats.StatsFactory;
+import org.thingsboard.mqtt.broker.common.stats.StatsType;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.thingsboard.mqtt.broker.common.stats.StatsConstantNames.STATS_NAME_TAG;
+
+public class DefaultClientSubscriptionConsumerStatsTest {
+
+    private static final String NAME = StatsType.CLIENT_SUBSCRIPTIONS_CONSUMER.getPrintName();
+
+    private SimpleMeterRegistry meterRegistry;
+
+    @Before
+    public void setUp() {
+        meterRegistry = new SimpleMeterRegistry();
+    }
+
+    @Test
+    public void givenStats_whenCreated_thenCountersUseRecordStatsNames() {
+        StatsFactory statsFactory = new DefaultStatsFactory(meterRegistry);
+        new DefaultClientSubscriptionConsumerStats(statsFactory);
+
+        // The consumer counts Kafka records read per poll, not topic subscriptions, so the stats names
+        // are `*Records` rather than the misleading `*Subscriptions`.
+        assertEquals(1, meterRegistry.find(NAME).tag(STATS_NAME_TAG, "totalRecords").counters().size());
+        assertEquals(1, meterRegistry.find(NAME).tag(STATS_NAME_TAG, "acceptedRecords").counters().size());
+        assertEquals(1, meterRegistry.find(NAME).tag(STATS_NAME_TAG, "ignoredRecords").counters().size());
+        // The old `*Subscriptions` stats names are gone.
+        assertTrue(meterRegistry.find(NAME).tag(STATS_NAME_TAG, "totalSubscriptions").counters().isEmpty());
+    }
+}

--- a/application/src/test/java/org/thingsboard/mqtt/broker/service/stats/DefaultClientSubscriptionConsumerStatsTest.java
+++ b/application/src/test/java/org/thingsboard/mqtt/broker/service/stats/DefaultClientSubscriptionConsumerStatsTest.java
@@ -49,5 +49,7 @@ public class DefaultClientSubscriptionConsumerStatsTest {
         assertEquals(1, meterRegistry.find(NAME).tag(STATS_NAME_TAG, "ignoredRecords").counters().size());
         // The old `*Subscriptions` stats names are gone.
         assertTrue(meterRegistry.find(NAME).tag(STATS_NAME_TAG, "totalSubscriptions").counters().isEmpty());
+        assertTrue(meterRegistry.find(NAME).tag(STATS_NAME_TAG, "acceptedSubscriptions").counters().isEmpty());
+        assertTrue(meterRegistry.find(NAME).tag(STATS_NAME_TAG, "ignoredSubscriptions").counters().isEmpty());
     }
 }

--- a/application/src/test/java/org/thingsboard/mqtt/broker/service/stats/StatsManagerImplTest.java
+++ b/application/src/test/java/org/thingsboard/mqtt/broker/service/stats/StatsManagerImplTest.java
@@ -117,7 +117,8 @@ public class StatsManagerImplTest {
     public void givenSqlQueueStats_whenCreated_thenQueueSizeGaugeRegisteredAndReflectsLiveDepth() {
         MessagesStats stats = statsManager.createSqlQueueStats("Events", 0);
 
-        Gauge gauge = meterRegistry.find(SQL_QUEUE + ".Events.queueSize").tag("queueIndex", "0").gauge();
+        Gauge gauge = meterRegistry.find(SQL_QUEUE + ".queueSize")
+                .tag("queueName", "Events").tag("queueIndex", "0").gauge();
         assertNotNull(gauge);
         // No queue supplier wired yet (TbSqlBlockingQueue#init wires it later) -> depth reads 0, not NaN.
         assertEquals(0.0, gauge.value(), 0.0);
@@ -127,6 +128,37 @@ public class StatsManagerImplTest {
         stats.updateQueueSize(depth::get);
         depth.set(7);
         assertEquals(7.0, gauge.value(), 0.0);
+    }
+
+    @Test
+    public void givenSqlQueueStats_whenCreated_thenQueueNameIsATagNotAMetricNameSegment() {
+        statsManager.createSqlQueueStats("Events", 0);
+
+        // The queue name is carried as a `queueName` tag on a single `sqlQueue` metric ...
+        assertEquals(3, meterRegistry.find(SQL_QUEUE)
+                .tag("queueName", "Events").tag("queueIndex", "0").counters().size());
+        // ... not baked into the metric name (the old `sqlQueue.<queueName>` form is gone).
+        assertTrue(meterRegistry.find(SQL_QUEUE + ".Events").counters().isEmpty());
+    }
+
+    @Test
+    public void givenSendTimer_whenCreated_thenRegisteredUnderKafkaProducerSendName() {
+        statsManager.createSendTimer("client-1");
+
+        assertEquals(1, meterRegistry.find("kafkaProducer.send").tag("producerId", "client-1").timers().size());
+        // The old generic `producer` name is gone.
+        assertTrue(meterRegistry.find("producer").timers().isEmpty());
+    }
+
+    @Test
+    public void givenCommitTimer_whenCreated_thenRegisteredUnderKafkaConsumerCommitWithoutOperationTag() {
+        statsManager.createCommitTimer("client-1");
+
+        assertEquals(1, meterRegistry.find("kafkaConsumer.commit").tag("consumerId", "client-1").timers().size());
+        // The always-constant `operation=syncCommit` tag is dropped ...
+        assertTrue(meterRegistry.find("kafkaConsumer.commit").tag("operation", "syncCommit").timers().isEmpty());
+        // ... and the old generic `consumer` name is gone.
+        assertTrue(meterRegistry.find("consumer").timers().isEmpty());
     }
 
     @Test

--- a/application/src/test/java/org/thingsboard/mqtt/broker/service/subscription/ConcurrentMapSubscriptionTrieTest.java
+++ b/application/src/test/java/org/thingsboard/mqtt/broker/service/subscription/ConcurrentMapSubscriptionTrieTest.java
@@ -45,8 +45,8 @@ public class ConcurrentMapSubscriptionTrieTest {
         this.subscriptionCounter = new AtomicInteger(0);
         this.nodesCounter = new AtomicLong(0);
         StatsManager statsManagerMock = Mockito.mock(StatsManager.class);
-        Mockito.when(statsManagerMock.createSubscriptionSizeCounter()).thenReturn(subscriptionCounter);
-        Mockito.when(statsManagerMock.createSubscriptionTrieNodesCounter()).thenReturn(nodesCounter);
+        Mockito.when(statsManagerMock.createSubscriptionSizeGauge()).thenReturn(subscriptionCounter);
+        Mockito.when(statsManagerMock.createSubscriptionTrieNodesGauge()).thenReturn(nodesCounter);
         this.subscriptionTrie = new ConcurrentMapSubscriptionTrie<>(statsManagerMock);
     }
 

--- a/application/src/test/java/org/thingsboard/mqtt/broker/service/subscription/SubscriptionTriePerformanceTest.java
+++ b/application/src/test/java/org/thingsboard/mqtt/broker/service/subscription/SubscriptionTriePerformanceTest.java
@@ -75,8 +75,8 @@ public class SubscriptionTriePerformanceTest {
     @Before
     public void before() {
         StatsManager statsManagerMock = Mockito.mock(StatsManager.class);
-        Mockito.when(statsManagerMock.createSubscriptionSizeCounter()).thenReturn(new AtomicInteger());
-        Mockito.when(statsManagerMock.createSubscriptionTrieNodesCounter()).thenReturn(new AtomicLong());
+        Mockito.when(statsManagerMock.createSubscriptionSizeGauge()).thenReturn(new AtomicInteger());
+        Mockito.when(statsManagerMock.createSubscriptionTrieNodesGauge()).thenReturn(new AtomicLong());
         this.subscriptionTrie = new ConcurrentMapSubscriptionTrie<>(statsManagerMock);
     }
 

--- a/common/integration/cluster-integration-api/src/main/java/org/thingsboard/mqtt/broker/service/DefaultIntegrationStatisticsService.java
+++ b/common/integration/cluster-integration-api/src/main/java/org/thingsboard/mqtt/broker/service/DefaultIntegrationStatisticsService.java
@@ -156,11 +156,6 @@ public class DefaultIntegrationStatisticsService implements IntegrationStatistic
         onMsg(IntegrationStatisticsMetricName.MSGS_UPLINK, integrationType, success);
     }
 
-    @Override
-    public void onDownlinkMsg(IntegrationType integrationType, boolean success) {
-        onMsg(IntegrationStatisticsMetricName.MSGS_DOWNLINK, integrationType, success);
-    }
-
     private void onMsg(IntegrationStatisticsMetricName metric, IntegrationType integrationType, boolean success) {
         try {
             incrementCounter(new IntegrationStatisticsKey(metric, success, integrationType));

--- a/common/integration/integration-api/src/main/java/org/thingsboard/mqtt/broker/integration/api/IntegrationStatisticsService.java
+++ b/common/integration/integration-api/src/main/java/org/thingsboard/mqtt/broker/integration/api/IntegrationStatisticsService.java
@@ -40,8 +40,6 @@ public interface IntegrationStatisticsService {
 
     void onUplinkMsg(IntegrationType integrationType, boolean success);
 
-    void onDownlinkMsg(IntegrationType integrationType, boolean success);
-
     void printStats();
 
     void reset();

--- a/common/integration/integration-api/src/main/java/org/thingsboard/mqtt/broker/integration/api/data/IntegrationStatisticsMetricName.java
+++ b/common/integration/integration-api/src/main/java/org/thingsboard/mqtt/broker/integration/api/data/IntegrationStatisticsMetricName.java
@@ -21,8 +21,7 @@ public enum IntegrationStatisticsMetricName {
 
     START("start"),
     STOP("stop"),
-    MSGS_UPLINK("msgUplink"),
-    MSGS_DOWNLINK("msgDownlink");
+    MSGS_UPLINK("msgUplink");
 
     @Getter
     private final String name;

--- a/common/stats/src/main/java/org/thingsboard/mqtt/broker/common/stats/StatsConstantNames.java
+++ b/common/stats/src/main/java/org/thingsboard/mqtt/broker/common/stats/StatsConstantNames.java
@@ -40,9 +40,9 @@ public class StatsConstantNames {
     public static final String INTEGRATION_ID_TAG = "integrationId";
     public static final String CONSUMER_ID_TAG = "consumerId";
 
-    public static final String TOTAL_SUBSCRIPTIONS = "totalSubscriptions";
-    public static final String ACCEPTED_SUBSCRIPTIONS = "acceptedSubscriptions";
-    public static final String IGNORED_SUBSCRIPTIONS = "ignoredSubscriptions";
+    public static final String TOTAL_RECORDS = "totalRecords";
+    public static final String ACCEPTED_RECORDS = "acceptedRecords";
+    public static final String IGNORED_RECORDS = "ignoredRecords";
 
     public static final String TOTAL_RETAINED_MSGS = "totalRetainedMsgs";
     public static final String NEW_RETAINED_MSGS = "newRetainedMsgs";

--- a/common/stats/src/main/java/org/thingsboard/mqtt/broker/common/stats/StatsType.java
+++ b/common/stats/src/main/java/org/thingsboard/mqtt/broker/common/stats/StatsType.java
@@ -54,8 +54,8 @@ public enum StatsType {
     PERSISTENT_MESSAGES_PROCESSING("persistentMessagesProcessing"),
     DELIVERY("delivery"),
 
-    QUEUE_PRODUCER("producer"),
-    QUEUE_CONSUMER("consumer"),
+    QUEUE_PRODUCER("kafkaProducer.send"),
+    QUEUE_CONSUMER("kafkaConsumer.commit"),
 
     IE_UPLINK_PRODUCER("ie.uplink.published"),
     INTEGRATION("integration"),


### PR DESCRIPTION
## Pull Request description

Dead-code removal and naming cleanups to the Prometheus/Micrometer metrics surface (no functional/behavioral change to the broker — only what is exported and how it is named). Part of an ongoing pass to make the metrics surface consistent and idiomatic.

**Scope of changes**

1. **Remove the dead `msgDownlink` counter.** `integration_stats_counter{name=msgDownlink}` was never emitted — `onDownlinkMsg` has no caller, so downlink throughput was always invisible. Removed `onDownlinkMsg` from `IntegrationStatisticsService` (+ impl) and dropped the `MSGS_DOWNLINK` enum constant. `onUplinkMsg` and the shared `onMsg` helper are unchanged.
2. **Rename gauge factory methods `create*Counter` → `create*Gauge`** (`nonWritableClients`, `subscriptionTopicTrieSize`, `retainMsgTrieSize`, `subscriptionTrieNodes`, `retainMsgTrieNodes`). These build Micrometer **gauges** but were named `*Counter`. Internal Java method names only — **exported metric names are unchanged**.
3. **`sqlQueue.<queueName>` → `sqlQueue{queueName}`** (breaking). The queue name moves from the metric name into a bounded `queueName` tag, for both the three counters and the `queueSize` gauge, so a single stable metric can be aggregated/selected across queues.
4. **Rename the generic Kafka timers** (breaking): `producer{producerId}` → `kafkaProducer.send{producerId}`, and `consumer{consumerId,operation=syncCommit}` → `kafkaConsumer.commit{consumerId}` (the always-constant `operation` tag is dropped).
5. **`clientSubscriptionsConsumer` statsName values `*Subscriptions` → `*Records`** (breaking): the counters advance per Kafka record read from the client-subscriptions topic, not per topic subscription, so `totalSubscriptions/acceptedSubscriptions/ignoredSubscriptions` overstated granularity → `totalRecords/acceptedRecords/ignoredRecords`.

**⚠️ Breaking metric changes (3, 4, 5).** These rename already-scraped series. Prometheus queries / Grafana panels that reference the old names must be updated:

| Old (Micrometer name / tag) | New |
|---|---|
| `sqlQueue.<queueName>{queueIndex,statsName}` | `sqlQueue{queueName,queueIndex,statsName}` |
| `sqlQueue.<queueName>.queueSize{queueIndex}` | `sqlQueue.queueSize{queueName,queueIndex}` |
| `producer{producerId}` | `kafkaProducer.send{producerId}` |
| `consumer{consumerId,operation=syncCommit}` | `kafkaConsumer.commit{consumerId}` |
| `clientSubscriptionsConsumer{statsName=totalSubscriptions/acceptedSubscriptions/ignoredSubscriptions}` | `clientSubscriptionsConsumer{statsName=totalRecords/acceptedRecords/ignoredRecords}` |

(The removed `msgDownlink` series was never emitted, so its removal is not a breaking change for any existing scrape.)

**Documentation note:** release notes should list the breaking metric renames above (old → new) as a migration note for dashboard/alert owners. These metrics have no `thingsboard-mqtt-broker.yml` description surface (they are runtime meters, not config params), so no yml change.

## General checklist

- [x] You have reviewed the guidelines document.
- [x] Labels that classify your pull request have been added.
- [x] The milestone is specified and corresponds to fix version.
- [x] Description references specific issue.
- [x] Description contains human-readable scope of changes.
- [x] Description contains brief notes about what needs to be added to the documentation.
- [x] No merge conflicts, commented blocks of code, code formatting issues.
- [x] Changes are backward compatible or upgrade script is provided. — **Intentionally not backward compatible:** items 3–5 rename already-scraped metrics. 2.4 is an accepted breakpoint; the old→new mapping above is the migration path (no code upgrade script applies to metric names).

## Front-End feature checklist

- N/A — no front-end changes.

## Back-End feature checklist

- [x] Added corresponding unit test(s). `SimpleMeterRegistry`-backed tests assert each renamed metric/tag is present under the new name and absent under the old (`StatsManagerImplTest` for sqlQueue + Kafka timers; new `DefaultClientSubscriptionConsumerStatsTest` for `*Records`). Full reactor build + affected unit tests green on Java 25.
- [x] No new dependencies added.
