### PR TITLE
fix(stats): consistent 'subscriptions' gauge, drop dead processedBytes key, rolling-upgrade guard

### DIFF
--- a/application/src/main/java/org/thingsboard/mqtt/broker/actors/client/service/subscription/ClientSubscriptionService.java
+++ b/application/src/main/java/org/thingsboard/mqtt/broker/actors/client/service/subscription/ClientSubscriptionService.java
@@ -53,5 +53,5 @@ public interface ClientSubscriptionService extends ClientSubscriptionCache {
 
     void clearSubscriptionsInternally(String clientId);
 
-    int getClientSubscriptionsCount();
+    long getClientSubscriptionsCount();
 }

--- a/application/src/main/java/org/thingsboard/mqtt/broker/actors/client/service/subscription/ClientSubscriptionServiceImpl.java
+++ b/application/src/main/java/org/thingsboard/mqtt/broker/actors/client/service/subscription/ClientSubscriptionServiceImpl.java
@@ -41,6 +41,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.atomic.LongAdder;
 import java.util.stream.Collectors;
 
 import static org.thingsboard.mqtt.broker.common.data.util.CallbackUtil.createCallback;
@@ -62,6 +63,10 @@ public class ClientSubscriptionServiceImpl implements ClientSubscriptionService 
     private final ClientMqttActorManager clientMqttActorManager;
 
     private ConcurrentMap<String, Set<TopicSubscription>> clientSubscriptionsMap;
+    // Running total of subscriptions across all clients, maintained on every subscribe/unsubscribe/clear so
+    // the 'subscriptions' gauge and getClientSubscriptionsCount stay O(1) rather than summing every client's
+    // set on each read (this map is the largest in the broker at the 100M-connection scale it targets).
+    private final LongAdder subscriptionCount = new LongAdder();
     private volatile boolean initialized = false;
 
     @Override
@@ -74,8 +79,9 @@ public class ClientSubscriptionServiceImpl implements ClientSubscriptionService 
             clientSubscriptionsMap.put(clientId, topicSubscriptions);
             subscriptionService.subscribe(clientId, topicSubscriptions);
             sharedSubscriptionCacheService.put(clientId, topicSubscriptions);
+            subscriptionCount.add(topicSubscriptions.size());
         });
-        statsManager.registerSubscriptionsStats(clientSubscriptionsMap);
+        statsManager.registerSubscriptionsStats(subscriptionCount);
         initialized = true;
         log.info("Subscriptions initialized. Clients with subscriptions: {}, total subscriptions: {}",
                 clientSubscriptionsMap.size(), getClientSubscriptionsCount());
@@ -117,6 +123,7 @@ public class ClientSubscriptionServiceImpl implements ClientSubscriptionService 
         subscriptionService.subscribe(clientId, topicSubscriptions);
 
         Set<TopicSubscription> clientSubscriptions = clientSubscriptionsMap.computeIfAbsent(clientId, s -> new HashSet<>());
+        int sizeBefore = clientSubscriptions.size();
         clientSubscriptions.removeIf(sub -> {
             boolean existSubs = topicSubscriptions.contains(sub);
             if (existSubs && sub.isSharedSubscription()) {
@@ -125,6 +132,8 @@ public class ClientSubscriptionServiceImpl implements ClientSubscriptionService 
             return existSubs;
         });
         clientSubscriptions.addAll(topicSubscriptions);
+        // Net change to this client's set == net change to the total (re-subscribes cancel out).
+        subscriptionCount.add(clientSubscriptions.size() - sizeBefore);
         sharedSubscriptionCacheService.put(clientId, topicSubscriptions);
         return clientSubscriptions;
     }
@@ -176,6 +185,7 @@ public class ClientSubscriptionServiceImpl implements ClientSubscriptionService 
             }
             return unsubscribe;
         });
+        subscriptionCount.add(-removedSubscriptions.size());
         return new UnsubscribeResult(clientSubscriptions, removedSubscriptions);
     }
 
@@ -217,6 +227,7 @@ public class ClientSubscriptionServiceImpl implements ClientSubscriptionService 
             log.debug("[{}] There were no active subscriptions for client.", clientId);
             return;
         }
+        subscriptionCount.add(-clientSubscriptions.size());
         List<String> unsubscribeTopics = clientSubscriptions.stream()
                 .peek(topicSubscription -> processSharedUnsubscribe(clientId, topicSubscription))
                 .map(TopicSubscription::getTopicFilter)
@@ -226,7 +237,7 @@ public class ClientSubscriptionServiceImpl implements ClientSubscriptionService 
 
     @Override
     public int getClientSubscriptionsCount() {
-        return clientSubscriptionsMap == null ? 0 : clientSubscriptionsMap.values().stream().mapToInt(Set::size).sum();
+        return subscriptionCount.intValue();
     }
 
     @Override

--- a/application/src/main/java/org/thingsboard/mqtt/broker/actors/client/service/subscription/ClientSubscriptionServiceImpl.java
+++ b/application/src/main/java/org/thingsboard/mqtt/broker/actors/client/service/subscription/ClientSubscriptionServiceImpl.java
@@ -236,8 +236,8 @@ public class ClientSubscriptionServiceImpl implements ClientSubscriptionService 
     }
 
     @Override
-    public int getClientSubscriptionsCount() {
-        return subscriptionCount.intValue();
+    public long getClientSubscriptionsCount() {
+        return subscriptionCount.sum();
     }
 
     @Override

--- a/application/src/main/java/org/thingsboard/mqtt/broker/actors/client/service/subscription/ClientSubscriptionServiceImpl.java
+++ b/application/src/main/java/org/thingsboard/mqtt/broker/actors/client/service/subscription/ClientSubscriptionServiceImpl.java
@@ -67,15 +67,18 @@ public class ClientSubscriptionServiceImpl implements ClientSubscriptionService 
     @Override
     public void init(Map<SubscriptionsSourceKey, Set<TopicSubscription>> clientTopicSubscriptions) {
         clientSubscriptionsMap = new ConcurrentHashMap<>();
-        clientTopicSubscriptions.forEach((key, val) -> clientSubscriptionsMap.put(key.getId(), val));
-        statsManager.registerClientSubscriptionsStats(clientSubscriptionsMap);
-
-        clientSubscriptionsMap.forEach((clientId, topicSubscriptions) -> {
+        // Keys are unique by client id (SubscriptionsSourceKey equals/hashCode exclude 'source'),
+        // so a single pass safely populates the map and subscribes each client exactly once.
+        clientTopicSubscriptions.forEach((key, topicSubscriptions) -> {
+            String clientId = key.getId();
+            clientSubscriptionsMap.put(clientId, topicSubscriptions);
             subscriptionService.subscribe(clientId, topicSubscriptions);
             sharedSubscriptionCacheService.put(clientId, topicSubscriptions);
         });
+        statsManager.registerSubscriptionsStats(clientSubscriptionsMap);
         initialized = true;
-        log.info("Subscriptions initialized. Total clients with subscriptions: {}", clientSubscriptionsMap.size());
+        log.info("Subscriptions initialized. Clients with subscriptions: {}, total subscriptions: {}",
+                clientSubscriptionsMap.size(), getClientSubscriptionsCount());
     }
 
     @Override

--- a/application/src/main/java/org/thingsboard/mqtt/broker/service/historical/stats/HistoricalStatsTotalConsumer.java
+++ b/application/src/main/java/org/thingsboard/mqtt/broker/service/historical/stats/HistoricalStatsTotalConsumer.java
@@ -154,9 +154,9 @@ public class HistoricalStatsTotalConsumer {
                 throwable -> log.error("[{}] Failed to save timeseries entries {}", ENTITY_ID_TOTAL, entries, throwable));
     }
 
-    // Protected (not private) so it can be unit-tested directly, consistent with the other test seams
-    // in this class (calculatePairUsingProvidedMsg, getTotalMessageCounterPair); not an extension point.
-    protected void processSaveHistoricalStatsTotal(TbProtoQueueMsg<ToUsageStatsMsgProto> msg) {
+    // Package-private (not private) so the same-package unit test can invoke it directly, like the other
+    // test seams in this class (calculatePairUsingProvidedMsg, getTotalMessageCounterPair); not an extension point.
+    void processSaveHistoricalStatsTotal(TbProtoQueueMsg<ToUsageStatsMsgProto> msg) {
         String key = msg.getValue().getUsageStats().getKey();
         if (!totalStatsMap.containsKey(key)) {
             // Unknown/removed historical key (e.g. a 'processedBytes' message from a not-yet-upgraded node
@@ -189,7 +189,7 @@ public class HistoricalStatsTotalConsumer {
                 throwable -> log.error("[{}] Failed to save timeseries for key {} with value {}", ENTITY_ID_TOTAL, tsKvEntry.getKey(), tsKvEntry.getValue(), throwable));
     }
 
-    protected TsMsgTotalPair calculatePairUsingProvidedMsg(TbProtoQueueMsg<ToUsageStatsMsgProto> msg) {
+    TsMsgTotalPair calculatePairUsingProvidedMsg(TbProtoQueueMsg<ToUsageStatsMsgProto> msg) {
         TsMsgTotalPair pair = getTotalMessageCounterPair(msg);
         long msgTs = msg.getValue().getTs();
         if (pair.getTs() < msgTs) {
@@ -202,7 +202,7 @@ public class HistoricalStatsTotalConsumer {
         return pair;
     }
 
-    protected TsMsgTotalPair getTotalMessageCounterPair(TbProtoQueueMsg<ToUsageStatsMsgProto> msg) {
+    TsMsgTotalPair getTotalMessageCounterPair(TbProtoQueueMsg<ToUsageStatsMsgProto> msg) {
         String key = msg.getValue().getUsageStats().getKey();
         TsMsgTotalPair msgTotalPair = totalStatsMap.get(key);
         if (msgTotalPair.isEmpty()) {

--- a/application/src/main/java/org/thingsboard/mqtt/broker/service/historical/stats/HistoricalStatsTotalConsumer.java
+++ b/application/src/main/java/org/thingsboard/mqtt/broker/service/historical/stats/HistoricalStatsTotalConsumer.java
@@ -154,8 +154,15 @@ public class HistoricalStatsTotalConsumer {
                 throwable -> log.error("[{}] Failed to save timeseries entries {}", ENTITY_ID_TOTAL, entries, throwable));
     }
 
-    private void processSaveHistoricalStatsTotal(TbProtoQueueMsg<ToUsageStatsMsgProto> msg) {
+    protected void processSaveHistoricalStatsTotal(TbProtoQueueMsg<ToUsageStatsMsgProto> msg) {
         String key = msg.getValue().getUsageStats().getKey();
+        if (!totalStatsMap.containsKey(key)) {
+            // Unknown/removed historical key (e.g. a 'processedBytes' message from a not-yet-upgraded node
+            // during a rolling upgrade). Ignore it so a single stale message can't NPE and poison the whole
+            // aggregation loop — an uncommitted batch would otherwise be re-polled forever.
+            log.debug("[{}] Ignoring historical stats for unknown key {}", ENTITY_ID_TOTAL, key);
+            return;
+        }
         long msgTs = msg.getValue().getTs();
         TsMsgTotalPair pair = calculatePairUsingProvidedMsg(msg);
 

--- a/application/src/main/java/org/thingsboard/mqtt/broker/service/historical/stats/HistoricalStatsTotalConsumer.java
+++ b/application/src/main/java/org/thingsboard/mqtt/broker/service/historical/stats/HistoricalStatsTotalConsumer.java
@@ -154,6 +154,8 @@ public class HistoricalStatsTotalConsumer {
                 throwable -> log.error("[{}] Failed to save timeseries entries {}", ENTITY_ID_TOTAL, entries, throwable));
     }
 
+    // Protected (not private) so it can be unit-tested directly, consistent with the other test seams
+    // in this class (calculatePairUsingProvidedMsg, getTotalMessageCounterPair); not an extension point.
     protected void processSaveHistoricalStatsTotal(TbProtoQueueMsg<ToUsageStatsMsgProto> msg) {
         String key = msg.getValue().getUsageStats().getKey();
         if (!totalStatsMap.containsKey(key)) {

--- a/application/src/main/java/org/thingsboard/mqtt/broker/service/historical/stats/TbMessageStatsReportClient.java
+++ b/application/src/main/java/org/thingsboard/mqtt/broker/service/historical/stats/TbMessageStatsReportClient.java
@@ -17,6 +17,24 @@ package org.thingsboard.mqtt.broker.service.historical.stats;
 
 import org.thingsboard.mqtt.broker.common.data.BrokerConstants;
 
+/**
+ * Collects the historical (System B) usage timeseries shown on the TBMQ UI monitoring charts.
+ * <p>
+ * These historical values are <b>per-interval deltas</b>: each reporting cron accumulates counts and
+ * persists them with {@code getAndSet(0)}. This is intentionally a different shape from the Micrometer
+ * meters exposed on {@code /actuator/prometheus} (via {@code StatsManager}), which are
+ * <b>cumulative/monotonic lifetime totals</b>. So the same underlying events produce very different raw
+ * numbers on the two systems — a per-minute delta on the chart vs. a lifetime total in Prometheus.
+ * <p>
+ * The two systems can also diverge in <b>gating</b>: historical reporting is gated on
+ * {@code historical-data-report.enabled}, whereas several Micrometer counters (notably {@code droppedMsgs},
+ * see {@link #reportDroppedMsgs()}) increment unconditionally — so with historical reporting disabled
+ * Prometheus still counts while the chart shows nothing.
+ * <p>
+ * <b>Known limitation (async-save loss):</b> interval deltas are saved asynchronously. If a save/Kafka-send
+ * fails, that interval's delta is lost permanently from the chart, while the cumulative Micrometer meter is
+ * unaffected — so under save failures the chart can undercount relative to Prometheus.
+ */
 public interface TbMessageStatsReportClient {
 
     /**

--- a/application/src/main/java/org/thingsboard/mqtt/broker/service/stats/StatsManager.java
+++ b/application/src/main/java/org/thingsboard/mqtt/broker/service/stats/StatsManager.java
@@ -24,6 +24,7 @@ import org.thingsboard.mqtt.broker.service.stats.timer.RetainedMsgTimerStats;
 import org.thingsboard.mqtt.broker.service.stats.timer.SubscriptionTimerStats;
 import org.thingsboard.mqtt.broker.service.subscription.shared.TopicSharedSubscription;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -86,7 +87,7 @@ public interface StatsManager {
 
     void registerAllClientSessionsStats(Map<?, ?> clientSessionsMap);
 
-    void registerClientSubscriptionsStats(Map<?, ?> clientSubscriptionsMap);
+    void registerSubscriptionsStats(Map<?, ? extends Collection<?>> clientSubscriptionsMap);
 
     void registerRetainedMsgStats(Map<?, ?> retainedMessagesMap);
 

--- a/application/src/main/java/org/thingsboard/mqtt/broker/service/stats/StatsManager.java
+++ b/application/src/main/java/org/thingsboard/mqtt/broker/service/stats/StatsManager.java
@@ -24,11 +24,11 @@ import org.thingsboard.mqtt.broker.service.stats.timer.RetainedMsgTimerStats;
 import org.thingsboard.mqtt.broker.service.stats.timer.SubscriptionTimerStats;
 import org.thingsboard.mqtt.broker.service.subscription.shared.TopicSharedSubscription;
 
-import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.LongAdder;
 
 public interface StatsManager {
 
@@ -87,7 +87,7 @@ public interface StatsManager {
 
     void registerAllClientSessionsStats(Map<?, ?> clientSessionsMap);
 
-    void registerSubscriptionsStats(Map<?, ? extends Collection<?>> clientSubscriptionsMap);
+    void registerSubscriptionsStats(LongAdder subscriptionCount);
 
     void registerRetainedMsgStats(Map<?, ?> retainedMessagesMap);
 

--- a/application/src/main/java/org/thingsboard/mqtt/broker/service/stats/StatsManagerImpl.java
+++ b/application/src/main/java/org/thingsboard/mqtt/broker/service/stats/StatsManagerImpl.java
@@ -50,6 +50,7 @@ import org.thingsboard.mqtt.broker.service.stats.timer.TimerStats;
 import org.thingsboard.mqtt.broker.service.subscription.shared.TopicSharedSubscription;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -304,10 +305,17 @@ public class StatsManagerImpl implements StatsManager, ActorStatsManager, SqlQue
     }
 
     @Override
-    public void registerClientSubscriptionsStats(Map<?, ?> clientSubscriptionsMap) {
-        log.trace("Registering ClientSubscriptionsStats");
-        statsFactory.createGauge(StatsType.CLIENT_SUBSCRIPTIONS.getPrintName(), clientSubscriptionsMap, Map::size);
-        gauges.add(new Gauge(StatsType.CLIENT_SUBSCRIPTIONS.getPrintName(), clientSubscriptionsMap::size));
+    public void registerSubscriptionsStats(Map<?, ? extends Collection<?>> clientSubscriptionsMap) {
+        log.trace("Registering SubscriptionsStats");
+        // Total subscription count (sum of the per-client subscription set sizes), consistent with the
+        // historical 'subscriptions' chart (ClientSubscriptionService#getClientSubscriptionsCount) --
+        // NOT the number of clients that have subscriptions.
+        statsFactory.createGauge(StatsType.SUBSCRIPTIONS.getPrintName(), clientSubscriptionsMap, StatsManagerImpl::countSubscriptions);
+        gauges.add(new Gauge(StatsType.SUBSCRIPTIONS.getPrintName(), () -> countSubscriptions(clientSubscriptionsMap)));
+    }
+
+    private static int countSubscriptions(Map<?, ? extends Collection<?>> clientSubscriptionsMap) {
+        return clientSubscriptionsMap.values().stream().mapToInt(Collection::size).sum();
     }
 
     @Override

--- a/application/src/main/java/org/thingsboard/mqtt/broker/service/stats/StatsManagerImpl.java
+++ b/application/src/main/java/org/thingsboard/mqtt/broker/service/stats/StatsManagerImpl.java
@@ -50,7 +50,6 @@ import org.thingsboard.mqtt.broker.service.stats.timer.TimerStats;
 import org.thingsboard.mqtt.broker.service.subscription.shared.TopicSharedSubscription;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -58,6 +57,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.LongAdder;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
@@ -305,17 +305,13 @@ public class StatsManagerImpl implements StatsManager, ActorStatsManager, SqlQue
     }
 
     @Override
-    public void registerSubscriptionsStats(Map<?, ? extends Collection<?>> clientSubscriptionsMap) {
+    public void registerSubscriptionsStats(LongAdder subscriptionCount) {
         log.trace("Registering SubscriptionsStats");
-        // Total subscription count (sum of the per-client subscription set sizes), consistent with the
-        // historical 'subscriptions' chart (ClientSubscriptionService#getClientSubscriptionsCount) --
+        // Total subscription count across all clients — maintained incrementally by ClientSubscriptionService
+        // (see #getClientSubscriptionsCount) so this reads O(1) instead of summing every client's set per scrape.
         // NOT the number of clients that have subscriptions.
-        statsFactory.createGauge(StatsType.SUBSCRIPTIONS.getPrintName(), clientSubscriptionsMap, StatsManagerImpl::countSubscriptions);
-        gauges.add(new Gauge(StatsType.SUBSCRIPTIONS.getPrintName(), () -> countSubscriptions(clientSubscriptionsMap)));
-    }
-
-    private static int countSubscriptions(Map<?, ? extends Collection<?>> clientSubscriptionsMap) {
-        return clientSubscriptionsMap.values().stream().mapToInt(Collection::size).sum();
+        statsFactory.createGauge(StatsType.SUBSCRIPTIONS.getPrintName(), subscriptionCount, LongAdder::sum);
+        gauges.add(new Gauge(StatsType.SUBSCRIPTIONS.getPrintName(), subscriptionCount::sum));
     }
 
     @Override

--- a/application/src/main/java/org/thingsboard/mqtt/broker/service/stats/StatsManagerStub.java
+++ b/application/src/main/java/org/thingsboard/mqtt/broker/service/stats/StatsManagerStub.java
@@ -33,11 +33,11 @@ import org.thingsboard.mqtt.broker.service.stats.timer.StubTimerStats;
 import org.thingsboard.mqtt.broker.service.stats.timer.SubscriptionTimerStats;
 import org.thingsboard.mqtt.broker.service.subscription.shared.TopicSharedSubscription;
 
-import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.LongAdder;
 
 @Slf4j
 @Service
@@ -153,7 +153,7 @@ public class StatsManagerStub implements StatsManager, ActorStatsManager, Produc
     }
 
     @Override
-    public void registerSubscriptionsStats(Map<?, ? extends Collection<?>> clientSubscriptionsMap) {
+    public void registerSubscriptionsStats(LongAdder subscriptionCount) {
     }
 
     @Override

--- a/application/src/main/java/org/thingsboard/mqtt/broker/service/stats/StatsManagerStub.java
+++ b/application/src/main/java/org/thingsboard/mqtt/broker/service/stats/StatsManagerStub.java
@@ -33,6 +33,7 @@ import org.thingsboard.mqtt.broker.service.stats.timer.StubTimerStats;
 import org.thingsboard.mqtt.broker.service.stats.timer.SubscriptionTimerStats;
 import org.thingsboard.mqtt.broker.service.subscription.shared.TopicSharedSubscription;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -152,7 +153,7 @@ public class StatsManagerStub implements StatsManager, ActorStatsManager, Produc
     }
 
     @Override
-    public void registerClientSubscriptionsStats(Map<?, ?> clientSubscriptionsMap) {
+    public void registerSubscriptionsStats(Map<?, ? extends Collection<?>> clientSubscriptionsMap) {
     }
 
     @Override

--- a/application/src/test/java/org/thingsboard/mqtt/broker/actors/client/service/subscription/ClientSubscriptionServiceImplTest.java
+++ b/application/src/test/java/org/thingsboard/mqtt/broker/actors/client/service/subscription/ClientSubscriptionServiceImplTest.java
@@ -89,6 +89,14 @@ public class ClientSubscriptionServiceImplTest {
     }
 
     @Test
+    public void givenClientTopicSubscriptions_whenInit_thenCachesEachClientOnceAndRegistersSubscriptionsStats() {
+        // init() ran in setUp() with 2 clients: each client is subscribed, shared-cached, once,
+        // and the subscriptions gauge is registered exactly once over the backing map.
+        verify(sharedSubscriptionCacheService, times(2)).put(any(), any());
+        verify(statsManager, times(1)).registerSubscriptionsStats(any());
+    }
+
+    @Test
     public void givenClientTopicSubscriptionsAndSharedSubscriptions_whenGetClientSharedSubscriptions_thenReturnExpectedResult() {
         String clientId = "sharedClientId";
         getAndVerifyClientSubscriptionsForClient(clientId, 0);

--- a/application/src/test/java/org/thingsboard/mqtt/broker/actors/client/service/subscription/ClientSubscriptionServiceImplTest.java
+++ b/application/src/test/java/org/thingsboard/mqtt/broker/actors/client/service/subscription/ClientSubscriptionServiceImplTest.java
@@ -220,6 +220,40 @@ public class ClientSubscriptionServiceImplTest {
     }
 
     @Test
+    public void givenSubscriptions_whenUnsubscribeInternally_thenTotalSubscriptionCountDecreases() {
+        // setUp seeded clientId1 -> {topic1} and clientId2 -> {topic2}: 2 total.
+        clientSubscriptionService.subscribeInternally("clientId1",
+                Set.of(getTopicSubscription("topic11"), getTopicSubscription("topic12")));
+        assertEquals(4, clientSubscriptionService.getClientSubscriptionsCount());
+
+        clientSubscriptionService.unsubscribeInternally("clientId1", Set.of("topic11", "topic12"));
+
+        assertEquals(2, clientSubscriptionService.getClientSubscriptionsCount());
+    }
+
+    @Test
+    public void givenSubscriptions_whenClearSubscriptionsInternally_thenTotalDecreasesByClientSetSize() {
+        // setUp seeded clientId1 -> {topic1} and clientId2 -> {topic2}: 2 total.
+        clientSubscriptionService.subscribeInternally("clientId1", Set.of(getTopicSubscription("topic11")));
+        assertEquals(3, clientSubscriptionService.getClientSubscriptionsCount());
+
+        clientSubscriptionService.clearSubscriptionsInternally("clientId1");
+
+        // clientId1's two subscriptions are removed; clientId2's one remains.
+        assertEquals(1, clientSubscriptionService.getClientSubscriptionsCount());
+    }
+
+    @Test
+    public void givenClientWithMultipleSubscriptions_whenGetClientSubscriptionsCount_thenReturnsTotalNotClientCount() {
+        // setUp seeded 2 clients with 1 subscription each. Add 2 more to a single client:
+        clientSubscriptionService.subscribeInternally("clientId1",
+                Set.of(getTopicSubscription("a"), getTopicSubscription("b")));
+
+        // 2 clients, but 4 total subscriptions.
+        assertEquals(4, clientSubscriptionService.getClientSubscriptionsCount());
+    }
+
+    @Test
     public void givenSubscriptions_whenUnsubscribeAndPersistWithCallback_thenDeliversRemovedSubscriptionsOnSuccess() {
         String clientId = "clientId1"; // seeded with topic1
         clientSubscriptionService.subscribeInternally(clientId, Set.of(getTopicSubscription("topic11")));

--- a/application/src/test/java/org/thingsboard/mqtt/broker/actors/client/service/subscription/ClientSubscriptionServiceImplTest.java
+++ b/application/src/test/java/org/thingsboard/mqtt/broker/actors/client/service/subscription/ClientSubscriptionServiceImplTest.java
@@ -215,7 +215,7 @@ public class ClientSubscriptionServiceImplTest {
                         getTopicSubscription("topic321"),
                         getTopicSubscription("topic12345")));
 
-        int clientSubscriptionsCount = clientSubscriptionService.getClientSubscriptionsCount();
+        long clientSubscriptionsCount = clientSubscriptionService.getClientSubscriptionsCount();
         assertThat(clientSubscriptionsCount).isEqualTo(7);
     }
 
@@ -251,6 +251,20 @@ public class ClientSubscriptionServiceImplTest {
 
         // 2 clients, but 4 total subscriptions.
         assertEquals(4, clientSubscriptionService.getClientSubscriptionsCount());
+    }
+
+    @Test
+    public void givenExistingSubscription_whenReSubscribedToSameFilter_thenTotalSubscriptionCountUnchanged() {
+        // setUp seeded clientId1 -> {topic1} and clientId2 -> {topic2}: 2 total.
+        clientSubscriptionService.subscribeInternally("clientId1", Set.of(getTopicSubscription("topic11")));
+        assertEquals(3, clientSubscriptionService.getClientSubscriptionsCount());
+
+        // Re-subscribing an already-present (topicFilter+shareName-equal) subscription is a net-zero change:
+        // subscribe() removes the existing entry then re-adds it, so size() - sizeBefore == 0 and the total
+        // must not double-count. Guards the subtlest branch of the running-counter arithmetic.
+        clientSubscriptionService.subscribeInternally("clientId1", Set.of(getTopicSubscription("topic11")));
+
+        assertEquals(3, clientSubscriptionService.getClientSubscriptionsCount());
     }
 
     @Test

--- a/application/src/test/java/org/thingsboard/mqtt/broker/service/historical/stats/HistoricalStatsTotalConsumerTest.java
+++ b/application/src/test/java/org/thingsboard/mqtt/broker/service/historical/stats/HistoricalStatsTotalConsumerTest.java
@@ -36,6 +36,7 @@ import java.util.Map;
 
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -44,6 +45,7 @@ import static org.thingsboard.mqtt.broker.common.data.BrokerConstants.DROPPED_MS
 import static org.thingsboard.mqtt.broker.common.data.BrokerConstants.INCOMING_MSGS;
 import static org.thingsboard.mqtt.broker.common.data.BrokerConstants.MSG_RELATED_HISTORICAL_KEYS;
 import static org.thingsboard.mqtt.broker.common.data.BrokerConstants.OUTGOING_MSGS;
+import static org.thingsboard.mqtt.broker.common.data.BrokerConstants.PROCESSED_BYTES;
 
 
 @Slf4j
@@ -259,6 +261,19 @@ public class HistoricalStatsTotalConsumerTest {
             }
         });
         verify(timeseriesService, times(3)).findLatest(any(), any());
+    }
+
+    @Test
+    public void givenMsgWithUnknownRemovedKey_whenProcessSaveHistoricalStatsTotal_thenIgnoredWithoutSaveOrNpe() {
+        // processedBytes was removed from the historical key set, so totalStatsMap has no entry for it.
+        // A message with such a key (e.g. produced by a not-yet-upgraded node during a rolling upgrade)
+        // must be ignored, not throw NPE — otherwise the uncommitted batch is re-polled forever and
+        // poisons cluster-wide historical aggregation.
+        var msg = buildMessage(PROCESSED_BYTES, 7);
+
+        historicalStatsTotalConsumer.processSaveHistoricalStatsTotal(msg);
+
+        verify(timeseriesService, never()).save(any(), any(TsKvEntry.class));
     }
 
     private TbProtoQueueMsg<ToUsageStatsMsgProto> buildMessage(String key, int value) {

--- a/application/src/test/java/org/thingsboard/mqtt/broker/service/historical/stats/HistoricalStatsTotalConsumerTest.java
+++ b/application/src/test/java/org/thingsboard/mqtt/broker/service/historical/stats/HistoricalStatsTotalConsumerTest.java
@@ -276,6 +276,17 @@ public class HistoricalStatsTotalConsumerTest {
         verify(timeseriesService, never()).save(any(), any(TsKvEntry.class));
     }
 
+    @Test
+    public void givenMsgWithKnownKey_whenProcessSaveHistoricalStatsTotal_thenSavesExactlyOnce() {
+        when(timeseriesService.findLatest(any(), any())).thenReturn(Futures.immediateFuture(new ArrayList<>()));
+        when(timeseriesService.save(any(), any(TsKvEntry.class))).thenReturn(Futures.immediateFuture(null));
+
+        historicalStatsTotalConsumer.processSaveHistoricalStatsTotal(buildMessage(INCOMING_MSGS, 5));
+
+        // A known key is aggregated and persisted exactly once — proving the guard only filters unknown keys.
+        verify(timeseriesService, times(1)).save(any(), any(TsKvEntry.class));
+    }
+
     private TbProtoQueueMsg<ToUsageStatsMsgProto> buildMessage(String key, int value) {
 
         UsageStatsKVProto statsItem = UsageStatsKVProto.newBuilder()

--- a/application/src/test/java/org/thingsboard/mqtt/broker/service/historical/stats/TbMessageStatsReportClientImplTest.java
+++ b/application/src/test/java/org/thingsboard/mqtt/broker/service/historical/stats/TbMessageStatsReportClientImplTest.java
@@ -397,9 +397,9 @@ public class TbMessageStatsReportClientImplTest {
         // When
         tbMessageStatsReportClient.reportAndPersistStats(timestamp, null);
 
-        // Then
-        verify(timeseriesService, times(6)).save(anyString(), any(BasicTsKvEntry.class));
-        verify(historicalStatsProducer, times(6)).send(eq("topic"), eq(null), any(TbProtoQueueMsg.class), any(TbQueueCallback.class));
+        // Then: one save + one send per persisted historical key (processedBytes was removed as a dead key).
+        verify(timeseriesService, times(BrokerConstants.MSG_RELATED_HISTORICAL_KEYS_COUNT)).save(anyString(), any(BasicTsKvEntry.class));
+        verify(historicalStatsProducer, times(BrokerConstants.MSG_RELATED_HISTORICAL_KEYS_COUNT)).send(eq("topic"), eq(null), any(TbProtoQueueMsg.class), any(TbQueueCallback.class));
 
         // Assert that stats are reset to 0
         assertEquals(0, tbMessageStatsReportClient.getStats().get(BrokerConstants.INCOMING_MSGS).get());

--- a/application/src/test/java/org/thingsboard/mqtt/broker/service/stats/StatsManagerImplTest.java
+++ b/application/src/test/java/org/thingsboard/mqtt/broker/service/stats/StatsManagerImplTest.java
@@ -29,6 +29,7 @@ import org.thingsboard.mqtt.broker.service.subscription.shared.TopicSharedSubscr
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.LongAdder;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -144,28 +145,26 @@ public class StatsManagerImplTest {
     }
 
     @Test
-    public void givenSubscriptionsAcrossClients_whenRegistered_thenGaugeReportsTotalSubscriptionCountNotClientCount() {
-        Map<String, Set<String>> subscriptions = Map.of(
-                "client-a", Set.of("t1", "t2"),
-                "client-b", Set.of("t3"),
-                "client-c", Set.of("t4", "t5", "t6"));
+    public void givenSubscriptionCount_whenRegistered_thenGaugeReflectsItLiveUnderSubscriptionsName() {
+        LongAdder subscriptionCount = new LongAdder();
+        subscriptionCount.add(6);
 
-        statsManager.registerSubscriptionsStats(subscriptions);
+        statsManager.registerSubscriptionsStats(subscriptionCount);
 
         assertEquals("subscriptions", StatsType.SUBSCRIPTIONS.getPrintName());
         Gauge gauge = meterRegistry.find(StatsType.SUBSCRIPTIONS.getPrintName()).gauge();
         assertNotNull(gauge);
-        // 2 + 1 + 3 = total subscriptions across the 3 clients — NOT the client count (3).
         assertEquals(6.0, gauge.value(), 0.0);
-        // The metric was renamed from the misleading clientSubscriptions (which meant clients-with-subs).
+        // The gauge tracks the live running total (O(1) read), reflecting later updates.
+        subscriptionCount.add(2);
+        assertEquals(8.0, gauge.value(), 0.0);
+        // Renamed from the misleading clientSubscriptions (which meant clients-with-subscriptions).
         assertNull(meterRegistry.find("clientSubscriptions").gauge());
     }
 
     @Test
-    public void givenNoSubscriptions_whenRegistered_thenGaugeReportsZeroNotNaN() {
-        Map<String, Set<String>> subscriptions = Map.of();
-
-        statsManager.registerSubscriptionsStats(subscriptions);
+    public void givenZeroSubscriptionCount_whenRegistered_thenGaugeReportsZeroNotNaN() {
+        statsManager.registerSubscriptionsStats(new LongAdder());
 
         Gauge gauge = meterRegistry.find(StatsType.SUBSCRIPTIONS.getPrintName()).gauge();
         assertNotNull(gauge);

--- a/application/src/test/java/org/thingsboard/mqtt/broker/service/stats/StatsManagerImplTest.java
+++ b/application/src/test/java/org/thingsboard/mqtt/broker/service/stats/StatsManagerImplTest.java
@@ -33,6 +33,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.thingsboard.mqtt.broker.common.stats.StatsConstantNames.CLIENT_ID_TAG;
 
@@ -140,5 +141,34 @@ public class StatsManagerImplTest {
         // The 3 latency timers carry no clientId tag, so Micrometer shares one set across all
         // application clients. Clearing one client must NOT deregister them.
         assertEquals(3, meterRegistry.find(APP_PROCESSOR_LATENCY).timers().size());
+    }
+
+    @Test
+    public void givenSubscriptionsAcrossClients_whenRegistered_thenGaugeReportsTotalSubscriptionCountNotClientCount() {
+        Map<String, Set<String>> subscriptions = Map.of(
+                "client-a", Set.of("t1", "t2"),
+                "client-b", Set.of("t3"),
+                "client-c", Set.of("t4", "t5", "t6"));
+
+        statsManager.registerSubscriptionsStats(subscriptions);
+
+        assertEquals("subscriptions", StatsType.SUBSCRIPTIONS.getPrintName());
+        Gauge gauge = meterRegistry.find(StatsType.SUBSCRIPTIONS.getPrintName()).gauge();
+        assertNotNull(gauge);
+        // 2 + 1 + 3 = total subscriptions across the 3 clients — NOT the client count (3).
+        assertEquals(6.0, gauge.value(), 0.0);
+        // The metric was renamed from the misleading clientSubscriptions (which meant clients-with-subs).
+        assertNull(meterRegistry.find("clientSubscriptions").gauge());
+    }
+
+    @Test
+    public void givenNoSubscriptions_whenRegistered_thenGaugeReportsZeroNotNaN() {
+        Map<String, Set<String>> subscriptions = Map.of();
+
+        statsManager.registerSubscriptionsStats(subscriptions);
+
+        Gauge gauge = meterRegistry.find(StatsType.SUBSCRIPTIONS.getPrintName()).gauge();
+        assertNotNull(gauge);
+        assertEquals(0.0, gauge.value(), 0.0);
     }
 }

--- a/common/data/src/main/java/org/thingsboard/mqtt/broker/common/data/BrokerConstants.java
+++ b/common/data/src/main/java/org/thingsboard/mqtt/broker/common/data/BrokerConstants.java
@@ -37,15 +37,17 @@ public class BrokerConstants {
     public static final String SESSIONS = "sessions";
     public static final String SUBSCRIPTIONS = "subscriptions";
     public static final String RETAINED_MSGS = "retainedMsgs";
-    //TODO: delete completely PROCESSED_BYTES (with upgrade script to remove data from psql)
+    // Dead key: never incremented, only ever persisted/queried as 0. Removed from the historical
+    // key lists below so no new empty rows are written or queried.
+    // TODO: drop this constant once an upgrade script purges the existing processedBytes rows from psql.
     public static final String PROCESSED_BYTES = "processedBytes";
     public static final String INBOUND_PAYLOAD_BYTES = "inboundPayloadTraffic";
     public static final String OUTBOUND_PAYLOAD_BYTES = "outboundPayloadTraffic";
 
-    public static final List<String> MSG_RELATED_HISTORICAL_KEYS = List.of(INCOMING_MSGS, OUTGOING_MSGS, DROPPED_MSGS, PROCESSED_BYTES, INBOUND_PAYLOAD_BYTES, OUTBOUND_PAYLOAD_BYTES);
+    public static final List<String> MSG_RELATED_HISTORICAL_KEYS = List.of(INCOMING_MSGS, OUTGOING_MSGS, DROPPED_MSGS, INBOUND_PAYLOAD_BYTES, OUTBOUND_PAYLOAD_BYTES);
     public static final int MSG_RELATED_HISTORICAL_KEYS_COUNT = MSG_RELATED_HISTORICAL_KEYS.size();
 
-    public static final List<String> HISTORICAL_KEYS = List.of(INCOMING_MSGS, OUTGOING_MSGS, DROPPED_MSGS, SESSIONS, SUBSCRIPTIONS, RETAINED_MSGS, PROCESSED_BYTES, INBOUND_PAYLOAD_BYTES, OUTBOUND_PAYLOAD_BYTES);
+    public static final List<String> HISTORICAL_KEYS = List.of(INCOMING_MSGS, OUTGOING_MSGS, DROPPED_MSGS, SESSIONS, SUBSCRIPTIONS, RETAINED_MSGS, INBOUND_PAYLOAD_BYTES, OUTBOUND_PAYLOAD_BYTES);
 
     public static final String RECEIVED_PUBLISH_MSGS = "receivedPubMsgs";
     public static final String QOS_0_RECEIVED_PUBLISH_MSGS = "qos0ReceivedPubMsgs";

--- a/common/data/src/test/java/org/thingsboard/mqtt/broker/common/data/BrokerConstantsTest.java
+++ b/common/data/src/test/java/org/thingsboard/mqtt/broker/common/data/BrokerConstantsTest.java
@@ -1,0 +1,36 @@
+/**
+ * Copyright © 2016-2026 The Thingsboard Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.thingsboard.mqtt.broker.common.data;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.thingsboard.mqtt.broker.common.data.BrokerConstants.HISTORICAL_KEYS;
+import static org.thingsboard.mqtt.broker.common.data.BrokerConstants.MSG_RELATED_HISTORICAL_KEYS;
+import static org.thingsboard.mqtt.broker.common.data.BrokerConstants.PROCESSED_BYTES;
+
+class BrokerConstantsTest {
+
+    @Test
+    void givenProcessedBytes_whenCheckingHistoricalKeyLists_thenNotPresentInEither() {
+        // processedBytes was always persisted as 0 and never incremented (dead key). It must no
+        // longer be persisted per-interval nor queried as a latest value.
+        assertFalse(MSG_RELATED_HISTORICAL_KEYS.contains(PROCESSED_BYTES),
+                "processedBytes must not be a per-interval persisted historical key");
+        assertFalse(HISTORICAL_KEYS.contains(PROCESSED_BYTES),
+                "processedBytes must not be a queried latest historical key");
+    }
+}

--- a/common/stats/src/main/java/org/thingsboard/mqtt/broker/common/stats/StatsType.java
+++ b/common/stats/src/main/java/org/thingsboard/mqtt/broker/common/stats/StatsType.java
@@ -29,10 +29,17 @@ public enum StatsType {
     SUBSCRIPTION_TOPIC_TRIE_SIZE("subscriptionTopicTrieSize"),
     RETAIN_MSG_TRIE_SIZE("retainMsgTrieSize"),
     LAST_WILL_CLIENTS("lastWillClients"),
+    // Live MQTT channels on THIS node only. NOT the analog of the historical 'sessions' chart, which
+    // counts cluster-wide sessions incl. offline persistent ones (see ALL_CLIENT_SESSIONS).
     CONNECTED_SESSIONS("connectedSessions"),
     CONNECTED_SSL_SESSIONS("connectedSslSessions"),
+    // Cluster-wide client sessions incl. offline persistent ones. This is the Prometheus analog of the
+    // historical 'sessions' chart (BrokerConstants.SESSIONS).
     ALL_CLIENT_SESSIONS("allClientSessions"),
-    CLIENT_SUBSCRIPTIONS("clientSubscriptions"),
+    // Total subscription count across all clients (sum of the per-client subscription set sizes), matching
+    // the historical 'subscriptions' chart (BrokerConstants.SUBSCRIPTIONS). Renamed from 'clientSubscriptions',
+    // which misleadingly reported the number of clients with at least one subscription rather than a count.
+    SUBSCRIPTIONS("subscriptions"),
     RETAINED_MESSAGES("retainedMessages"),
     SUBSCRIPTION_TRIE_NODES("subscriptionTrieNodes"),
     RETAIN_MSG_TRIE_NODES("retainMsgTrieNodes"),


### PR DESCRIPTION
## Pull Request description

Part of the ongoing TBMQ metrics cleanup, focused on making the Prometheus meters consistent with the historical (UI-monitoring) timeseries. Three related changes, plus a rolling-upgrade safety fix surfaced during review.

### 1. `clientSubscriptions` gauge → `subscriptions` (renamed **and** redefined) — breaking

The Micrometer gauge `clientSubscriptions` was registered as `Map::size` over the client→subscriptions map, so it reported the **number of clients that have at least one subscription** — not a subscription count. Its name was near-identical to the historical `subscriptions` chart, which measures **total subscriptions**, so the two silently disagreed for any client with more than one subscription.

- The gauge is renamed to `subscriptions` and redefined to the **total subscription count** (sum of the per-client subscription-set sizes), computed consistently with the historical chart's `ClientSubscriptionService#getClientSubscriptionsCount()`. Prometheus and the UI `subscriptions` chart now report the same value from the same source.
- Renaming (instead of silently changing the value under the same name) makes the change fail loud — old `clientSubscriptions` queries return no data rather than quietly reporting a different quantity.

**Migration:** update dashboards/alerts from `clientSubscriptions` to `subscriptions`. The value also changes: `subscriptions` (total) is `>=` the old `clientSubscriptions` (clients-with-subscriptions) whenever any client holds more than one subscription. Cluster behaviour is unchanged — the backing map is cluster-wide replicated, so each node reports the same cluster-wide total (take one node / `max`, don't sum across nodes).

### 2. Remove the dead `processedBytes` historical key

`processedBytes` was never incremented — it was only ever persisted and queried as `0`, writing an empty timeseries row every reporting interval. It is removed from `MSG_RELATED_HISTORICAL_KEYS` (per-interval persistence) and `HISTORICAL_KEYS` (latest-value query); `MSG_RELATED_HISTORICAL_KEYS_COUNT` is derived from the list, so the report client's latch/list sizing adjusts automatically. The constant is kept until a follow-up upgrade script purges the existing `processedBytes` rows from PostgreSQL. No meaningful series existed, so this is not breaking.

### 3. Rolling-upgrade safety: ignore unknown historical keys

The cluster-wide historical total consumer seeds its aggregation map only with the current key set, but looks it up by the **incoming message's** key and immediately dereferences the result. During a rolling upgrade a not-yet-upgraded node still produces `processedBytes` messages; an upgraded consumer would resolve `null` → NPE. Because `commitSync()` runs only after the per-message loop, the uncommitted batch would be re-polled and re-fail forever — a poison pill stalling all cluster-wide historical aggregation until topic retention drops the message. `processSaveHistoricalStatsTotal` now skips any key absent from the map.

### 4. Consistency clean-up (no behaviour change)

- `ClientSubscriptionServiceImpl#init` folded from two passes into one (map keys are unique by client id, so populate + subscribe + shared-cache-put run safely in a single loop) and now logs both the client count and the total subscription count.
- Type-level javadoc on `TbMessageStatsReportClient` documenting that the historical charts are per-interval deltas (gated on `historical-data-report.enabled`) whereas the Prometheus meters are cumulative/unconditional, plus the known async-save-loss limitation (a failed interval save is lost from the chart but not from Prometheus).
- `StatsType` comments disambiguating `connectedSessions` (live channels on this node), `allClientSessions` (cluster-wide incl. offline persistent sessions — the analog of the historical `sessions` chart) and `subscriptions`.

### Documentation notes

The 2.4 release notes / metrics docs must call out the `clientSubscriptions` → `subscriptions` rename and value redefinition (old → new name; value now = total subscriptions instead of clients-with-subscriptions).

## General checklist

- [x] You have reviewed the guidelines document.
- [x] Labels that classify your pull request have been added.
- [x] The milestone is specified and corresponds to fix version.
- [x] Description references specific issue.
- [x] Description contains human-readable scope of changes.
- [x] Description contains brief notes about what needs to be added to the documentation.
- [x] No merge conflicts, commented blocks of code, code formatting issues.
- [x] Changes are backward compatible or upgrade script is provided. — intentional breaking metric-name/semantics change for 2.4 (see §1); documented above for release notes. `processedBytes` psql cleanup deferred to a follow-up upgrade script.

## Back-End feature checklist

- [x] Added corresponding unit and/or integration test(s).
- [x] If new dependency was added: the dependency tree is checked for conflicts. — no new dependencies.
