### PR TITLE
feat(stats): add clientDisconnects Prometheus counter

### DIFF
--- a/application/src/main/java/org/thingsboard/mqtt/broker/actors/client/service/disconnect/DisconnectServiceImpl.java
+++ b/application/src/main/java/org/thingsboard/mqtt/broker/actors/client/service/disconnect/DisconnectServiceImpl.java
@@ -28,6 +28,7 @@ import org.thingsboard.mqtt.broker.common.data.ClientInfo;
 import org.thingsboard.mqtt.broker.common.data.SessionInfo;
 import org.thingsboard.mqtt.broker.service.auth.AuthorizationRuleService;
 import org.thingsboard.mqtt.broker.service.integration.IntegrationLifecycleEventPublisher;
+import org.thingsboard.mqtt.broker.service.stats.StatsManager;
 import org.thingsboard.mqtt.broker.service.historical.stats.TbMessageStatsReportClient;
 import org.thingsboard.mqtt.broker.service.limits.RateLimitService;
 import org.thingsboard.mqtt.broker.service.mqtt.MqttMessageGenerator;
@@ -62,6 +63,7 @@ public class DisconnectServiceImpl implements DisconnectService {
     private final TbMessageStatsReportClient tbMessageStatsReportClient;
     private final ChannelBackpressureManager channelBackpressureManager;
     private final IntegrationLifecycleEventPublisher integrationLifecycleEventPublisher;
+    private final StatsManager statsManager;
 
     @Override
     public void disconnect(ClientActorStateInfo actorState, MqttDisconnectMsg disconnectMsg) {
@@ -95,6 +97,11 @@ public class DisconnectServiceImpl implements DisconnectService {
         // CLIENT_CONNECTION_FAILED event covers that case instead.
         if (reasonType != DisconnectReasonType.ON_CONNECTION_FAILURE) {
             integrationLifecycleEventPublisher.publishDisconnected(sessionCtx, reasonType);
+            // Count every genuine disconnect of an established session. Sharing the ON_CONNECTION_FAILURE
+            // exclusion (and running past the getSessionInfo() == null early return above) keeps clientDisconnect
+            // consistent with the CLIENT_DISCONNECTED lifecycle event and avoids double-counting broker-refused
+            // connections, which are surfaced separately as connection refusals.
+            statsManager.getClientDisconnectStats().increment(reasonType);
         }
         cleanupClientSession(actorState, disconnectMsg, sessionExpiryInterval);
     }

--- a/application/src/main/java/org/thingsboard/mqtt/broker/actors/client/service/disconnect/DisconnectServiceImpl.java
+++ b/application/src/main/java/org/thingsboard/mqtt/broker/actors/client/service/disconnect/DisconnectServiceImpl.java
@@ -18,6 +18,7 @@ package org.thingsboard.mqtt.broker.actors.client.service.disconnect;
 import io.netty.handler.codec.mqtt.MqttProperties;
 import io.netty.handler.codec.mqtt.MqttReasonCodes;
 import io.netty.handler.codec.mqtt.MqttVersion;
+import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -27,9 +28,8 @@ import org.thingsboard.mqtt.broker.actors.client.state.ClientActorStateInfo;
 import org.thingsboard.mqtt.broker.common.data.ClientInfo;
 import org.thingsboard.mqtt.broker.common.data.SessionInfo;
 import org.thingsboard.mqtt.broker.service.auth.AuthorizationRuleService;
-import org.thingsboard.mqtt.broker.service.integration.IntegrationLifecycleEventPublisher;
-import org.thingsboard.mqtt.broker.service.stats.StatsManager;
 import org.thingsboard.mqtt.broker.service.historical.stats.TbMessageStatsReportClient;
+import org.thingsboard.mqtt.broker.service.integration.IntegrationLifecycleEventPublisher;
 import org.thingsboard.mqtt.broker.service.limits.RateLimitService;
 import org.thingsboard.mqtt.broker.service.mqtt.MqttMessageGenerator;
 import org.thingsboard.mqtt.broker.service.mqtt.client.event.ClientSessionEventService;
@@ -38,6 +38,8 @@ import org.thingsboard.mqtt.broker.service.mqtt.flow.control.FlowControlService;
 import org.thingsboard.mqtt.broker.service.mqtt.keepalive.KeepAliveService;
 import org.thingsboard.mqtt.broker.service.mqtt.persistence.MsgPersistenceManager;
 import org.thingsboard.mqtt.broker.service.mqtt.will.LastWillService;
+import org.thingsboard.mqtt.broker.service.stats.ClientDisconnectStats;
+import org.thingsboard.mqtt.broker.service.stats.StatsManager;
 import org.thingsboard.mqtt.broker.session.ClientSessionCtx;
 import org.thingsboard.mqtt.broker.session.DisconnectReason;
 import org.thingsboard.mqtt.broker.session.DisconnectReasonType;
@@ -64,6 +66,15 @@ public class DisconnectServiceImpl implements DisconnectService {
     private final ChannelBackpressureManager channelBackpressureManager;
     private final IntegrationLifecycleEventPublisher integrationLifecycleEventPublisher;
     private final StatsManager statsManager;
+
+    private ClientDisconnectStats clientDisconnectStats;
+
+    @PostConstruct
+    void init() {
+        // Resolve once: the instance is created in StatsManagerImpl.init() and never reassigned, matching the
+        // other hot-path consumers (TbMessageStatsReportClientImpl, IntegrationLifecycleEventPublisherImpl).
+        clientDisconnectStats = statsManager.getClientDisconnectStats();
+    }
 
     @Override
     public void disconnect(ClientActorStateInfo actorState, MqttDisconnectMsg disconnectMsg) {
@@ -97,11 +108,8 @@ public class DisconnectServiceImpl implements DisconnectService {
         // CLIENT_CONNECTION_FAILED event covers that case instead.
         if (reasonType != DisconnectReasonType.ON_CONNECTION_FAILURE) {
             integrationLifecycleEventPublisher.publishDisconnected(sessionCtx, reasonType);
-            // Count every genuine disconnect of an established session. Sharing the ON_CONNECTION_FAILURE
-            // exclusion (and running past the getSessionInfo() == null early return above) keeps clientDisconnects
-            // consistent with the CLIENT_DISCONNECTED lifecycle event and avoids double-counting broker-refused
-            // connections, which are surfaced separately as connection refusals.
-            statsManager.getClientDisconnectStats().increment(reasonType);
+            // clientDisconnects counts every established-session disconnect, in lockstep with the CLIENT_DISCONNECTED event above.
+            clientDisconnectStats.increment(reasonType);
         }
         cleanupClientSession(actorState, disconnectMsg, sessionExpiryInterval);
     }

--- a/application/src/main/java/org/thingsboard/mqtt/broker/actors/client/service/disconnect/DisconnectServiceImpl.java
+++ b/application/src/main/java/org/thingsboard/mqtt/broker/actors/client/service/disconnect/DisconnectServiceImpl.java
@@ -98,7 +98,7 @@ public class DisconnectServiceImpl implements DisconnectService {
         if (reasonType != DisconnectReasonType.ON_CONNECTION_FAILURE) {
             integrationLifecycleEventPublisher.publishDisconnected(sessionCtx, reasonType);
             // Count every genuine disconnect of an established session. Sharing the ON_CONNECTION_FAILURE
-            // exclusion (and running past the getSessionInfo() == null early return above) keeps clientDisconnect
+            // exclusion (and running past the getSessionInfo() == null early return above) keeps clientDisconnects
             // consistent with the CLIENT_DISCONNECTED lifecycle event and avoids double-counting broker-refused
             // connections, which are surfaced separately as connection refusals.
             statsManager.getClientDisconnectStats().increment(reasonType);

--- a/application/src/main/java/org/thingsboard/mqtt/broker/actors/service/MsgTypeActorProcessingMetricService.java
+++ b/application/src/main/java/org/thingsboard/mqtt/broker/actors/service/MsgTypeActorProcessingMetricService.java
@@ -23,6 +23,7 @@ import org.springframework.stereotype.Service;
 import org.thingsboard.mqtt.broker.actors.msg.MsgType;
 import org.thingsboard.mqtt.broker.common.stats.StatsConstantNames;
 import org.thingsboard.mqtt.broker.common.stats.StatsFactory;
+import org.thingsboard.mqtt.broker.common.stats.StatsType;
 
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -34,14 +35,12 @@ import java.util.concurrent.TimeUnit;
 @ConditionalOnProperty(prefix = "actors.system.processing-metrics", value = "enabled", havingValue = "true")
 public class MsgTypeActorProcessingMetricService implements ActorProcessingMetricService {
 
-    private static final String ACTOR_MSG_PROCESSING_STATS_NAME = "actors.processing";
-
     private final ConcurrentMap<MsgType, Timer> timers = new ConcurrentHashMap<>();
     private final StatsFactory statsFactory;
 
     @Override
     public void logMsgProcessingTime(MsgType msgType, long time) {
-        Timer timer = timers.computeIfAbsent(msgType, t -> statsFactory.createTimer(ACTOR_MSG_PROCESSING_STATS_NAME,
+        Timer timer = timers.computeIfAbsent(msgType, t -> statsFactory.createTimer(StatsType.ACTORS_PROCESSING.getPrintName(),
                 StatsConstantNames.MSG_TYPE, msgType.toString()));
         timer.record(time, TimeUnit.NANOSECONDS);
     }

--- a/application/src/main/java/org/thingsboard/mqtt/broker/actors/service/MsgTypeActorProcessingMetricService.java
+++ b/application/src/main/java/org/thingsboard/mqtt/broker/actors/service/MsgTypeActorProcessingMetricService.java
@@ -18,7 +18,6 @@ package org.thingsboard.mqtt.broker.actors.service;
 import io.micrometer.core.instrument.Timer;
 import lombok.RequiredArgsConstructor;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
-import org.springframework.context.annotation.Primary;
 import org.springframework.stereotype.Service;
 import org.thingsboard.mqtt.broker.actors.msg.MsgType;
 import org.thingsboard.mqtt.broker.common.stats.StatsConstantNames;
@@ -30,7 +29,6 @@ import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.TimeUnit;
 
 @Service
-@Primary
 @RequiredArgsConstructor
 @ConditionalOnProperty(prefix = "actors.system.processing-metrics", value = "enabled", havingValue = "true")
 public class MsgTypeActorProcessingMetricService implements ActorProcessingMetricService {

--- a/application/src/main/java/org/thingsboard/mqtt/broker/service/stats/ClientDisconnectStats.java
+++ b/application/src/main/java/org/thingsboard/mqtt/broker/service/stats/ClientDisconnectStats.java
@@ -18,8 +18,8 @@ package org.thingsboard.mqtt.broker.service.stats;
 import org.thingsboard.mqtt.broker.session.DisconnectReasonType;
 
 /**
- * Tracks client disconnects as a cumulative {@code clientDisconnect} Prometheus counter. In CE the counter is
- * untagged, so {@code rate(clientDisconnect_total[...])} yields the broker-wide disconnect rate; the per-reason
+ * Tracks client disconnects as a cumulative {@code clientDisconnects} Prometheus counter. In CE the counter is
+ * untagged, so {@code rate(clientDisconnects_total[...])} yields the broker-wide disconnect rate; the per-reason
  * breakdown is a PE-only extension that overrides {@link #increment(DisconnectReasonType)}.
  * <p>
  * Obtained from {@link StatsManager}, so it shares the {@code stats.enabled} master switch with every other

--- a/application/src/main/java/org/thingsboard/mqtt/broker/service/stats/ClientDisconnectStats.java
+++ b/application/src/main/java/org/thingsboard/mqtt/broker/service/stats/ClientDisconnectStats.java
@@ -39,7 +39,7 @@ public interface ClientDisconnectStats {
     int getCount();
 
     /**
-     * Clears the per-interval count read by {@link #getCount()}. The cumulative {@code clientDisconnect}
+     * Clears the per-interval count read by {@link #getCount()}. The cumulative {@code clientDisconnects}
      * Prometheus counter is unaffected and stays monotonic.
      */
     void reset();

--- a/application/src/main/java/org/thingsboard/mqtt/broker/service/stats/ClientDisconnectStats.java
+++ b/application/src/main/java/org/thingsboard/mqtt/broker/service/stats/ClientDisconnectStats.java
@@ -1,0 +1,46 @@
+/**
+ * Copyright © 2016-2026 The Thingsboard Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.thingsboard.mqtt.broker.service.stats;
+
+import org.thingsboard.mqtt.broker.session.DisconnectReasonType;
+
+/**
+ * Tracks client disconnects as a cumulative {@code clientDisconnect} Prometheus counter. In CE the counter is
+ * untagged, so {@code rate(clientDisconnect_total[...])} yields the broker-wide disconnect rate; the per-reason
+ * breakdown is a PE-only extension that overrides {@link #increment(DisconnectReasonType)}.
+ * <p>
+ * Obtained from {@link StatsManager}, so it shares the {@code stats.enabled} master switch with every other
+ * broker metric; when stats are disabled the stub implementation is a no-op and nothing is exposed.
+ */
+public interface ClientDisconnectStats {
+
+    /**
+     * Records one client disconnect. {@code reasonType} is carried so the PE extension can tag/persist by
+     * reason; the CE implementation ignores it and increments a single untagged counter.
+     */
+    void increment(DisconnectReasonType reasonType);
+
+    /**
+     * Number of disconnects since the last {@link #reset()} — read for the periodic stats log line.
+     */
+    int getCount();
+
+    /**
+     * Clears the per-interval count read by {@link #getCount()}. The cumulative {@code clientDisconnect}
+     * Prometheus counter is unaffected and stays monotonic.
+     */
+    void reset();
+}

--- a/application/src/main/java/org/thingsboard/mqtt/broker/service/stats/DefaultClientDisconnectStats.java
+++ b/application/src/main/java/org/thingsboard/mqtt/broker/service/stats/DefaultClientDisconnectStats.java
@@ -16,8 +16,8 @@
 package org.thingsboard.mqtt.broker.service.stats;
 
 import org.thingsboard.mqtt.broker.common.stats.DefaultCounter;
-import org.thingsboard.mqtt.broker.common.stats.StatsConstantNames;
 import org.thingsboard.mqtt.broker.common.stats.StatsFactory;
+import org.thingsboard.mqtt.broker.common.stats.StatsType;
 import org.thingsboard.mqtt.broker.session.DisconnectReasonType;
 
 public class DefaultClientDisconnectStats implements ClientDisconnectStats {
@@ -25,12 +25,12 @@ public class DefaultClientDisconnectStats implements ClientDisconnectStats {
     private final DefaultCounter clientDisconnectCounter;
 
     public DefaultClientDisconnectStats(StatsFactory statsFactory) {
-        this.clientDisconnectCounter = statsFactory.createDefaultCounter(StatsConstantNames.CLIENT_DISCONNECT);
+        this.clientDisconnectCounter = statsFactory.createDefaultCounter(StatsType.CLIENT_DISCONNECTS.getPrintName());
     }
 
     @Override
     public void increment(DisconnectReasonType reasonType) {
-        // CE records a single untagged clientDisconnect counter — the reason is deliberately not used as a
+        // CE records a single untagged clientDisconnects counter — the reason is deliberately not used as a
         // Micrometer tag. The reason breakdown (tagging + persistence) is a PE-only extension that overrides
         // this class; DisconnectReasonType stays on the shared seam so PE can extend without touching callers.
         clientDisconnectCounter.increment();

--- a/application/src/main/java/org/thingsboard/mqtt/broker/service/stats/DefaultClientDisconnectStats.java
+++ b/application/src/main/java/org/thingsboard/mqtt/broker/service/stats/DefaultClientDisconnectStats.java
@@ -1,0 +1,48 @@
+/**
+ * Copyright © 2016-2026 The Thingsboard Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.thingsboard.mqtt.broker.service.stats;
+
+import org.thingsboard.mqtt.broker.common.stats.DefaultCounter;
+import org.thingsboard.mqtt.broker.common.stats.StatsConstantNames;
+import org.thingsboard.mqtt.broker.common.stats.StatsFactory;
+import org.thingsboard.mqtt.broker.session.DisconnectReasonType;
+
+public class DefaultClientDisconnectStats implements ClientDisconnectStats {
+
+    private final DefaultCounter clientDisconnectCounter;
+
+    public DefaultClientDisconnectStats(StatsFactory statsFactory) {
+        this.clientDisconnectCounter = statsFactory.createDefaultCounter(StatsConstantNames.CLIENT_DISCONNECT);
+    }
+
+    @Override
+    public void increment(DisconnectReasonType reasonType) {
+        // CE records a single untagged clientDisconnect counter — the reason is deliberately not used as a
+        // Micrometer tag. The reason breakdown (tagging + persistence) is a PE-only extension that overrides
+        // this class; DisconnectReasonType stays on the shared seam so PE can extend without touching callers.
+        clientDisconnectCounter.increment();
+    }
+
+    @Override
+    public int getCount() {
+        return clientDisconnectCounter.get();
+    }
+
+    @Override
+    public void reset() {
+        clientDisconnectCounter.clear();
+    }
+}

--- a/application/src/main/java/org/thingsboard/mqtt/broker/service/stats/DefaultDroppedLifecycleEventStats.java
+++ b/application/src/main/java/org/thingsboard/mqtt/broker/service/stats/DefaultDroppedLifecycleEventStats.java
@@ -16,15 +16,15 @@
 package org.thingsboard.mqtt.broker.service.stats;
 
 import org.thingsboard.mqtt.broker.common.stats.DefaultCounter;
-import org.thingsboard.mqtt.broker.common.stats.StatsConstantNames;
 import org.thingsboard.mqtt.broker.common.stats.StatsFactory;
+import org.thingsboard.mqtt.broker.common.stats.StatsType;
 
 public class DefaultDroppedLifecycleEventStats implements DroppedLifecycleEventStats {
 
     private final DefaultCounter droppedLifecycleEventsCounter;
 
     public DefaultDroppedLifecycleEventStats(StatsFactory statsFactory) {
-        this.droppedLifecycleEventsCounter = statsFactory.createDefaultCounter(StatsConstantNames.DROPPED_LIFECYCLE_EVENTS);
+        this.droppedLifecycleEventsCounter = statsFactory.createDefaultCounter(StatsType.DROPPED_LIFECYCLE_EVENTS.getPrintName());
     }
 
     @Override

--- a/application/src/main/java/org/thingsboard/mqtt/broker/service/stats/DefaultDroppedMsgStats.java
+++ b/application/src/main/java/org/thingsboard/mqtt/broker/service/stats/DefaultDroppedMsgStats.java
@@ -15,16 +15,16 @@
  */
 package org.thingsboard.mqtt.broker.service.stats;
 
-import org.thingsboard.mqtt.broker.common.data.BrokerConstants;
 import org.thingsboard.mqtt.broker.common.stats.DefaultCounter;
 import org.thingsboard.mqtt.broker.common.stats.StatsFactory;
+import org.thingsboard.mqtt.broker.common.stats.StatsType;
 
 public class DefaultDroppedMsgStats implements DroppedMsgStats {
 
     private final DefaultCounter droppedMsgsCounter;
 
     public DefaultDroppedMsgStats(StatsFactory statsFactory) {
-        this.droppedMsgsCounter = statsFactory.createDefaultCounter(BrokerConstants.DROPPED_MSGS);
+        this.droppedMsgsCounter = statsFactory.createDefaultCounter(StatsType.DROPPED_MSGS.getPrintName());
     }
 
     @Override

--- a/application/src/main/java/org/thingsboard/mqtt/broker/service/stats/StatsManager.java
+++ b/application/src/main/java/org/thingsboard/mqtt/broker/service/stats/StatsManager.java
@@ -49,6 +49,8 @@ public interface StatsManager {
      */
     DroppedLifecycleEventStats getDroppedLifecycleEventStats();
 
+    ClientDisconnectStats getClientDisconnectStats();
+
     ClientSessionEventConsumerStats createClientSessionEventConsumerStats(String consumerId);
 
     PublishMsgConsumerStats createPublishMsgConsumerStats(String consumerId);

--- a/application/src/main/java/org/thingsboard/mqtt/broker/service/stats/StatsManager.java
+++ b/application/src/main/java/org/thingsboard/mqtt/broker/service/stats/StatsManager.java
@@ -49,6 +49,10 @@ public interface StatsManager {
      */
     DroppedLifecycleEventStats getDroppedLifecycleEventStats();
 
+    /**
+     * Returns the client-disconnect stats. Shares the {@code stats.enabled} master switch; when stats
+     * are disabled the stub manager returns a no-op instance.
+     */
     ClientDisconnectStats getClientDisconnectStats();
 
     ClientSessionEventConsumerStats createClientSessionEventConsumerStats(String consumerId);

--- a/application/src/main/java/org/thingsboard/mqtt/broker/service/stats/StatsManagerImpl.java
+++ b/application/src/main/java/org/thingsboard/mqtt/broker/service/stats/StatsManagerImpl.java
@@ -500,10 +500,10 @@ public class StatsManagerImpl implements StatsManager, ActorStatsManager, SqlQue
         log.info("[{}] Stats: count = [{}]", BrokerConstants.DROPPED_MSGS, droppedMsgStats.getCount());
         droppedMsgStats.reset();
 
-        log.info("[{}] Stats: count = [{}]", StatsConstantNames.DROPPED_LIFECYCLE_EVENTS, droppedLifecycleEventStats.getCount());
+        log.info("[{}] Stats: count = [{}]", StatsType.DROPPED_LIFECYCLE_EVENTS.getPrintName(), droppedLifecycleEventStats.getCount());
         droppedLifecycleEventStats.reset();
 
-        log.info("[{}] Stats: count = [{}]", StatsConstantNames.CLIENT_DISCONNECT, clientDisconnectStats.getCount());
+        log.info("[{}] Stats: count = [{}]", StatsType.CLIENT_DISCONNECTS.getPrintName(), clientDisconnectStats.getCount());
         clientDisconnectStats.reset();
 
         StringBuilder gaugeLogBuilder = new StringBuilder();

--- a/application/src/main/java/org/thingsboard/mqtt/broker/service/stats/StatsManagerImpl.java
+++ b/application/src/main/java/org/thingsboard/mqtt/broker/service/stats/StatsManagerImpl.java
@@ -86,6 +86,7 @@ public class StatsManagerImpl implements StatsManager, ActorStatsManager, SqlQue
     private FlowControlStats flowControlStats;
     private DroppedMsgStats droppedMsgStats;
     private DroppedLifecycleEventStats droppedLifecycleEventStats;
+    private ClientDisconnectStats clientDisconnectStats;
 
     @Value("${stats.application-processor.enabled}")
     private boolean applicationProcessorStatsEnabled;
@@ -104,6 +105,7 @@ public class StatsManagerImpl implements StatsManager, ActorStatsManager, SqlQue
         gauges.add(new Gauge(StatsType.FLOW_CONTROL.getPrintName() + ".delayedQueueSize", defaultFlowControlStats::getDelayedQueueSize));
         this.droppedMsgStats = new DefaultDroppedMsgStats(statsFactory);
         this.droppedLifecycleEventStats = new DefaultDroppedLifecycleEventStats(statsFactory);
+        this.clientDisconnectStats = new DefaultClientDisconnectStats(statsFactory);
     }
 
     @PreDestroy
@@ -133,6 +135,11 @@ public class StatsManagerImpl implements StatsManager, ActorStatsManager, SqlQue
     @Override
     public DroppedLifecycleEventStats getDroppedLifecycleEventStats() {
         return droppedLifecycleEventStats;
+    }
+
+    @Override
+    public ClientDisconnectStats getClientDisconnectStats() {
+        return clientDisconnectStats;
     }
 
     @Override
@@ -495,6 +502,9 @@ public class StatsManagerImpl implements StatsManager, ActorStatsManager, SqlQue
 
         log.info("[{}] Stats: count = [{}]", StatsConstantNames.DROPPED_LIFECYCLE_EVENTS, droppedLifecycleEventStats.getCount());
         droppedLifecycleEventStats.reset();
+
+        log.info("[{}] Stats: count = [{}]", StatsConstantNames.CLIENT_DISCONNECT, clientDisconnectStats.getCount());
+        clientDisconnectStats.reset();
 
         StringBuilder gaugeLogBuilder = new StringBuilder();
         for (Gauge gauge : gauges) {

--- a/application/src/main/java/org/thingsboard/mqtt/broker/service/stats/StatsManagerImpl.java
+++ b/application/src/main/java/org/thingsboard/mqtt/broker/service/stats/StatsManagerImpl.java
@@ -23,7 +23,6 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
-import org.springframework.context.annotation.Primary;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.util.CollectionUtils;
@@ -62,7 +61,6 @@ import java.util.stream.Collectors;
 
 @Slf4j
 @Service
-@Primary
 @RequiredArgsConstructor
 @ConditionalOnProperty(prefix = "stats", value = "enabled", havingValue = "true")
 public class StatsManagerImpl implements StatsManager, ActorStatsManager, SqlQueueStatsManager, ProducerStatsManager, ConsumerStatsManager {

--- a/application/src/main/java/org/thingsboard/mqtt/broker/service/stats/StatsManagerImpl.java
+++ b/application/src/main/java/org/thingsboard/mqtt/broker/service/stats/StatsManagerImpl.java
@@ -28,7 +28,6 @@ import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.util.CollectionUtils;
 import org.thingsboard.mqtt.broker.actors.ActorStatsManager;
-import org.thingsboard.mqtt.broker.common.data.BrokerConstants;
 import org.thingsboard.mqtt.broker.common.stats.MessagesStats;
 import org.thingsboard.mqtt.broker.common.stats.MessagesStatsFormatter;
 import org.thingsboard.mqtt.broker.common.stats.ResettableTimer;
@@ -497,7 +496,7 @@ public class StatsManagerImpl implements StatsManager, ActorStatsManager, SqlQue
         log.info("[{}] Stats: {}", StatsType.FLOW_CONTROL.getPrintName(), flowControlStatsStr);
         flowControlStats.reset();
 
-        log.info("[{}] Stats: count = [{}]", BrokerConstants.DROPPED_MSGS, droppedMsgStats.getCount());
+        log.info("[{}] Stats: count = [{}]", StatsType.DROPPED_MSGS.getPrintName(), droppedMsgStats.getCount());
         droppedMsgStats.reset();
 
         log.info("[{}] Stats: count = [{}]", StatsType.DROPPED_LIFECYCLE_EVENTS.getPrintName(), droppedLifecycleEventStats.getCount());

--- a/application/src/main/java/org/thingsboard/mqtt/broker/service/stats/StatsManagerStub.java
+++ b/application/src/main/java/org/thingsboard/mqtt/broker/service/stats/StatsManagerStub.java
@@ -67,6 +67,11 @@ public class StatsManagerStub implements StatsManager, ActorStatsManager, Produc
     }
 
     @Override
+    public ClientDisconnectStats getClientDisconnectStats() {
+        return StubClientDisconnectStats.STUB_CLIENT_DISCONNECT_STATS;
+    }
+
+    @Override
     public ClientSessionEventConsumerStats createClientSessionEventConsumerStats(String consumerId) {
         return StubClientSessionEventConsumerStats.STUB_CLIENT_SESSION_EVENT_CONSUMER_STATS;
     }

--- a/application/src/main/java/org/thingsboard/mqtt/broker/service/stats/StubClientDisconnectStats.java
+++ b/application/src/main/java/org/thingsboard/mqtt/broker/service/stats/StubClientDisconnectStats.java
@@ -1,0 +1,36 @@
+/**
+ * Copyright © 2016-2026 The Thingsboard Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.thingsboard.mqtt.broker.service.stats;
+
+import org.thingsboard.mqtt.broker.session.DisconnectReasonType;
+
+public class StubClientDisconnectStats implements ClientDisconnectStats {
+
+    public static final StubClientDisconnectStats STUB_CLIENT_DISCONNECT_STATS = new StubClientDisconnectStats();
+
+    @Override
+    public void increment(DisconnectReasonType reasonType) {
+    }
+
+    @Override
+    public int getCount() {
+        return 0;
+    }
+
+    @Override
+    public void reset() {
+    }
+}

--- a/application/src/test/java/org/thingsboard/mqtt/broker/actors/client/service/disconnect/DisconnectServiceImplTest.java
+++ b/application/src/test/java/org/thingsboard/mqtt/broker/actors/client/service/disconnect/DisconnectServiceImplTest.java
@@ -44,6 +44,8 @@ import org.thingsboard.mqtt.broker.service.mqtt.flow.control.FlowControlService;
 import org.thingsboard.mqtt.broker.service.mqtt.keepalive.KeepAliveService;
 import org.thingsboard.mqtt.broker.service.mqtt.persistence.MsgPersistenceManager;
 import org.thingsboard.mqtt.broker.service.mqtt.will.LastWillService;
+import org.thingsboard.mqtt.broker.service.stats.ClientDisconnectStats;
+import org.thingsboard.mqtt.broker.service.stats.StatsManager;
 import org.thingsboard.mqtt.broker.session.ClientSessionCtx;
 import org.thingsboard.mqtt.broker.session.DisconnectReason;
 import org.thingsboard.mqtt.broker.session.DisconnectReasonType;
@@ -91,6 +93,8 @@ public class DisconnectServiceImplTest {
     ChannelBackpressureManager channelBackpressureManager;
     @MockitoBean
     IntegrationLifecycleEventPublisher integrationLifecycleEventPublisher;
+    @MockitoBean
+    StatsManager statsManager;
 
     @MockitoSpyBean
     DisconnectServiceImpl disconnectService;
@@ -99,6 +103,7 @@ public class DisconnectServiceImplTest {
     ClientActorStateInfo clientActorState;
     QueuedMqttMessages queuedMqttMessages;
     SessionInfo sessionInfo;
+    ClientDisconnectStats clientDisconnectStats;
 
     @Before
     public void setUp() {
@@ -117,6 +122,9 @@ public class DisconnectServiceImplTest {
         when(clientActorState.getQueuedMessages()).thenReturn(queuedMqttMessages);
 
         when(ctx.getClientId()).thenReturn(CLIENT_ID);
+
+        clientDisconnectStats = mock(ClientDisconnectStats.class);
+        when(statsManager.getClientDisconnectStats()).thenReturn(clientDisconnectStats);
     }
 
     @Test
@@ -238,6 +246,43 @@ public class DisconnectServiceImplTest {
         InOrder inOrder = inOrder(ctx, flowControlService);
         inOrder.verify(ctx).releasePublishedInFlightCtx();
         inOrder.verify(flowControlService).removeFromMap(eq(CLIENT_ID));
+    }
+
+    @Test
+    public void givenEstablishedSession_whenDisconnect_thenClientDisconnectCounterIncrementedWithReason() {
+        MqttDisconnectMsg disconnectMsg = newDisconnectMsg(new DisconnectReason(ON_DISCONNECT_MSG));
+        disconnectService.disconnect(clientActorState, disconnectMsg);
+
+        verify(clientDisconnectStats, times(1)).increment(ON_DISCONNECT_MSG);
+    }
+
+    @Test
+    public void givenClusterConflictingSession_whenDisconnect_thenClientDisconnectCounterIncremented() {
+        // Cross-node takeover is a real established-session disconnect (it emits CLIENT_DISCONNECTED), so it counts.
+        MqttDisconnectMsg disconnectMsg = newDisconnectMsg(new DisconnectReason(DisconnectReasonType.ON_CLUSTER_CONFLICTING_SESSIONS));
+        disconnectService.disconnect(clientActorState, disconnectMsg);
+
+        verify(clientDisconnectStats, times(1)).increment(DisconnectReasonType.ON_CLUSTER_CONFLICTING_SESSIONS);
+    }
+
+    @Test
+    public void givenConnectionFailure_whenDisconnect_thenClientDisconnectCounterNotIncremented() {
+        // A broker-refused connection never established a session; it's counted as a connection refusal, not here.
+        MqttDisconnectMsg disconnectMsg = newDisconnectMsg(new DisconnectReason(DisconnectReasonType.ON_CONNECTION_FAILURE));
+        disconnectService.disconnect(clientActorState, disconnectMsg);
+
+        verify(clientDisconnectStats, never()).increment(any(DisconnectReasonType.class));
+    }
+
+    @Test
+    public void givenSessionInfoIsNull_whenDisconnect_thenClientDisconnectCounterNotIncremented() {
+        // Never-initialized session (early return before the increment site).
+        when(ctx.getSessionInfo()).thenReturn(null);
+
+        MqttDisconnectMsg disconnectMsg = newDisconnectMsg(new DisconnectReason(ON_DISCONNECT_MSG));
+        disconnectService.disconnect(clientActorState, disconnectMsg);
+
+        verify(clientDisconnectStats, never()).increment(any(DisconnectReasonType.class));
     }
 
     private MqttDisconnectMsg newDisconnectMsg(DisconnectReason reason) {

--- a/application/src/test/java/org/thingsboard/mqtt/broker/actors/client/service/disconnect/DisconnectServiceImplTest.java
+++ b/application/src/test/java/org/thingsboard/mqtt/broker/actors/client/service/disconnect/DisconnectServiceImplTest.java
@@ -125,6 +125,9 @@ public class DisconnectServiceImplTest {
 
         clientDisconnectStats = mock(ClientDisconnectStats.class);
         when(statsManager.getClientDisconnectStats()).thenReturn(clientDisconnectStats);
+        // The bean caches the stats reference in @PostConstruct; re-run it here so the cached field
+        // picks up the stub above (context init ran before this stub was set).
+        disconnectService.init();
     }
 
     @Test
@@ -137,6 +140,8 @@ public class DisconnectServiceImplTest {
         verify(disconnectService, never()).cleanupClientSession(clientActorState, disconnectMsg, -1);
         verify(disconnectService, never()).notifyClientDisconnected(clientActorState, 0, ON_DISCONNECT_MSG);
         verify(disconnectService, times(1)).closeChannel(ctx);
+        // Never-initialized session returns before the increment site, so the counter must not move.
+        verify(clientDisconnectStats, never()).increment(any(DisconnectReasonType.class));
     }
 
     @Test
@@ -152,6 +157,8 @@ public class DisconnectServiceImplTest {
         verify(flowControlService, times(1)).removeFromMap(eq(CLIENT_ID));
         verify(tbMessageStatsReportClient).removeClient(eq(CLIENT_ID));
         verify(mqttMessageGenerator, never()).createDisconnectMsg(any());
+        // A genuine established-session disconnect counts, and the disconnect reason is passed through.
+        verify(clientDisconnectStats, times(1)).increment(ON_DISCONNECT_MSG);
     }
 
     @Test
@@ -166,6 +173,8 @@ public class DisconnectServiceImplTest {
         // ...but the lifecycle CLIENT_DISCONNECTED event must still be emitted, to pair with the CLIENT_CONNECTED
         // that this node emitted for the now-superseded session.
         verify(integrationLifecycleEventPublisher, times(1)).publishDisconnected(ctx, DisconnectReasonType.ON_CLUSTER_CONFLICTING_SESSIONS);
+        // Cross-node takeover is a real established-session disconnect, so it counts in lockstep with the event.
+        verify(clientDisconnectStats, times(1)).increment(DisconnectReasonType.ON_CLUSTER_CONFLICTING_SESSIONS);
     }
 
     @Test
@@ -176,6 +185,8 @@ public class DisconnectServiceImplTest {
         // A broker-refused connection never established a session, so the teardown disconnect must NOT emit
         // CLIENT_DISCONNECTED (there is no CLIENT_CONNECTED to pair with); CLIENT_CONNECTION_FAILED covers it instead.
         verify(integrationLifecycleEventPublisher, never()).publishDisconnected(ctx, DisconnectReasonType.ON_CONNECTION_FAILURE);
+        // ...and for the same reason it must not be counted here; it is surfaced separately as a connection refusal.
+        verify(clientDisconnectStats, never()).increment(any(DisconnectReasonType.class));
     }
 
     @Test
@@ -246,43 +257,6 @@ public class DisconnectServiceImplTest {
         InOrder inOrder = inOrder(ctx, flowControlService);
         inOrder.verify(ctx).releasePublishedInFlightCtx();
         inOrder.verify(flowControlService).removeFromMap(eq(CLIENT_ID));
-    }
-
-    @Test
-    public void givenEstablishedSession_whenDisconnect_thenClientDisconnectCounterIncrementedWithReason() {
-        MqttDisconnectMsg disconnectMsg = newDisconnectMsg(new DisconnectReason(ON_DISCONNECT_MSG));
-        disconnectService.disconnect(clientActorState, disconnectMsg);
-
-        verify(clientDisconnectStats, times(1)).increment(ON_DISCONNECT_MSG);
-    }
-
-    @Test
-    public void givenClusterConflictingSession_whenDisconnect_thenClientDisconnectCounterIncremented() {
-        // Cross-node takeover is a real established-session disconnect (it emits CLIENT_DISCONNECTED), so it counts.
-        MqttDisconnectMsg disconnectMsg = newDisconnectMsg(new DisconnectReason(DisconnectReasonType.ON_CLUSTER_CONFLICTING_SESSIONS));
-        disconnectService.disconnect(clientActorState, disconnectMsg);
-
-        verify(clientDisconnectStats, times(1)).increment(DisconnectReasonType.ON_CLUSTER_CONFLICTING_SESSIONS);
-    }
-
-    @Test
-    public void givenConnectionFailure_whenDisconnect_thenClientDisconnectCounterNotIncremented() {
-        // A broker-refused connection never established a session; it's counted as a connection refusal, not here.
-        MqttDisconnectMsg disconnectMsg = newDisconnectMsg(new DisconnectReason(DisconnectReasonType.ON_CONNECTION_FAILURE));
-        disconnectService.disconnect(clientActorState, disconnectMsg);
-
-        verify(clientDisconnectStats, never()).increment(any(DisconnectReasonType.class));
-    }
-
-    @Test
-    public void givenSessionInfoIsNull_whenDisconnect_thenClientDisconnectCounterNotIncremented() {
-        // Never-initialized session (early return before the increment site).
-        when(ctx.getSessionInfo()).thenReturn(null);
-
-        MqttDisconnectMsg disconnectMsg = newDisconnectMsg(new DisconnectReason(ON_DISCONNECT_MSG));
-        disconnectService.disconnect(clientActorState, disconnectMsg);
-
-        verify(clientDisconnectStats, never()).increment(any(DisconnectReasonType.class));
     }
 
     private MqttDisconnectMsg newDisconnectMsg(DisconnectReason reason) {

--- a/application/src/test/java/org/thingsboard/mqtt/broker/actors/service/MsgTypeActorProcessingMetricServiceTest.java
+++ b/application/src/test/java/org/thingsboard/mqtt/broker/actors/service/MsgTypeActorProcessingMetricServiceTest.java
@@ -23,6 +23,7 @@ import org.thingsboard.mqtt.broker.actors.msg.MsgType;
 import org.thingsboard.mqtt.broker.common.stats.DefaultStatsFactory;
 import org.thingsboard.mqtt.broker.common.stats.StatsConstantNames;
 import org.thingsboard.mqtt.broker.common.stats.StatsFactory;
+import org.thingsboard.mqtt.broker.common.stats.StatsType;
 
 import java.util.concurrent.TimeUnit;
 
@@ -47,7 +48,7 @@ public class MsgTypeActorProcessingMetricServiceTest {
         // If the timer records the value as MILLISECONDS, the recorded total is 1_500_000 ms, not 1.5 ms.
         service.logMsgProcessingTime(MsgType.INCOMING_PUBLISH_MSG, 1_500_000L);
 
-        Timer timer = meterRegistry.find("actors.processing")
+        Timer timer = meterRegistry.find(StatsType.ACTORS_PROCESSING.getPrintName())
                 .tag(StatsConstantNames.MSG_TYPE, MsgType.INCOMING_PUBLISH_MSG.toString())
                 .timer();
         assertNotNull(timer);

--- a/application/src/test/java/org/thingsboard/mqtt/broker/service/stats/DefaultClientDisconnectStatsTest.java
+++ b/application/src/test/java/org/thingsboard/mqtt/broker/service/stats/DefaultClientDisconnectStatsTest.java
@@ -1,0 +1,79 @@
+/**
+ * Copyright © 2016-2026 The Thingsboard Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.thingsboard.mqtt.broker.service.stats;
+
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.Before;
+import org.junit.Test;
+import org.thingsboard.mqtt.broker.common.stats.DefaultStatsFactory;
+import org.thingsboard.mqtt.broker.common.stats.StatsConstantNames;
+import org.thingsboard.mqtt.broker.common.stats.StatsFactory;
+import org.thingsboard.mqtt.broker.session.DisconnectReasonType;
+
+import static org.junit.Assert.assertEquals;
+
+public class DefaultClientDisconnectStatsTest {
+
+    private SimpleMeterRegistry meterRegistry;
+    private DefaultClientDisconnectStats clientDisconnectStats;
+
+    @Before
+    public void setUp() {
+        meterRegistry = new SimpleMeterRegistry();
+        StatsFactory statsFactory = new DefaultStatsFactory(meterRegistry);
+        clientDisconnectStats = new DefaultClientDisconnectStats(statsFactory);
+    }
+
+    @Test
+    public void givenFreshStats_whenIncrement_thenCountAndPrometheusCounterIncrease() {
+        clientDisconnectStats.increment(DisconnectReasonType.ON_DISCONNECT_MSG);
+        clientDisconnectStats.increment(DisconnectReasonType.ON_KEEP_ALIVE);
+
+        assertEquals(2, clientDisconnectStats.getCount());
+        assertEquals(2.0, meterRegistry.counter(StatsConstantNames.CLIENT_DISCONNECT).count(), 0.0);
+    }
+
+    @Test
+    public void givenDifferentReasons_whenIncrement_thenAllMapToSingleUntaggedCounter() {
+        clientDisconnectStats.increment(DisconnectReasonType.ON_DISCONNECT_MSG);
+        clientDisconnectStats.increment(DisconnectReasonType.ON_CLUSTER_CONFLICTING_SESSIONS);
+        clientDisconnectStats.increment(DisconnectReasonType.ON_RATE_LIMITS);
+
+        // CE emits a single untagged clientDisconnect counter; the reason is intentionally ignored
+        // (the reason breakdown is a PE-only extension). All reasons accumulate into one series.
+        assertEquals(3.0, meterRegistry.counter(StatsConstantNames.CLIENT_DISCONNECT).count(), 0.0);
+        assertEquals(1, meterRegistry.find(StatsConstantNames.CLIENT_DISCONNECT).counters().size());
+    }
+
+    @Test
+    public void givenIncrementedStats_whenReset_thenCountClearedButPrometheusCounterStaysMonotonic() {
+        clientDisconnectStats.increment(DisconnectReasonType.ON_DISCONNECT_MSG);
+        clientDisconnectStats.increment(DisconnectReasonType.ON_DISCONNECT_MSG);
+        clientDisconnectStats.increment(DisconnectReasonType.ON_DISCONNECT_MSG);
+
+        clientDisconnectStats.reset();
+
+        // Per-interval count cleared for the next log line...
+        assertEquals(0, clientDisconnectStats.getCount());
+        // ...but the cumulative Prometheus counter must never be reset.
+        assertEquals(3.0, meterRegistry.counter(StatsConstantNames.CLIENT_DISCONNECT).count(), 0.0);
+
+        clientDisconnectStats.increment(DisconnectReasonType.ON_KEEP_ALIVE);
+
+        assertEquals(1, clientDisconnectStats.getCount());
+        assertEquals(4.0, meterRegistry.counter(StatsConstantNames.CLIENT_DISCONNECT).count(), 0.0);
+    }
+}

--- a/application/src/test/java/org/thingsboard/mqtt/broker/service/stats/DefaultClientDisconnectStatsTest.java
+++ b/application/src/test/java/org/thingsboard/mqtt/broker/service/stats/DefaultClientDisconnectStatsTest.java
@@ -19,8 +19,8 @@ import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.junit.Before;
 import org.junit.Test;
 import org.thingsboard.mqtt.broker.common.stats.DefaultStatsFactory;
-import org.thingsboard.mqtt.broker.common.stats.StatsConstantNames;
 import org.thingsboard.mqtt.broker.common.stats.StatsFactory;
+import org.thingsboard.mqtt.broker.common.stats.StatsType;
 import org.thingsboard.mqtt.broker.session.DisconnectReasonType;
 
 import static org.junit.Assert.assertEquals;
@@ -43,7 +43,7 @@ public class DefaultClientDisconnectStatsTest {
         clientDisconnectStats.increment(DisconnectReasonType.ON_KEEP_ALIVE);
 
         assertEquals(2, clientDisconnectStats.getCount());
-        assertEquals(2.0, meterRegistry.counter(StatsConstantNames.CLIENT_DISCONNECT).count(), 0.0);
+        assertEquals(2.0, meterRegistry.counter(StatsType.CLIENT_DISCONNECTS.getPrintName()).count(), 0.0);
     }
 
     @Test
@@ -52,10 +52,10 @@ public class DefaultClientDisconnectStatsTest {
         clientDisconnectStats.increment(DisconnectReasonType.ON_CLUSTER_CONFLICTING_SESSIONS);
         clientDisconnectStats.increment(DisconnectReasonType.ON_RATE_LIMITS);
 
-        // CE emits a single untagged clientDisconnect counter; the reason is intentionally ignored
+        // CE emits a single untagged clientDisconnects counter; the reason is intentionally ignored
         // (the reason breakdown is a PE-only extension). All reasons accumulate into one series.
-        assertEquals(3.0, meterRegistry.counter(StatsConstantNames.CLIENT_DISCONNECT).count(), 0.0);
-        assertEquals(1, meterRegistry.find(StatsConstantNames.CLIENT_DISCONNECT).counters().size());
+        assertEquals(3.0, meterRegistry.counter(StatsType.CLIENT_DISCONNECTS.getPrintName()).count(), 0.0);
+        assertEquals(1, meterRegistry.find(StatsType.CLIENT_DISCONNECTS.getPrintName()).counters().size());
     }
 
     @Test
@@ -69,11 +69,11 @@ public class DefaultClientDisconnectStatsTest {
         // Per-interval count cleared for the next log line...
         assertEquals(0, clientDisconnectStats.getCount());
         // ...but the cumulative Prometheus counter must never be reset.
-        assertEquals(3.0, meterRegistry.counter(StatsConstantNames.CLIENT_DISCONNECT).count(), 0.0);
+        assertEquals(3.0, meterRegistry.counter(StatsType.CLIENT_DISCONNECTS.getPrintName()).count(), 0.0);
 
         clientDisconnectStats.increment(DisconnectReasonType.ON_KEEP_ALIVE);
 
         assertEquals(1, clientDisconnectStats.getCount());
-        assertEquals(4.0, meterRegistry.counter(StatsConstantNames.CLIENT_DISCONNECT).count(), 0.0);
+        assertEquals(4.0, meterRegistry.counter(StatsType.CLIENT_DISCONNECTS.getPrintName()).count(), 0.0);
     }
 }

--- a/application/src/test/java/org/thingsboard/mqtt/broker/service/stats/StatsManagerImplTest.java
+++ b/application/src/test/java/org/thingsboard/mqtt/broker/service/stats/StatsManagerImplTest.java
@@ -22,7 +22,6 @@ import org.junit.Test;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.thingsboard.mqtt.broker.common.stats.DefaultStatsFactory;
 import org.thingsboard.mqtt.broker.common.stats.MessagesStats;
-import org.thingsboard.mqtt.broker.common.stats.StatsConstantNames;
 import org.thingsboard.mqtt.broker.common.stats.StatsFactory;
 import org.thingsboard.mqtt.broker.common.stats.StatsType;
 import org.thingsboard.mqtt.broker.service.subscription.shared.TopicSharedSubscription;
@@ -215,6 +214,6 @@ public class StatsManagerImplTest {
         stats.increment(DisconnectReasonType.ON_DISCONNECT_MSG);
         stats.increment(DisconnectReasonType.ON_KEEP_ALIVE);
 
-        assertEquals(2.0, meterRegistry.counter(StatsConstantNames.CLIENT_DISCONNECT).count(), 0.0);
+        assertEquals(2.0, meterRegistry.counter(StatsType.CLIENT_DISCONNECTS.getPrintName()).count(), 0.0);
     }
 }

--- a/application/src/test/java/org/thingsboard/mqtt/broker/service/stats/StatsManagerImplTest.java
+++ b/application/src/test/java/org/thingsboard/mqtt/broker/service/stats/StatsManagerImplTest.java
@@ -22,9 +22,11 @@ import org.junit.Test;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.thingsboard.mqtt.broker.common.stats.DefaultStatsFactory;
 import org.thingsboard.mqtt.broker.common.stats.MessagesStats;
+import org.thingsboard.mqtt.broker.common.stats.StatsConstantNames;
 import org.thingsboard.mqtt.broker.common.stats.StatsFactory;
 import org.thingsboard.mqtt.broker.common.stats.StatsType;
 import org.thingsboard.mqtt.broker.service.subscription.shared.TopicSharedSubscription;
+import org.thingsboard.mqtt.broker.session.DisconnectReasonType;
 
 import java.util.Map;
 import java.util.Set;
@@ -201,5 +203,18 @@ public class StatsManagerImplTest {
         Gauge gauge = meterRegistry.find(StatsType.SUBSCRIPTIONS.getPrintName()).gauge();
         assertNotNull(gauge);
         assertEquals(0.0, gauge.value(), 0.0);
+    }
+
+    @Test
+    public void givenStatsManager_whenGetClientDisconnectStats_thenReturnsWiredStatsThatRegisterCounter() {
+        statsManager.init();
+
+        ClientDisconnectStats stats = statsManager.getClientDisconnectStats();
+        assertNotNull(stats);
+
+        stats.increment(DisconnectReasonType.ON_DISCONNECT_MSG);
+        stats.increment(DisconnectReasonType.ON_KEEP_ALIVE);
+
+        assertEquals(2.0, meterRegistry.counter(StatsConstantNames.CLIENT_DISCONNECT).count(), 0.0);
     }
 }

--- a/application/src/test/java/org/thingsboard/mqtt/broker/service/testing/integration/SessionTakenOverIntegrationTestCase.java
+++ b/application/src/test/java/org/thingsboard/mqtt/broker/service/testing/integration/SessionTakenOverIntegrationTestCase.java
@@ -16,10 +16,12 @@
 package org.thingsboard.mqtt.broker.service.testing.integration;
 
 import com.google.common.util.concurrent.Futures;
+import io.micrometer.core.instrument.MeterRegistry;
 import io.netty.handler.codec.mqtt.MqttQoS;
 import io.netty.handler.codec.mqtt.MqttVersion;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.RandomStringUtils;
+import org.awaitility.Awaitility;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -34,6 +36,7 @@ import org.thingsboard.mqtt.MqttHandler;
 import org.thingsboard.mqtt.broker.AbstractPubSubIntegrationTest;
 import org.thingsboard.mqtt.broker.common.data.ClientSession;
 import org.thingsboard.mqtt.broker.common.data.subscription.TopicSubscription;
+import org.thingsboard.mqtt.broker.common.stats.StatsType;
 import org.thingsboard.mqtt.broker.dao.DaoSqlTest;
 import org.thingsboard.mqtt.broker.service.mqtt.client.session.ClientSessionCache;
 import org.thingsboard.mqtt.broker.service.subscription.ClientSubscriptionCache;
@@ -56,6 +59,8 @@ public class SessionTakenOverIntegrationTestCase extends AbstractPubSubIntegrati
     private ClientSessionCache clientSessionCache;
     @Autowired
     private ClientSubscriptionCache clientSubscriptionCache;
+    @Autowired
+    private MeterRegistry meterRegistry;
 
     @Test
     public void givenCleanSessionClient_whenCleanSessionTakenOver_thenNoSubscriptionsPresent() throws Throwable {
@@ -137,6 +142,35 @@ public class SessionTakenOverIntegrationTestCase extends AbstractPubSubIntegrati
         Assert.assertEquals(0, clientSubscriptions.size());
 
         clientTakenOver.disconnect();
+    }
+
+    @Test
+    public void givenConnectedClient_whenSessionTakenOver_thenClientDisconnectsCounterIncremented() throws Throwable {
+        String clientId = RandomStringUtils.randomAlphabetic(10);
+        MqttClientConfig config = getConfig(clientId, true);
+
+        MqttClient client = MqttClient.create(config, null, externalExecutorService);
+        connectClient(client);
+
+        // Cumulative Micrometer counter (never reset), so assert the delta caused by the takeover disconnect —
+        // immune to disconnects produced by the other test methods sharing this context.
+        double before = clientDisconnectsCount();
+
+        // Reconnecting with the same clientId forces the broker to disconnect the original session with
+        // ON_CLUSTER_CONFLICTING_SESSIONS: a broker-generated disconnect that must bump clientDisconnects.
+        MqttClient clientTakenOver = MqttClient.create(config, null, externalExecutorService);
+        connectClient(clientTakenOver);
+
+        // The takeover disconnect is processed asynchronously on the client actor thread, so poll the counter.
+        Awaitility.await()
+                .atMost(30, TimeUnit.SECONDS)
+                .until(() -> clientDisconnectsCount() - before >= 1);
+
+        clientTakenOver.disconnect();
+    }
+
+    private double clientDisconnectsCount() {
+        return meterRegistry.get(StatsType.CLIENT_DISCONNECTS.getPrintName()).counter().count();
     }
 
     private void connectClient(MqttClient client) throws InterruptedException, ExecutionException, TimeoutException {

--- a/common/stats/src/main/java/org/thingsboard/mqtt/broker/common/stats/StatsConstantNames.java
+++ b/common/stats/src/main/java/org/thingsboard/mqtt/broker/common/stats/StatsConstantNames.java
@@ -53,7 +53,4 @@ public class StatsConstantNames {
 
     public static final String MSG_TYPE = "msgType";
 
-    public static final String DROPPED_LIFECYCLE_EVENTS = "droppedLifecycleEvents";
-    public static final String CLIENT_DISCONNECT = "clientDisconnect";
-
 }

--- a/common/stats/src/main/java/org/thingsboard/mqtt/broker/common/stats/StatsConstantNames.java
+++ b/common/stats/src/main/java/org/thingsboard/mqtt/broker/common/stats/StatsConstantNames.java
@@ -54,5 +54,6 @@ public class StatsConstantNames {
     public static final String MSG_TYPE = "msgType";
 
     public static final String DROPPED_LIFECYCLE_EVENTS = "droppedLifecycleEvents";
+    public static final String CLIENT_DISCONNECT = "clientDisconnect";
 
 }

--- a/common/stats/src/main/java/org/thingsboard/mqtt/broker/common/stats/StatsType.java
+++ b/common/stats/src/main/java/org/thingsboard/mqtt/broker/common/stats/StatsType.java
@@ -38,9 +38,9 @@ public enum StatsType {
     // historical 'sessions' chart (BrokerConstants.SESSIONS).
     ALL_CLIENT_SESSIONS("allClientSessions"),
     // Total subscription count across all clients (sum of the per-client subscription set sizes), matching
-    // the historical 'subscriptions' chart (BrokerConstants.SUBSCRIPTIONS). Renamed from 'clientSubscriptions',
-    // which misleadingly reported the number of clients with at least one subscription rather than a count.
-    SUBSCRIPTIONS("subscriptions"),
+    // the historical 'subscriptions' chart. Renamed from 'clientSubscriptions', which misleadingly reported
+    // the number of clients with at least one subscription rather than a count.
+    SUBSCRIPTIONS(BrokerConstants.SUBSCRIPTIONS),
     RETAINED_MESSAGES("retainedMessages"),
     SUBSCRIPTION_TRIE_NODES("subscriptionTrieNodes"),
     RETAIN_MSG_TRIE_NODES("retainMsgTrieNodes"),

--- a/common/stats/src/main/java/org/thingsboard/mqtt/broker/common/stats/StatsType.java
+++ b/common/stats/src/main/java/org/thingsboard/mqtt/broker/common/stats/StatsType.java
@@ -68,6 +68,9 @@ public enum StatsType {
     INTEGRATION("integration"),
     INTEGRATION_PROCESSOR("integrationProcessor"),
     INTEGRATION_EVENT_PROCESSOR("integrationEventProcessor"),
+
+    DROPPED_LIFECYCLE_EVENTS("droppedLifecycleEvents"),
+    CLIENT_DISCONNECTS("clientDisconnects"),
     ;
 
     private final String printName;

--- a/common/stats/src/main/java/org/thingsboard/mqtt/broker/common/stats/StatsType.java
+++ b/common/stats/src/main/java/org/thingsboard/mqtt/broker/common/stats/StatsType.java
@@ -17,6 +17,7 @@ package org.thingsboard.mqtt.broker.common.stats;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import org.thingsboard.mqtt.broker.common.data.BrokerConstants;
 
 @RequiredArgsConstructor
 @Getter
@@ -52,6 +53,7 @@ public enum StatsType {
     CLIENT_SUBSCRIPTIONS_CONSUMER("clientSubscriptionsConsumer"),
     RETAINED_MSG_CONSUMER("retainedMsgConsumer"),
     CLIENT_ACTOR("clientActor"),
+    ACTORS_PROCESSING("actors.processing"),
     FLOW_CONTROL("flowControl"),
 
     SUBSCRIPTION_LOOKUP("subscriptionLookup"),
@@ -69,6 +71,7 @@ public enum StatsType {
     INTEGRATION_PROCESSOR("integrationProcessor"),
     INTEGRATION_EVENT_PROCESSOR("integrationEventProcessor"),
 
+    DROPPED_MSGS(BrokerConstants.DROPPED_MSGS),
     DROPPED_LIFECYCLE_EVENTS("droppedLifecycleEvents"),
     CLIENT_DISCONNECTS("clientDisconnects"),
     ;


### PR DESCRIPTION
## Pull Request description

Adds a broker-wide **`clientDisconnects`** Micrometer counter (Prometheus `clientDisconnects_total`), giving operators a disconnect-rate signal that CE previously lacked — until now the only session signal was the `connectedSessions` current-count gauge. `rate(clientDisconnects_total[5m])` / `increase(...)` yields disconnects over time, separating churn spikes from steady state.

**Scope of changes**

- New `ClientDisconnectStats` seam in `service.stats` (interface + `DefaultClientDisconnectStats` + no-op `StubClientDisconnectStats`), exposed via `StatsManager.getClientDisconnectStats()`. Mirrors the existing `DroppedLifecycleEventStats` / `DroppedMsgStats` family and rides the existing `stats.enabled` master switch (real impl when enabled, no-op stub otherwise) — no dedicated flag.
- `DisconnectServiceImpl.disconnect` increments the counter for every genuine disconnect of an **established** session — all client- and broker-initiated reasons, including cross-node session takeover (`ON_CLUSTER_CONFLICTING_SESSIONS`). The stats instance is resolved once in `@PostConstruct`, matching the other hot-path consumers (`TbMessageStatsReportClientImpl`, `IntegrationLifecycleEventPublisherImpl`).
- The counter is intentionally **untagged** (a single aggregate series). `DisconnectReasonType` is threaded through `ClientDisconnectStats.increment(reasonType)` as an extension point, but this CE implementation records one untagged counter and ignores the reason.
- The increment fires under the exact same condition as the `CLIENT_DISCONNECTED` lifecycle event, so it excludes:
  - `ON_CONNECTION_FAILURE` — a broker-refused connection that never established a session (a connection *refusal*, not a disconnect);
  - not-fully-initialized sessions (`getSessionInfo() == null` early return).
- Adds a periodic stats-log line + per-interval reset, matching the sibling `droppedMsgs` / `droppedLifecycleEvents` lines. The cumulative Prometheus counter stays monotonic across resets.

**Refactors bundled in** (same stats classes, no behavior change)

- Centralized the Micrometer meter print-names in the `StatsType` enum, where the rest of the meter names already live: the new `clientDisconnects`, plus the existing `droppedLifecycleEvents`, `actors.processing`, and `droppedMsgs`. `droppedMsgs` aliases `BrokerConstants.DROPPED_MSGS` because that value doubles as a historical-stats key in `common/data`, which cannot depend on `common/stats` — only the meter-side usages route through `StatsType`. **Exported metric names are unchanged.**
- Removed a redundant `@Primary` from `MsgTypeActorProcessingMetricService` and `StatsManagerImpl`. Each interface is implemented only by a real bean and a stub gated by mutually-exclusive `@ConditionalOnProperty` (feature `enabled` true vs. false/missing), so at most one bean of each type ever exists and `@Primary` has nothing to disambiguate.

**Tests**

- New `DefaultClientDisconnectStatsTest` (3): increment increases both the local count and the Micrometer counter; different reasons all map to a single untagged series; reset clears the per-interval count while the Prometheus counter stays monotonic.
- `StatsManagerImplTest`: `getClientDisconnectStats()` returns a wired instance that registers/increments the `clientDisconnects` counter.
- `DisconnectServiceImplTest`: counter assertions folded into the existing disconnect tests — an established disconnect increments with the reason passed through, cluster takeover increments, while `ON_CONNECTION_FAILURE` and the null-session early return do not (the counter fires in lockstep with the `CLIENT_DISCONNECTED` event, so the assertions live beside the lifecycle-event assertions they mirror).
- New `SessionTakenOverIntegrationTestCase` case: end-to-end proof that a real broker-generated `ON_CLUSTER_CONFLICTING_SESSIONS` takeover bumps the `clientDisconnects` meter in a live `MeterRegistry`.

**Documentation**

- No YAML/config change (this is a runtime Micrometer meter, not a config parameter). If the Prometheus metrics reference page is maintained, add `clientDisconnects_total` — a broker-wide cumulative disconnect counter.

**Backward compatibility**

- Fully backward compatible — additive new meter. The bundled refactors leave all exported metric names unchanged, and nothing is renamed or removed on the wire; no configuration or schema change.

## General checklist

- [x] You have reviewed the guidelines document.
- [x] Labels that classify your pull request have been added.
- [x] The milestone is specified and corresponds to fix version.
- [x] Description references specific issue.
- [x] Description contains human-readable scope of changes.
- [x] Description contains brief notes about what needs to be added to the documentation.
- [x] No merge conflicts, commented blocks of code, code formatting issues.
- [x] Changes are backward compatible or upgrade script is provided.

## Front-End feature checklist

- [x] N/A — back-end only, no UI or widget/API changes.

## Back-End feature checklist

- [x] Added corresponding unit test(s): `DefaultClientDisconnectStatsTest` (new), additions to `StatsManagerImplTest` and `DisconnectServiceImplTest`, and a new end-to-end `SessionTakenOverIntegrationTestCase` case.
- [x] No new dependency was added.
