### PR TITLE
feat(stats): complete droppedMsgs across the PUBLISH pipeline

### DIFF
--- a/application/src/main/java/org/thingsboard/mqtt/broker/actors/client/service/connect/ConnectServiceImpl.java
+++ b/application/src/main/java/org/thingsboard/mqtt/broker/actors/client/service/connect/ConnectServiceImpl.java
@@ -58,6 +58,7 @@ import org.thingsboard.mqtt.broker.service.mqtt.persistence.MsgPersistenceManage
 import org.thingsboard.mqtt.broker.service.mqtt.validation.PublishMsgValidationService;
 import org.thingsboard.mqtt.broker.service.mqtt.will.LastWillService;
 import org.thingsboard.mqtt.broker.service.integration.IntegrationLifecycleEventPublisher;
+import org.thingsboard.mqtt.broker.service.historical.stats.TbMessageStatsReportClient;
 import org.thingsboard.mqtt.broker.service.stats.StatsManager;
 import org.thingsboard.mqtt.broker.service.subscription.ClientSubscriptionCache;
 import org.thingsboard.mqtt.broker.service.subscription.shared.TopicSharedSubscription;
@@ -95,6 +96,7 @@ public class ConnectServiceImpl implements ConnectService {
     private final PublishMsgValidationService publishMsgValidationService;
     private final MqttPublishMsgDeliveryService mqttPublishMsgDeliveryService;
     private final StatsManager statsManager;
+    private final TbMessageStatsReportClient tbMessageStatsReportClient;
     private final IntegrationLifecycleEventPublisher integrationLifecycleEventPublisher;
 
     private ExecutorService connectHandlerExecutor;
@@ -159,6 +161,7 @@ public class ConnectServiceImpl implements ConnectService {
                     flowControlService,
                     mqttPublishMsgDeliveryService,
                     statsManager.getFlowControlStats(),
+                    tbMessageStatsReportClient,
                     receiveMaxValue,
                     delayedQueueMaxSize);
         }

--- a/application/src/main/java/org/thingsboard/mqtt/broker/actors/client/service/handlers/MqttPublishHandler.java
+++ b/application/src/main/java/org/thingsboard/mqtt/broker/actors/client/service/handlers/MqttPublishHandler.java
@@ -124,6 +124,7 @@ public class MqttPublishHandler {
             }
         } catch (FullMsgQueueException e) {
             log.warn("[{}][{}] Failed to process publish msg: {}", ctx.getClientId(), ctx.getSessionId(), publishMsg.getPacketId(), e);
+            tbMessageStatsReportClient.reportDroppedMsgs();
             disconnectClient(ctx, DisconnectReasonType.ON_RECEIVE_MAXIMUM_EXCEEDED, e.getMessage());
             return;
         }

--- a/application/src/main/java/org/thingsboard/mqtt/broker/actors/client/state/PublishedInFlightCtxImpl.java
+++ b/application/src/main/java/org/thingsboard/mqtt/broker/actors/client/state/PublishedInFlightCtxImpl.java
@@ -275,7 +275,11 @@ public class PublishedInFlightCtxImpl implements PublishedInFlightCtx {
     // A flow-control drop counts toward droppedMsgs only for a non-persistent session and a non-retained
     // message: persistent copies are recoverable from the store (APPLICATION via Kafka, counted once at
     // give-up in ApplicationPersistenceProcessorImpl; DEVICE via Redis redelivery), and retained messages are
-    // recoverable from the retained-message store (consistent with DefaultMqttPublishMsgDeliveryService).
+    // recoverable from the retained-message store.
+    //
+    // NOTE: this predicate intentionally has NO QoS0 clause, unlike DefaultMqttPublishMsgDeliveryService#isCountableDrop.
+    // QoS0 messages short-circuit in atMostOnce()/addInFlightMsg() and never enter the delay queue, so they cannot be
+    // dropped here — the two predicates are deliberately different. Do not "align" them by adding a QoS0 clause here.
     private boolean isCountableDrop(MqttPublishMessage msg) {
         return !clientSessionCtx.getSessionInfo().isPersistent() && !msg.fixedHeader().isRetain();
     }

--- a/application/src/main/java/org/thingsboard/mqtt/broker/actors/client/state/PublishedInFlightCtxImpl.java
+++ b/application/src/main/java/org/thingsboard/mqtt/broker/actors/client/state/PublishedInFlightCtxImpl.java
@@ -218,14 +218,22 @@ public class PublishedInFlightCtxImpl implements PublishedInFlightCtx {
             lock.unlock();
         }
 
+        // Session persistence is fixed for the session, so evaluate it once here rather than per expired message:
+        // for a persistent session nothing expiring here is a countable drop (the copy is recoverable from the
+        // store), so the per-message retain check is skipped entirely. Count in the same pass that releases the
+        // buffers instead of a second stream over the list. See isCountableDrop for the full rule and rationale.
+        boolean countableSession = !toRelease.isEmpty() && !clientSessionCtx.getSessionInfo().isPersistent();
+        int countableDrops = 0;
         for (MqttPublishMessage m : toRelease) {
+            if (countableSession && !m.fixedHeader().isRetain()) {
+                countableDrops++;
+            }
             ReferenceCountUtil.safeRelease(m);
         }
         int expiredCount = toRelease.size();
         if (expiredCount > 0) {
             stats.decDelayed(expiredCount);
             stats.incDropTtl(expiredCount);
-            int countableDrops = (int) toRelease.stream().filter(this::isCountableDrop).count();
             if (countableDrops > 0) {
                 tbMessageStatsReportClient.reportDroppedMsgs(countableDrops);
             }

--- a/application/src/main/java/org/thingsboard/mqtt/broker/actors/client/state/PublishedInFlightCtxImpl.java
+++ b/application/src/main/java/org/thingsboard/mqtt/broker/actors/client/state/PublishedInFlightCtxImpl.java
@@ -118,6 +118,8 @@ public class PublishedInFlightCtxImpl implements PublishedInFlightCtx {
                     clientId, clientReceiveMax, delayedMsgQueueMaxSize);
             ReferenceCountUtil.safeRelease(toRelease);
             stats.incDropOverflow();
+            // Count as dropped only for non-persistent sessions; persistent (APPLICATION) copies stay in the
+            // store and are counted once at give-up (ApplicationPersistenceProcessorImpl).
             if (!clientSessionCtx.getSessionInfo().isPersistent()) {
                 tbMessageStatsReportClient.reportDroppedMsgs();
             }
@@ -225,6 +227,8 @@ public class PublishedInFlightCtxImpl implements PublishedInFlightCtx {
         if (expiredCount > 0) {
             stats.decDelayed(expiredCount);
             stats.incDropTtl(expiredCount);
+            // Count as dropped only for non-persistent sessions; persistent (APPLICATION) copies stay in the
+            // store and are counted once at give-up (ApplicationPersistenceProcessorImpl).
             if (!clientSessionCtx.getSessionInfo().isPersistent()) {
                 tbMessageStatsReportClient.reportDroppedMsgs(expiredCount);
             }

--- a/application/src/main/java/org/thingsboard/mqtt/broker/actors/client/state/PublishedInFlightCtxImpl.java
+++ b/application/src/main/java/org/thingsboard/mqtt/broker/actors/client/state/PublishedInFlightCtxImpl.java
@@ -118,9 +118,7 @@ public class PublishedInFlightCtxImpl implements PublishedInFlightCtx {
                     clientId, clientReceiveMax, delayedMsgQueueMaxSize);
             ReferenceCountUtil.safeRelease(toRelease);
             stats.incDropOverflow();
-            // Count as dropped only for non-persistent sessions; persistent (APPLICATION) copies stay in the
-            // store and are counted once at give-up (ApplicationPersistenceProcessorImpl).
-            if (!clientSessionCtx.getSessionInfo().isPersistent()) {
+            if (isCountableDrop(toRelease)) {
                 tbMessageStatsReportClient.reportDroppedMsgs();
             }
         }
@@ -227,10 +225,9 @@ public class PublishedInFlightCtxImpl implements PublishedInFlightCtx {
         if (expiredCount > 0) {
             stats.decDelayed(expiredCount);
             stats.incDropTtl(expiredCount);
-            // Count as dropped only for non-persistent sessions; persistent (APPLICATION) copies stay in the
-            // store and are counted once at give-up (ApplicationPersistenceProcessorImpl).
-            if (!clientSessionCtx.getSessionInfo().isPersistent()) {
-                tbMessageStatsReportClient.reportDroppedMsgs(expiredCount);
+            int countableDrops = (int) toRelease.stream().filter(this::isCountableDrop).count();
+            if (countableDrops > 0) {
+                tbMessageStatsReportClient.reportDroppedMsgs(countableDrops);
             }
         }
 
@@ -273,6 +270,14 @@ public class PublishedInFlightCtxImpl implements PublishedInFlightCtx {
 
     private boolean atMostOnce(MqttPublishMessage mqttPubMsg) {
         return MqttQoS.AT_MOST_ONCE == mqttPubMsg.fixedHeader().qosLevel();
+    }
+
+    // A flow-control drop counts toward droppedMsgs only for a non-persistent session and a non-retained
+    // message: persistent copies are recoverable from the store (APPLICATION via Kafka, counted once at
+    // give-up in ApplicationPersistenceProcessorImpl; DEVICE via Redis redelivery), and retained messages are
+    // recoverable from the retained-message store (consistent with DefaultMqttPublishMsgDeliveryService).
+    private boolean isCountableDrop(MqttPublishMessage msg) {
+        return !clientSessionCtx.getSessionInfo().isPersistent() && !msg.fixedHeader().isRetain();
     }
 
 }

--- a/application/src/main/java/org/thingsboard/mqtt/broker/actors/client/state/PublishedInFlightCtxImpl.java
+++ b/application/src/main/java/org/thingsboard/mqtt/broker/actors/client/state/PublishedInFlightCtxImpl.java
@@ -20,6 +20,7 @@ import io.netty.handler.codec.mqtt.MqttQoS;
 import io.netty.util.ReferenceCountUtil;
 import lombok.extern.slf4j.Slf4j;
 import org.thingsboard.mqtt.broker.common.data.mqtt.MqttPubMsgWithCreatedTime;
+import org.thingsboard.mqtt.broker.service.historical.stats.TbMessageStatsReportClient;
 import org.thingsboard.mqtt.broker.service.mqtt.delivery.MqttPublishMsgDeliveryService;
 import org.thingsboard.mqtt.broker.service.mqtt.flow.control.FlowControlService;
 import org.thingsboard.mqtt.broker.service.stats.FlowControlStats;
@@ -49,6 +50,7 @@ public class PublishedInFlightCtxImpl implements PublishedInFlightCtx {
     private final ClientSessionCtx clientSessionCtx;
     private final MqttPublishMsgDeliveryService deliveryService;
     private final FlowControlStats stats;
+    private final TbMessageStatsReportClient tbMessageStatsReportClient;
     private final String clientId;
     private final int clientReceiveMax;
     private final int delayedMsgQueueMaxSize;
@@ -57,12 +59,14 @@ public class PublishedInFlightCtxImpl implements PublishedInFlightCtx {
                                     ClientSessionCtx clientSessionCtx,
                                     MqttPublishMsgDeliveryService deliveryService,
                                     FlowControlStats stats,
+                                    TbMessageStatsReportClient tbMessageStatsReportClient,
                                     int clientReceiveMax,
                                     int delayedMsgQueueMaxSize) {
         this.flowControlService = flowControlService;
         this.clientSessionCtx = clientSessionCtx;
         this.deliveryService = deliveryService;
         this.stats = stats;
+        this.tbMessageStatsReportClient = tbMessageStatsReportClient;
         this.clientId = clientSessionCtx.getClientId();
         this.clientReceiveMax = clientReceiveMax;
         this.delayedMsgQueueMaxSize = delayedMsgQueueMaxSize;
@@ -114,6 +118,9 @@ public class PublishedInFlightCtxImpl implements PublishedInFlightCtx {
                     clientId, clientReceiveMax, delayedMsgQueueMaxSize);
             ReferenceCountUtil.safeRelease(toRelease);
             stats.incDropOverflow();
+            if (!clientSessionCtx.getSessionInfo().isPersistent()) {
+                tbMessageStatsReportClient.reportDroppedMsgs();
+            }
         }
         return reserve;
     }
@@ -218,6 +225,9 @@ public class PublishedInFlightCtxImpl implements PublishedInFlightCtx {
         if (expiredCount > 0) {
             stats.decDelayed(expiredCount);
             stats.incDropTtl(expiredCount);
+            if (!clientSessionCtx.getSessionInfo().isPersistent()) {
+                tbMessageStatsReportClient.reportDroppedMsgs(expiredCount);
+            }
         }
 
         if (queueEmpty) {

--- a/application/src/main/java/org/thingsboard/mqtt/broker/actors/client/state/PublishedInFlightCtxImpl.java
+++ b/application/src/main/java/org/thingsboard/mqtt/broker/actors/client/state/PublishedInFlightCtxImpl.java
@@ -218,14 +218,13 @@ public class PublishedInFlightCtxImpl implements PublishedInFlightCtx {
             lock.unlock();
         }
 
-        // Session persistence is fixed for the session, so evaluate it once here rather than per expired message:
-        // for a persistent session nothing expiring here is a countable drop (the copy is recoverable from the
-        // store), so the per-message retain check is skipped entirely. Count in the same pass that releases the
-        // buffers instead of a second stream over the list. See isCountableDrop for the full rule and rationale.
-        boolean countableSession = !toRelease.isEmpty() && !clientSessionCtx.getSessionInfo().isPersistent();
+        // Persistence is a per-session invariant: check it once, not per message. A persistent-session copy is
+        // recoverable from the store so it never counts here; otherwise a non-retained message counts (see
+        // isCountableDrop for the full rule). Tally in the same pass that releases the buffers.
+        boolean nonPersistentSession = !clientSessionCtx.getSessionInfo().isPersistent();
         int countableDrops = 0;
         for (MqttPublishMessage m : toRelease) {
-            if (countableSession && !m.fixedHeader().isRetain()) {
+            if (nonPersistentSession && !m.fixedHeader().isRetain()) {
                 countableDrops++;
             }
             ReferenceCountUtil.safeRelease(m);

--- a/application/src/main/java/org/thingsboard/mqtt/broker/actors/client/state/PublishedInFlightCtxImpl.java
+++ b/application/src/main/java/org/thingsboard/mqtt/broker/actors/client/state/PublishedInFlightCtxImpl.java
@@ -218,13 +218,12 @@ public class PublishedInFlightCtxImpl implements PublishedInFlightCtx {
             lock.unlock();
         }
 
-        // Persistence is a per-session invariant: check it once, not per message. A persistent-session copy is
-        // recoverable from the store so it never counts here; otherwise a non-retained message counts (see
-        // isCountableDrop for the full rule). Tally in the same pass that releases the buffers.
+        // Session persistence is a per-session invariant, so resolve it once and pass it to isCountableDrop for each
+        // message rather than re-reading the field per message. Tally in the same pass that releases the buffers.
         boolean nonPersistentSession = !clientSessionCtx.getSessionInfo().isPersistent();
         int countableDrops = 0;
         for (MqttPublishMessage m : toRelease) {
-            if (nonPersistentSession && !m.fixedHeader().isRetain()) {
+            if (isCountableDrop(nonPersistentSession, m)) {
                 countableDrops++;
             }
             ReferenceCountUtil.safeRelease(m);
@@ -279,16 +278,24 @@ public class PublishedInFlightCtxImpl implements PublishedInFlightCtx {
         return MqttQoS.AT_MOST_ONCE == mqttPubMsg.fixedHeader().qosLevel();
     }
 
-    // A flow-control drop counts toward droppedMsgs only for a non-persistent session and a non-retained
-    // message: persistent copies are recoverable from the store (APPLICATION via Kafka, counted once at
-    // give-up in ApplicationPersistenceProcessorImpl; DEVICE via Redis redelivery), and retained messages are
-    // recoverable from the retained-message store.
-    //
-    // NOTE: this predicate intentionally has NO QoS0 clause, unlike DefaultMqttPublishMsgDeliveryService#isCountableDrop.
-    // QoS0 messages short-circuit in atMostOnce()/addInFlightMsg() and never enter the delay queue, so they cannot be
-    // dropped here — the two predicates are deliberately different. Do not "align" them by adding a QoS0 clause here.
     private boolean isCountableDrop(MqttPublishMessage msg) {
-        return !clientSessionCtx.getSessionInfo().isPersistent() && !msg.fixedHeader().isRetain();
+        return isCountableDrop(!clientSessionCtx.getSessionInfo().isPersistent(), msg);
+    }
+
+    // Single source of truth for the countable-drop rule, shared by the overflow site (addInFlightMsg, via the
+    // single-arg overload) and the expireTtl batch (which resolves session persistence once and passes it in so the
+    // per-session field read is not repeated per message).
+    //
+    // A flow-control drop counts toward droppedMsgs only for a non-persistent session and a non-retained message:
+    // persistent copies are recoverable from the store (APPLICATION via Kafka, counted once at give-up in
+    // ApplicationPersistenceProcessorImpl; DEVICE via Redis redelivery), and retained messages are recoverable from
+    // the retained-message store.
+    //
+    // NOTE: intentionally NO QoS0 clause, unlike DefaultMqttPublishMsgDeliveryService#isCountableDrop. QoS0 messages
+    // short-circuit in atMostOnce()/addInFlightMsg() and never enter the delay queue, so they cannot be dropped here —
+    // the two predicates are deliberately different. Do not "align" them by adding a QoS0 clause here.
+    private boolean isCountableDrop(boolean nonPersistentSession, MqttPublishMessage msg) {
+        return nonPersistentSession && !msg.fixedHeader().isRetain();
     }
 
 }

--- a/application/src/main/java/org/thingsboard/mqtt/broker/actors/client/state/PublishedInFlightCtxImpl.java
+++ b/application/src/main/java/org/thingsboard/mqtt/broker/actors/client/state/PublishedInFlightCtxImpl.java
@@ -220,7 +220,7 @@ public class PublishedInFlightCtxImpl implements PublishedInFlightCtx {
 
         // Session persistence is a per-session invariant, so resolve it once and pass it to isCountableDrop for each
         // message rather than re-reading the field per message. Tally in the same pass that releases the buffers.
-        boolean nonPersistentSession = !clientSessionCtx.getSessionInfo().isPersistent();
+        boolean nonPersistentSession = isNonPersistentSession();
         int countableDrops = 0;
         for (MqttPublishMessage m : toRelease) {
             if (isCountableDrop(nonPersistentSession, m)) {
@@ -278,8 +278,12 @@ public class PublishedInFlightCtxImpl implements PublishedInFlightCtx {
         return MqttQoS.AT_MOST_ONCE == mqttPubMsg.fixedHeader().qosLevel();
     }
 
+    private boolean isNonPersistentSession() {
+        return !clientSessionCtx.getSessionInfo().isPersistent();
+    }
+
     private boolean isCountableDrop(MqttPublishMessage msg) {
-        return isCountableDrop(!clientSessionCtx.getSessionInfo().isPersistent(), msg);
+        return isCountableDrop(isNonPersistentSession(), msg);
     }
 
     // Single source of truth for the countable-drop rule, shared by the overflow site (addInFlightMsg, via the

--- a/application/src/main/java/org/thingsboard/mqtt/broker/service/mqtt/delivery/DefaultMqttPublishMsgDeliveryService.java
+++ b/application/src/main/java/org/thingsboard/mqtt/broker/service/mqtt/delivery/DefaultMqttPublishMsgDeliveryService.java
@@ -59,10 +59,10 @@ public class DefaultMqttPublishMsgDeliveryService implements MqttPublishMsgDeliv
         try {
             long startTime = System.nanoTime();
             ChannelFuture future = ctx.getChannel().writeAndFlush(msg);
-            recordDeliveryOnSuccess(ctx, msg, future, startTime);
+            recordDeliveryOutcome(ctx, msg, future, startTime);
         } catch (Exception e) {
             log.warn("[{}][{}] Failed to send PUBLISH msg to MQTT client", ctx.getClientId(), ctx.getSessionId(), e);
-            if (!msg.fixedHeader().isRetain() && !ctx.getSessionInfo().isPersistent()) {
+            if (isCountableDrop(ctx, msg)) {
                 tbMessageStatsReportClient.reportDroppedMsgs();
             }
         }
@@ -74,34 +74,43 @@ public class DefaultMqttPublishMsgDeliveryService implements MqttPublishMsgDeliv
             if (added) {
                 long startTime = System.nanoTime();
                 ChannelFuture future = processor.get();
-                recordDeliveryOnSuccess(ctx, msg, future, startTime);
+                recordDeliveryOutcome(ctx, msg, future, startTime);
             }
         } catch (Exception e) {
             log.warn("[{}][{}] Failed to send PUBLISH msg to MQTT client", ctx.getClientId(), ctx.getSessionId(), e);
-            if (!msg.fixedHeader().isRetain() && !ctx.getSessionInfo().isPersistent()) {
+            if (isCountableDrop(ctx, msg)) {
                 tbMessageStatsReportClient.reportDroppedMsgs();
             }
         }
     }
 
     /**
-     * Records the delivery latency when the write {@link ChannelFuture} completes successfully, i.e. once the
-     * PUBLISH bytes have been written to the socket — not the synchronous cost of handing the write off to the
-     * Netty event loop, which the surrounding {@code writeAndFlush}/{@code write} calls return before completing.
+     * Handles the outcome of a write once its {@link ChannelFuture} completes.
+     * <p>
+     * On success it records the delivery latency, i.e. the time until the PUBLISH bytes have been written to the
+     * socket — not the synchronous cost of handing the write off to the Netty event loop, which the surrounding
+     * {@code writeAndFlush}/{@code write} calls return before completing. On failure it reports a dropped message
+     * when the drop is countable (see {@link #isCountableDrop}): non-retained and non-persistent, since persistent
+     * copies remain recoverable from the store and are counted later at give-up.
+     * <p>
      * The listener is attached only when stats are enabled, so that a per-message listener allocation and an
      * event-loop callback are not paid on the hot delivery path when metrics are turned off.
      */
-    private void recordDeliveryOnSuccess(ClientSessionCtx ctx, MqttPublishMessage msg, ChannelFuture future, long startTime) {
+    private void recordDeliveryOutcome(ClientSessionCtx ctx, MqttPublishMessage msg, ChannelFuture future, long startTime) {
         if (!statsEnabled) {
             return;
         }
         future.addListener(f -> {
             if (f.isSuccess()) {
                 deliveryTimerStats.logDelivery(startTime, TimeUnit.NANOSECONDS);
-            } else if (!msg.fixedHeader().isRetain() && !ctx.getSessionInfo().isPersistent()) {
+            } else if (isCountableDrop(ctx, msg)) {
                 tbMessageStatsReportClient.reportDroppedMsgs();
             }
         });
+    }
+
+    private boolean isCountableDrop(ClientSessionCtx ctx, MqttPublishMessage msg) {
+        return !msg.fixedHeader().isRetain() && !ctx.getSessionInfo().isPersistent();
     }
 
 }

--- a/application/src/main/java/org/thingsboard/mqtt/broker/service/mqtt/delivery/DefaultMqttPublishMsgDeliveryService.java
+++ b/application/src/main/java/org/thingsboard/mqtt/broker/service/mqtt/delivery/DefaultMqttPublishMsgDeliveryService.java
@@ -59,10 +59,10 @@ public class DefaultMqttPublishMsgDeliveryService implements MqttPublishMsgDeliv
         try {
             long startTime = System.nanoTime();
             ChannelFuture future = ctx.getChannel().writeAndFlush(msg);
-            recordDeliveryOnSuccess(future, startTime);
+            recordDeliveryOnSuccess(ctx, msg, future, startTime);
         } catch (Exception e) {
             log.warn("[{}][{}] Failed to send PUBLISH msg to MQTT client", ctx.getClientId(), ctx.getSessionId(), e);
-            if (!msg.fixedHeader().isRetain()) {
+            if (!msg.fixedHeader().isRetain() && !ctx.getSessionInfo().isPersistent()) {
                 tbMessageStatsReportClient.reportDroppedMsgs();
             }
         }
@@ -74,11 +74,11 @@ public class DefaultMqttPublishMsgDeliveryService implements MqttPublishMsgDeliv
             if (added) {
                 long startTime = System.nanoTime();
                 ChannelFuture future = processor.get();
-                recordDeliveryOnSuccess(future, startTime);
+                recordDeliveryOnSuccess(ctx, msg, future, startTime);
             }
         } catch (Exception e) {
             log.warn("[{}][{}] Failed to send PUBLISH msg to MQTT client", ctx.getClientId(), ctx.getSessionId(), e);
-            if (!msg.fixedHeader().isRetain()) {
+            if (!msg.fixedHeader().isRetain() && !ctx.getSessionInfo().isPersistent()) {
                 tbMessageStatsReportClient.reportDroppedMsgs();
             }
         }
@@ -91,13 +91,15 @@ public class DefaultMqttPublishMsgDeliveryService implements MqttPublishMsgDeliv
      * The listener is attached only when stats are enabled, so that a per-message listener allocation and an
      * event-loop callback are not paid on the hot delivery path when metrics are turned off.
      */
-    private void recordDeliveryOnSuccess(ChannelFuture future, long startTime) {
+    private void recordDeliveryOnSuccess(ClientSessionCtx ctx, MqttPublishMessage msg, ChannelFuture future, long startTime) {
         if (!statsEnabled) {
             return;
         }
         future.addListener(f -> {
             if (f.isSuccess()) {
                 deliveryTimerStats.logDelivery(startTime, TimeUnit.NANOSECONDS);
+            } else if (!msg.fixedHeader().isRetain() && !ctx.getSessionInfo().isPersistent()) {
+                tbMessageStatsReportClient.reportDroppedMsgs();
             }
         });
     }

--- a/application/src/main/java/org/thingsboard/mqtt/broker/service/mqtt/delivery/DefaultMqttPublishMsgDeliveryService.java
+++ b/application/src/main/java/org/thingsboard/mqtt/broker/service/mqtt/delivery/DefaultMqttPublishMsgDeliveryService.java
@@ -17,6 +17,7 @@ package org.thingsboard.mqtt.broker.service.mqtt.delivery;
 
 import io.netty.channel.ChannelFuture;
 import io.netty.handler.codec.mqtt.MqttPublishMessage;
+import io.netty.handler.codec.mqtt.MqttQoS;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -95,6 +96,12 @@ public class DefaultMqttPublishMsgDeliveryService implements MqttPublishMsgDeliv
      * <p>
      * The listener is attached only when stats are enabled, so that a per-message listener allocation and an
      * event-loop callback are not paid on the hot delivery path when metrics are turned off.
+     * <p>
+     * On failure it reports a dropped message when the drop is countable (see {@link #isCountableDrop}):
+     * non-retained, and either non-persistent or QoS0, since a persistent-session copy of a QoS&gt;0 message
+     * remains recoverable from the store (APPLICATION: redelivered from Kafka, counted once at give-up in
+     * {@code ApplicationPersistenceProcessorImpl}; DEVICE: redelivered from Redis) whereas QoS0 is never stored
+     * and so is always a permanent loss.
      */
     private void recordDeliveryOutcome(ClientSessionCtx ctx, MqttPublishMessage msg, ChannelFuture future, long startTime) {
         if (!statsEnabled) {
@@ -109,11 +116,13 @@ public class DefaultMqttPublishMsgDeliveryService implements MqttPublishMsgDeliv
         });
     }
 
-    // A drop is countable only when non-retained and non-persistent: persistent (APPLICATION) copies stay in
-    // the store and are counted once at give-up (ApplicationPersistenceProcessorImpl), so counting them here
-    // too would double count.
+    // A drop is countable only when non-retained, and either non-persistent or QoS0. QoS0 is never stored, so
+    // it is a permanent loss even for a persistent session; QoS>0 to a persistent session is recoverable from
+    // the store (APPLICATION: from Kafka, counted once at give-up in ApplicationPersistenceProcessorImpl;
+    // DEVICE: redelivered from Redis) so must not be counted here too, or it would be double counted.
     private boolean isCountableDrop(ClientSessionCtx ctx, MqttPublishMessage msg) {
-        return !msg.fixedHeader().isRetain() && !ctx.getSessionInfo().isPersistent();
+        return !msg.fixedHeader().isRetain()
+                && (!ctx.getSessionInfo().isPersistent() || msg.fixedHeader().qosLevel() == MqttQoS.AT_MOST_ONCE);
     }
 
 }

--- a/application/src/main/java/org/thingsboard/mqtt/broker/service/mqtt/delivery/DefaultMqttPublishMsgDeliveryService.java
+++ b/application/src/main/java/org/thingsboard/mqtt/broker/service/mqtt/delivery/DefaultMqttPublishMsgDeliveryService.java
@@ -90,18 +90,16 @@ public class DefaultMqttPublishMsgDeliveryService implements MqttPublishMsgDeliv
      * <p>
      * On success it records the delivery latency, i.e. the time until the PUBLISH bytes have been written to the
      * socket — not the synchronous cost of handing the write off to the Netty event loop, which the surrounding
-     * {@code writeAndFlush}/{@code write} calls return before completing. On failure it reports a dropped message
-     * when the drop is countable (see {@link #isCountableDrop}): non-retained and non-persistent, since persistent
-     * copies remain recoverable from the store and are counted later at give-up.
-     * <p>
-     * The listener is attached only when stats are enabled, so that a per-message listener allocation and an
-     * event-loop callback are not paid on the hot delivery path when metrics are turned off.
+     * {@code writeAndFlush}/{@code write} calls return before completing.
      * <p>
      * On failure it reports a dropped message when the drop is countable (see {@link #isCountableDrop}):
      * non-retained, and either non-persistent or QoS0, since a persistent-session copy of a QoS&gt;0 message
      * remains recoverable from the store (APPLICATION: redelivered from Kafka, counted once at give-up in
      * {@code ApplicationPersistenceProcessorImpl}; DEVICE: redelivered from Redis) whereas QoS0 is never stored
      * and so is always a permanent loss.
+     * <p>
+     * The listener is attached only when stats are enabled, so that a per-message listener allocation and an
+     * event-loop callback are not paid on the hot delivery path when metrics are turned off.
      */
     private void recordDeliveryOutcome(ClientSessionCtx ctx, MqttPublishMessage msg, ChannelFuture future, long startTime) {
         if (!statsEnabled) {

--- a/application/src/main/java/org/thingsboard/mqtt/broker/service/mqtt/delivery/DefaultMqttPublishMsgDeliveryService.java
+++ b/application/src/main/java/org/thingsboard/mqtt/broker/service/mqtt/delivery/DefaultMqttPublishMsgDeliveryService.java
@@ -109,6 +109,9 @@ public class DefaultMqttPublishMsgDeliveryService implements MqttPublishMsgDeliv
         });
     }
 
+    // A drop is countable only when non-retained and non-persistent: persistent (APPLICATION) copies stay in
+    // the store and are counted once at give-up (ApplicationPersistenceProcessorImpl), so counting them here
+    // too would double count.
     private boolean isCountableDrop(ClientSessionCtx ctx, MqttPublishMessage msg) {
         return !msg.fixedHeader().isRetain() && !ctx.getSessionInfo().isPersistent();
     }

--- a/application/src/main/java/org/thingsboard/mqtt/broker/service/mqtt/persistence/application/ApplicationPersistenceProcessorImpl.java
+++ b/application/src/main/java/org/thingsboard/mqtt/broker/service/mqtt/persistence/application/ApplicationPersistenceProcessorImpl.java
@@ -37,6 +37,7 @@ import org.thingsboard.mqtt.broker.queue.cluster.ServiceInfoProvider;
 import org.thingsboard.mqtt.broker.queue.common.TbProtoQueueMsg;
 import org.thingsboard.mqtt.broker.queue.provider.ApplicationPersistenceMsgQueueFactory;
 import org.thingsboard.mqtt.broker.service.analysis.ClientLogger;
+import org.thingsboard.mqtt.broker.service.historical.stats.TbMessageStatsReportClient;
 import org.thingsboard.mqtt.broker.service.mqtt.MqttMsgDeliveryService;
 import org.thingsboard.mqtt.broker.service.mqtt.PublishMsg;
 import org.thingsboard.mqtt.broker.service.mqtt.persistence.application.data.ApplicationMainProcessingState;
@@ -110,6 +111,7 @@ public class ApplicationPersistenceProcessorImpl implements ApplicationPersisten
     private final ApplicationTopicService applicationTopicService;
     private final ApplicationClientHelperService appClientHelperService;
     private final AppMsgDeliveryStrategy appMsgDeliveryStrategy;
+    private final TbMessageStatsReportClient tbMessageStatsReportClient;
     private final boolean isDebugEnabled = log.isDebugEnabled();
 
     @Value("${queue.application-persisted-msg.poll-interval}")
@@ -687,6 +689,9 @@ public class ApplicationPersistenceProcessorImpl implements ApplicationPersisten
         int skipped = skippedPublish + skippedPubRel;
         if (skipped == 0) {
             return;
+        }
+        if (skippedPublish > 0) {
+            tbMessageStatsReportClient.reportDroppedMsgs(skippedPublish);
         }
         log.warn("[{}] Giving up on pack: skipping {} un-acked message(s) [PUBLISH: {}, PUBREL: {}]{}. " +
                         "Set APPLICATION ack-strategy retries to 0 for unlimited retries.",

--- a/application/src/main/java/org/thingsboard/mqtt/broker/service/mqtt/persistence/device/queue/DeviceMsgQueueConsumerImpl.java
+++ b/application/src/main/java/org/thingsboard/mqtt/broker/service/mqtt/persistence/device/queue/DeviceMsgQueueConsumerImpl.java
@@ -29,6 +29,7 @@ import org.thingsboard.mqtt.broker.queue.cluster.ServiceInfoProvider;
 import org.thingsboard.mqtt.broker.queue.common.TbProtoQueueMsg;
 import org.thingsboard.mqtt.broker.queue.provider.DevicePersistenceMsgQueueFactory;
 import org.thingsboard.mqtt.broker.service.analysis.ClientLogger;
+import org.thingsboard.mqtt.broker.service.historical.stats.TbMessageStatsReportClient;
 import org.thingsboard.mqtt.broker.service.mqtt.persistence.device.processing.ClientIdMessagesPack;
 import org.thingsboard.mqtt.broker.service.mqtt.persistence.device.processing.DeviceAckStrategy;
 import org.thingsboard.mqtt.broker.service.mqtt.persistence.device.processing.DeviceMsgAcknowledgeStrategyFactory;
@@ -63,6 +64,7 @@ public class DeviceMsgQueueConsumerImpl implements DeviceMsgQueueConsumer {
     private final StatsManager statsManager;
     private final ServiceInfoProvider serviceInfoProvider;
     private final ClientLogger clientLogger;
+    private final TbMessageStatsReportClient tbMessageStatsReportClient;
 
     @Value("${queue.device-persisted-msg.consumers-count}")
     private int consumersCount;
@@ -148,6 +150,7 @@ public class DeviceMsgQueueConsumerImpl implements DeviceMsgQueueConsumer {
                         stats.log(totalMessagesCount, result, decision.commit());
 
                         if (decision.commit()) {
+                            reportDroppedMsgsOnGiveUp(result);
                             consumer.commitSync();
                             break;
                         } else {
@@ -181,6 +184,15 @@ public class DeviceMsgQueueConsumerImpl implements DeviceMsgQueueConsumer {
         consumers.forEach(TbQueueConsumer::unsubscribeAndClose);
         if (consumersExecutor != null) {
             ThingsBoardExecutors.shutdownAndAwaitTermination(consumersExecutor, "Device msg consumer");
+        }
+    }
+
+    void reportDroppedMsgsOnGiveUp(DevicePackProcessingResult result) {
+        int dropped = result.getFailedMap().values().stream()
+                .mapToInt(pack -> pack.messages().size())
+                .sum();
+        if (dropped > 0) {
+            tbMessageStatsReportClient.reportDroppedMsgs(dropped);
         }
     }
 

--- a/application/src/main/java/org/thingsboard/mqtt/broker/service/processing/PublishMsgConsumerServiceImpl.java
+++ b/application/src/main/java/org/thingsboard/mqtt/broker/service/processing/PublishMsgConsumerServiceImpl.java
@@ -132,6 +132,7 @@ public class PublishMsgConsumerServiceImpl implements PublishMsgConsumerService 
                         stats.log(totalMsgCount, result, decision.isCommit());
 
                         if (decision.isCommit()) {
+                            reportDroppedMsgsOnGiveUp(result);
                             consumer.commitSync();
                             break;
                         } else {
@@ -154,6 +155,13 @@ public class PublishMsgConsumerServiceImpl implements PublishMsgConsumerService 
             }
             log.info("[{}] Publish Msg Consumer stopped.", consumerId);
         });
+    }
+
+    void reportDroppedMsgsOnGiveUp(PackProcessingResult result) {
+        int dropped = result.getPendingMap().size() + result.getFailedMap().size();
+        if (dropped > 0) {
+            tbMessageStatsReportClient.reportDroppedMsgs(dropped);
+        }
     }
 
     private List<TbProtoQueueMsg<PublishMsgProto>> applyRateLimits(TbQueueConsumer<TbProtoQueueMsg<PublishMsgProto>> consumer,

--- a/application/src/main/java/org/thingsboard/mqtt/broker/session/ClientSessionCtx.java
+++ b/application/src/main/java/org/thingsboard/mqtt/broker/session/ClientSessionCtx.java
@@ -35,6 +35,7 @@ import org.thingsboard.mqtt.broker.server.MqttHandlerCtx;
 import org.thingsboard.mqtt.broker.service.auth.enhanced.ScramServerWithCallbackHandler;
 import org.thingsboard.mqtt.broker.service.mqtt.delivery.MqttPublishMsgDeliveryService;
 import org.thingsboard.mqtt.broker.service.mqtt.flow.control.FlowControlService;
+import org.thingsboard.mqtt.broker.service.historical.stats.TbMessageStatsReportClient;
 import org.thingsboard.mqtt.broker.service.security.authorization.AuthRulePatterns;
 import org.thingsboard.mqtt.broker.service.stats.FlowControlStats;
 
@@ -170,10 +171,11 @@ public class ClientSessionCtx implements SessionContext {
     public void initPublishedInFlightCtx(FlowControlService flowControlService,
                                          MqttPublishMsgDeliveryService deliveryService,
                                          FlowControlStats stats,
+                                         TbMessageStatsReportClient tbMessageStatsReportClient,
                                          int receiveMaxValue,
                                          int delayedQueueMaxSize) {
         publishedInFlightCtx = new PublishedInFlightCtxImpl(
-                flowControlService, this, deliveryService, stats, receiveMaxValue, delayedQueueMaxSize);
+                flowControlService, this, deliveryService, stats, tbMessageStatsReportClient, receiveMaxValue, delayedQueueMaxSize);
     }
 
     public boolean addInFlightMsg(MqttPublishMessage mqttPubMsg) {

--- a/application/src/test/java/org/thingsboard/mqtt/broker/actors/client/service/connect/ConnectServiceImplTest.java
+++ b/application/src/test/java/org/thingsboard/mqtt/broker/actors/client/service/connect/ConnectServiceImplTest.java
@@ -37,6 +37,7 @@ import org.thingsboard.mqtt.broker.common.data.ClientType;
 import org.thingsboard.mqtt.broker.common.data.SessionInfo;
 import org.thingsboard.mqtt.broker.exception.DataValidationException;
 import org.thingsboard.mqtt.broker.queue.cluster.ServiceInfoProvider;
+import org.thingsboard.mqtt.broker.service.historical.stats.TbMessageStatsReportClient;
 import org.thingsboard.mqtt.broker.service.integration.IntegrationLifecycleEventPublisher;
 import org.thingsboard.mqtt.broker.service.mqtt.MqttMessageGenerator;
 import org.thingsboard.mqtt.broker.service.mqtt.PublishMsg;
@@ -109,6 +110,8 @@ public class ConnectServiceImplTest {
     MqttPublishMsgDeliveryService mqttPublishMsgDeliveryService;
     @MockitoBean
     StatsManager statsManager;
+    @MockitoBean
+    TbMessageStatsReportClient tbMessageStatsReportClient;
     @MockitoBean
     IntegrationLifecycleEventPublisher integrationLifecycleEventPublisher;
 

--- a/application/src/test/java/org/thingsboard/mqtt/broker/actors/client/service/handlers/MqttPublishHandlerTest.java
+++ b/application/src/test/java/org/thingsboard/mqtt/broker/actors/client/service/handlers/MqttPublishHandlerTest.java
@@ -187,6 +187,7 @@ public class MqttPublishHandlerTest {
         MqttDisconnectMsg disconnectMsg = newMsgCaptor.getValue();
         assertThat(disconnectMsg).isNotNull();
         assertThat(disconnectMsg.getReason().getType()).isEqualTo(DisconnectReasonType.ON_RECEIVE_MAXIMUM_EXCEEDED);
+        verify(tbMessageStatsReportClient, times(1)).reportDroppedMsgs();
     }
 
     @Test
@@ -205,6 +206,7 @@ public class MqttPublishHandlerTest {
         MqttDisconnectMsg disconnectMsg = newMsgCaptor.getValue();
         assertThat(disconnectMsg).isNotNull();
         assertThat(disconnectMsg.getReason().getType()).isEqualTo(DisconnectReasonType.ON_RECEIVE_MAXIMUM_EXCEEDED);
+        verify(tbMessageStatsReportClient, times(1)).reportDroppedMsgs();
     }
 
     @Test
@@ -218,6 +220,7 @@ public class MqttPublishHandlerTest {
             mqttPublishHandler.process(ctx, createMqttPubMsg(publishMsg), actorRef);
         }
         verify(clientMqttActorManager, never()).disconnect(eq("clientId"), any());
+        verify(tbMessageStatsReportClient, never()).reportDroppedMsgs();
     }
 
     @Test

--- a/application/src/test/java/org/thingsboard/mqtt/broker/actors/client/state/PublishedInFlightCtxImplTest.java
+++ b/application/src/test/java/org/thingsboard/mqtt/broker/actors/client/state/PublishedInFlightCtxImplTest.java
@@ -27,6 +27,8 @@ import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.thingsboard.mqtt.broker.common.data.BrokerConstants;
+import org.thingsboard.mqtt.broker.common.data.SessionInfo;
+import org.thingsboard.mqtt.broker.service.historical.stats.TbMessageStatsReportClient;
 import org.thingsboard.mqtt.broker.service.mqtt.delivery.MqttPublishMsgDeliveryService;
 import org.thingsboard.mqtt.broker.service.mqtt.flow.control.FlowControlService;
 import org.thingsboard.mqtt.broker.service.stats.FlowControlStats;
@@ -40,6 +42,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.same;
 import static org.mockito.Mockito.doAnswer;
@@ -59,6 +62,7 @@ public class PublishedInFlightCtxImplTest {
     private ClientSessionCtx clientSessionCtx;
     private MqttPublishMsgDeliveryService deliveryService;
     private FlowControlStats stats;
+    private TbMessageStatsReportClient tbMessageStatsReportClient;
 
     private PublishedInFlightCtxImpl ctx;
 
@@ -68,11 +72,12 @@ public class PublishedInFlightCtxImplTest {
         clientSessionCtx = mock(ClientSessionCtx.class);
         deliveryService = mock(MqttPublishMsgDeliveryService.class);
         stats = mock(FlowControlStats.class);
+        tbMessageStatsReportClient = mock(TbMessageStatsReportClient.class);
 
         when(clientSessionCtx.getClientId()).thenReturn(CLIENT_ID);
         when(clientSessionCtx.isWritable()).thenReturn(true);
 
-        ctx = new PublishedInFlightCtxImpl(flowControlService, clientSessionCtx, deliveryService, stats, RECEIVE_MAX, 5);
+        ctx = new PublishedInFlightCtxImpl(flowControlService, clientSessionCtx, deliveryService, stats, tbMessageStatsReportClient, RECEIVE_MAX, 5);
     }
 
     @Test
@@ -110,6 +115,7 @@ public class PublishedInFlightCtxImplTest {
 
     @Test
     public void addInFlightMsg_delayedQueueFull_dropsAndReleasesByteBuf() {
+        stubPersistence(false);
         // Fill in-flight window
         for (int i = 1; i <= 5; i++) {
             ctx.addInFlightMsg(qos1(i));
@@ -125,6 +131,23 @@ public class PublishedInFlightCtxImplTest {
         assertFalse(result);
         assertEquals(0, overflow.payload().refCnt());
         verify(stats, times(1)).incDropOverflow();
+        verify(tbMessageStatsReportClient, times(1)).reportDroppedMsgs();
+    }
+
+    @Test
+    public void addInFlightMsg_delayedQueueFull_persistentSession_notReportedAsDropped() {
+        stubPersistence(true);
+        for (int i = 1; i <= 5; i++) {
+            ctx.addInFlightMsg(qos1(i));
+        }
+        for (int i = 6; i <= 10; i++) {
+            ctx.addInFlightMsg(qos1(i));
+        }
+
+        ctx.addInFlightMsg(qos1(11));
+
+        verify(stats, times(1)).incDropOverflow();
+        verify(tbMessageStatsReportClient, never()).reportDroppedMsgs();
     }
 
     @Test
@@ -145,7 +168,7 @@ public class PublishedInFlightCtxImplTest {
     @Test
     public void addInFlightMsg_mqtt3xDefaultReceiveMax_alwaysReservesInFlight() {
         ctx = new PublishedInFlightCtxImpl(flowControlService, clientSessionCtx, deliveryService, stats,
-                BrokerConstants.DEFAULT_RECEIVE_MAXIMUM, 5);
+                tbMessageStatsReportClient, BrokerConstants.DEFAULT_RECEIVE_MAXIMUM, 5);
 
         for (int i = 1; i <= 1000; i++) {
             assertTrue(ctx.addInFlightMsg(qos1(i)));
@@ -274,6 +297,7 @@ public class PublishedInFlightCtxImplTest {
 
     @Test
     public void expireTtl_dropsExpiredAndReleasesByteBufs() throws InterruptedException {
+        stubPersistence(false);
         // Fill in-flight window so the next message is buffered (not sent in-flight).
         for (int i = 1; i <= 5; i++) {
             ctx.addInFlightMsg(qos1(i));
@@ -285,7 +309,23 @@ public class PublishedInFlightCtxImplTest {
         ctx.expireTtl(1L);
 
         verify(stats, times(1)).incDropTtl(1);
+        verify(tbMessageStatsReportClient, times(1)).reportDroppedMsgs(1);
         assertEquals(0, expired.payload().refCnt());
+    }
+
+    @Test
+    public void expireTtl_persistentSession_notReportedAsDropped() throws InterruptedException {
+        stubPersistence(true);
+        for (int i = 1; i <= 5; i++) {
+            ctx.addInFlightMsg(qos1(i));
+        }
+        ctx.addInFlightMsg(qos1(6));
+
+        Thread.sleep(20);
+        ctx.expireTtl(1L);
+
+        verify(stats, times(1)).incDropTtl(1);
+        verify(tbMessageStatsReportClient, never()).reportDroppedMsgs(anyInt());
     }
 
     @Test
@@ -314,7 +354,7 @@ public class PublishedInFlightCtxImplTest {
     public void concurrentAddAndAck_isSafe() throws InterruptedException {
         // Use large window so adds don't get rejected.
         ctx = new PublishedInFlightCtxImpl(flowControlService, clientSessionCtx, deliveryService, stats,
-                BrokerConstants.DEFAULT_RECEIVE_MAXIMUM, 5);
+                tbMessageStatsReportClient, BrokerConstants.DEFAULT_RECEIVE_MAXIMUM, 5);
 
         int ops = 2000;
         AtomicBoolean failed = new AtomicBoolean(false);
@@ -361,7 +401,7 @@ public class PublishedInFlightCtxImplTest {
     @Test
     public void release_concurrentWithAck_isSafe() throws InterruptedException {
         ctx = new PublishedInFlightCtxImpl(flowControlService, clientSessionCtx, deliveryService, stats,
-                BrokerConstants.DEFAULT_RECEIVE_MAXIMUM, 5);
+                tbMessageStatsReportClient, BrokerConstants.DEFAULT_RECEIVE_MAXIMUM, 5);
 
         int ops = 1000;
         for (int i = 1; i <= ops; i++) {
@@ -402,7 +442,7 @@ public class PublishedInFlightCtxImplTest {
 
     @Test
     public void receiveMaxOne_serialDelivery() {
-        ctx = new PublishedInFlightCtxImpl(flowControlService, clientSessionCtx, deliveryService, stats, 1, 5);
+        ctx = new PublishedInFlightCtxImpl(flowControlService, clientSessionCtx, deliveryService, stats, tbMessageStatsReportClient, 1, 5);
 
         assertTrue(ctx.addInFlightMsg(qos1(1)));
 
@@ -427,6 +467,12 @@ public class PublishedInFlightCtxImplTest {
         // QoS 0 never reaches the release path, EMPTY_BUFFER is fine.
         MqttFixedHeader fixed = new MqttFixedHeader(MqttMessageType.PUBLISH, false, MqttQoS.AT_MOST_ONCE, false, 0);
         return new MqttPublishMessage(fixed, new MqttPublishVariableHeader("t", packetId), Unpooled.EMPTY_BUFFER);
+    }
+
+    private void stubPersistence(boolean persistent) {
+        SessionInfo sessionInfo = mock(SessionInfo.class);
+        when(sessionInfo.isPersistent()).thenReturn(persistent);
+        when(clientSessionCtx.getSessionInfo()).thenReturn(sessionInfo);
     }
 
 }

--- a/application/src/test/java/org/thingsboard/mqtt/broker/actors/client/state/PublishedInFlightCtxImplTest.java
+++ b/application/src/test/java/org/thingsboard/mqtt/broker/actors/client/state/PublishedInFlightCtxImplTest.java
@@ -151,6 +151,24 @@ public class PublishedInFlightCtxImplTest {
     }
 
     @Test
+    public void addInFlightMsg_delayedQueueFull_retainedMsg_notReportedAsDropped() {
+        stubPersistence(false);
+        for (int i = 1; i <= 5; i++) {
+            ctx.addInFlightMsg(qos1(i));          // fill in-flight window (non-retained)
+        }
+        for (int i = 6; i <= 10; i++) {
+            ctx.addInFlightMsg(qos1(i));          // fill delay queue (non-retained)
+        }
+
+        MqttPublishMessage retainedOverflow = qos1Retained(11);
+        boolean result = ctx.addInFlightMsg(retainedOverflow);   // this one is dropped (overflow)
+
+        assertFalse(result);
+        verify(stats, times(1)).incDropOverflow();
+        verify(tbMessageStatsReportClient, never()).reportDroppedMsgs();  // retained ⇒ not counted
+    }
+
+    @Test
     public void addInFlightMsg_duplicatePacketId_reservesForDeliveryButDoesNotDoubleCountInflight() {
         assertTrue(ctx.addInFlightMsg(qos1(1)));
 
@@ -329,6 +347,22 @@ public class PublishedInFlightCtxImplTest {
     }
 
     @Test
+    public void expireTtl_mixedRetainedAndPlain_countsOnlyNonRetained() throws InterruptedException {
+        stubPersistence(false);
+        for (int i = 1; i <= 5; i++) {
+            ctx.addInFlightMsg(qos1(i));          // fill in-flight window so the next two are buffered
+        }
+        ctx.addInFlightMsg(qos1(6));              // non-retained, buffered
+        ctx.addInFlightMsg(qos1Retained(7));      // retained, buffered
+
+        Thread.sleep(20);
+        ctx.expireTtl(1L);                        // both expire
+
+        verify(stats, times(1)).incDropTtl(2);                       // flow-control meter counts both
+        verify(tbMessageStatsReportClient, times(1)).reportDroppedMsgs(1);  // only the 1 non-retained counted
+    }
+
+    @Test
     public void release_clearsBothStructuresAndReleasesBufferedMessages() {
         for (int i = 1; i <= 5; i++) {
             ctx.addInFlightMsg(qos1(i));
@@ -458,6 +492,13 @@ public class PublishedInFlightCtxImplTest {
 
     private MqttPublishMessage qos1(int packetId) {
         MqttFixedHeader fixed = new MqttFixedHeader(MqttMessageType.PUBLISH, false, MqttQoS.AT_LEAST_ONCE, false, 0);
+        return new MqttPublishMessage(fixed,
+                new MqttPublishVariableHeader("t", packetId),
+                Unpooled.buffer(1).writeByte(0x42));
+    }
+
+    private MqttPublishMessage qos1Retained(int packetId) {
+        MqttFixedHeader fixed = new MqttFixedHeader(MqttMessageType.PUBLISH, false, MqttQoS.AT_LEAST_ONCE, true, 0);
         return new MqttPublishMessage(fixed,
                 new MqttPublishVariableHeader("t", packetId),
                 Unpooled.buffer(1).writeByte(0x42));

--- a/application/src/test/java/org/thingsboard/mqtt/broker/service/mqtt/delivery/DefaultMqttPublishMsgDeliveryServiceTest.java
+++ b/application/src/test/java/org/thingsboard/mqtt/broker/service/mqtt/delivery/DefaultMqttPublishMsgDeliveryServiceTest.java
@@ -21,6 +21,7 @@ import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.mqtt.MqttFixedHeader;
 import io.netty.handler.codec.mqtt.MqttPublishMessage;
+import io.netty.handler.codec.mqtt.MqttQoS;
 import io.netty.util.concurrent.GenericFutureListener;
 import org.junit.Before;
 import org.junit.Test;
@@ -150,6 +151,25 @@ public class DefaultMqttPublishMsgDeliveryServiceTest {
 
     @Test
     @SuppressWarnings("unchecked")
+    public void givenAsyncFailureQos0Persistent_whenSendPublish_thenReportsDropped() throws Exception {
+        DefaultMqttPublishMsgDeliveryService service = buildService(true);
+        MqttFixedHeader fixedHeader = mock(MqttFixedHeader.class);
+        when(fixedHeader.isRetain()).thenReturn(false);
+        when(fixedHeader.qosLevel()).thenReturn(MqttQoS.AT_MOST_ONCE);
+        when(msg.fixedHeader()).thenReturn(fixedHeader);
+        stubPersistence(true);
+        when(ctx.addInFlightMsg(msg)).thenReturn(true);
+        when(channel.writeAndFlush(msg)).thenReturn(future);
+        when(future.isSuccess()).thenReturn(false);
+
+        service.sendPublishMsgToClient(ctx, msg);
+        captureListener().operationComplete(future);
+
+        verify(reportClient, times(1)).reportDroppedMsgs();
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
     public void givenAsyncFailureRetained_whenSendPublish_thenNotCounted() throws Exception {
         DefaultMqttPublishMsgDeliveryService service = buildService(true);
         MqttFixedHeader fixedHeader = mock(MqttFixedHeader.class);
@@ -236,5 +256,21 @@ public class DefaultMqttPublishMsgDeliveryServiceTest {
         verify(reportClient, times(1)).reportDroppedMsgs();
         verify(future, never()).addListener(any(GenericFutureListener.class));
         assertEquals(0, deliveryTimer().count());
+    }
+
+    @Test
+    public void givenSyncThrowQos0Persistent_whenSendPublish_thenReportsDropped() {
+        DefaultMqttPublishMsgDeliveryService service = buildService(true);
+        MqttFixedHeader fixedHeader = mock(MqttFixedHeader.class);
+        when(fixedHeader.isRetain()).thenReturn(false);
+        when(fixedHeader.qosLevel()).thenReturn(MqttQoS.AT_MOST_ONCE);
+        when(msg.fixedHeader()).thenReturn(fixedHeader);
+        stubPersistence(true);
+        when(ctx.addInFlightMsg(msg)).thenReturn(true);
+        when(channel.writeAndFlush(msg)).thenThrow(new RuntimeException("boom"));
+
+        service.sendPublishMsgToClient(ctx, msg);
+
+        verify(reportClient, times(1)).reportDroppedMsgs();
     }
 }

--- a/application/src/test/java/org/thingsboard/mqtt/broker/service/mqtt/delivery/DefaultMqttPublishMsgDeliveryServiceTest.java
+++ b/application/src/test/java/org/thingsboard/mqtt/broker/service/mqtt/delivery/DefaultMqttPublishMsgDeliveryServiceTest.java
@@ -166,6 +166,7 @@ public class DefaultMqttPublishMsgDeliveryServiceTest {
         captureListener().operationComplete(future);
 
         verify(reportClient, times(1)).reportDroppedMsgs();
+        assertEquals(0, deliveryTimer().count());
     }
 
     @Test
@@ -272,5 +273,7 @@ public class DefaultMqttPublishMsgDeliveryServiceTest {
         service.sendPublishMsgToClient(ctx, msg);
 
         verify(reportClient, times(1)).reportDroppedMsgs();
+        verify(future, never()).addListener(any(GenericFutureListener.class));
+        assertEquals(0, deliveryTimer().count());
     }
 }

--- a/application/src/test/java/org/thingsboard/mqtt/broker/service/mqtt/delivery/DefaultMqttPublishMsgDeliveryServiceTest.java
+++ b/application/src/test/java/org/thingsboard/mqtt/broker/service/mqtt/delivery/DefaultMqttPublishMsgDeliveryServiceTest.java
@@ -230,6 +230,37 @@ public class DefaultMqttPublishMsgDeliveryServiceTest {
     }
 
     @Test
+    public void givenSyncThrowNonPersistentNonRetained_whenSendAlreadyTracked_thenReportsDroppedAndRecordsNothing() {
+        DefaultMqttPublishMsgDeliveryService service = buildService(true);
+        MqttFixedHeader fixedHeader = mock(MqttFixedHeader.class);
+        when(fixedHeader.isRetain()).thenReturn(false);
+        when(msg.fixedHeader()).thenReturn(fixedHeader);
+        stubPersistence(false);
+        when(channel.writeAndFlush(msg)).thenThrow(new RuntimeException("boom"));
+
+        service.sendAlreadyTrackedPublishMsgToClient(ctx, msg);
+
+        verify(reportClient, times(1)).reportDroppedMsgs();
+        verify(future, never()).addListener(any(GenericFutureListener.class));
+        assertEquals(0, deliveryTimer().count());
+    }
+
+    @Test
+    public void givenSyncThrowPersistentQos1_whenSendAlreadyTracked_thenNotCounted() {
+        DefaultMqttPublishMsgDeliveryService service = buildService(true);
+        MqttFixedHeader fixedHeader = mock(MqttFixedHeader.class);
+        when(fixedHeader.isRetain()).thenReturn(false);
+        when(fixedHeader.qosLevel()).thenReturn(MqttQoS.AT_LEAST_ONCE);
+        when(msg.fixedHeader()).thenReturn(fixedHeader);
+        stubPersistence(true);
+        when(channel.writeAndFlush(msg)).thenThrow(new RuntimeException("boom"));
+
+        service.sendAlreadyTrackedPublishMsgToClient(ctx, msg);
+
+        verify(reportClient, never()).reportDroppedMsgs();
+    }
+
+    @Test
     public void givenInFlightSlotNotReserved_whenSendPublish_thenNothingWrittenOrRecorded() {
         DefaultMqttPublishMsgDeliveryService service = buildService(true);
         when(ctx.addInFlightMsg(msg)).thenReturn(false);

--- a/application/src/test/java/org/thingsboard/mqtt/broker/service/mqtt/delivery/DefaultMqttPublishMsgDeliveryServiceTest.java
+++ b/application/src/test/java/org/thingsboard/mqtt/broker/service/mqtt/delivery/DefaultMqttPublishMsgDeliveryServiceTest.java
@@ -28,6 +28,7 @@ import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
+import org.thingsboard.mqtt.broker.common.data.SessionInfo;
 import org.thingsboard.mqtt.broker.common.stats.DefaultStatsFactory;
 import org.thingsboard.mqtt.broker.common.stats.StatsFactory;
 import org.thingsboard.mqtt.broker.common.stats.StatsType;
@@ -88,6 +89,12 @@ public class DefaultMqttPublishMsgDeliveryServiceTest {
         return captor.getValue();
     }
 
+    private void stubPersistence(boolean persistent) {
+        SessionInfo sessionInfo = mock(SessionInfo.class);
+        when(sessionInfo.isPersistent()).thenReturn(persistent);
+        when(ctx.getSessionInfo()).thenReturn(sessionInfo);
+    }
+
     @Test
     @SuppressWarnings("unchecked")
     public void givenStatsEnabled_whenSendPublish_thenDeliveryRecordedOnFutureCompletionNotSynchronously() throws Exception {
@@ -106,8 +113,12 @@ public class DefaultMqttPublishMsgDeliveryServiceTest {
 
     @Test
     @SuppressWarnings("unchecked")
-    public void givenStatsEnabled_whenWriteFutureFails_thenDeliveryNotRecorded() throws Exception {
+    public void givenAsyncFailureNonPersistentNonRetained_whenSendPublish_thenReportsDroppedAndNoDelivery() throws Exception {
         DefaultMqttPublishMsgDeliveryService service = buildService(true);
+        MqttFixedHeader fixedHeader = mock(MqttFixedHeader.class);
+        when(fixedHeader.isRetain()).thenReturn(false);
+        when(msg.fixedHeader()).thenReturn(fixedHeader);
+        stubPersistence(false);
         when(ctx.addInFlightMsg(msg)).thenReturn(true);
         when(channel.writeAndFlush(msg)).thenReturn(future);
         when(future.isSuccess()).thenReturn(false);
@@ -115,7 +126,43 @@ public class DefaultMqttPublishMsgDeliveryServiceTest {
         service.sendPublishMsgToClient(ctx, msg);
         captureListener().operationComplete(future);
 
+        verify(reportClient, times(1)).reportDroppedMsgs();
         assertEquals(0, deliveryTimer().count());
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void givenAsyncFailurePersistent_whenSendPublish_thenNotCounted() throws Exception {
+        DefaultMqttPublishMsgDeliveryService service = buildService(true);
+        MqttFixedHeader fixedHeader = mock(MqttFixedHeader.class);
+        when(fixedHeader.isRetain()).thenReturn(false);
+        when(msg.fixedHeader()).thenReturn(fixedHeader);
+        stubPersistence(true);
+        when(ctx.addInFlightMsg(msg)).thenReturn(true);
+        when(channel.writeAndFlush(msg)).thenReturn(future);
+        when(future.isSuccess()).thenReturn(false);
+
+        service.sendPublishMsgToClient(ctx, msg);
+        captureListener().operationComplete(future);
+
+        verify(reportClient, never()).reportDroppedMsgs();
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void givenAsyncFailureRetained_whenSendPublish_thenNotCounted() throws Exception {
+        DefaultMqttPublishMsgDeliveryService service = buildService(true);
+        MqttFixedHeader fixedHeader = mock(MqttFixedHeader.class);
+        when(fixedHeader.isRetain()).thenReturn(true);
+        when(msg.fixedHeader()).thenReturn(fixedHeader);
+        when(ctx.addInFlightMsg(msg)).thenReturn(true);
+        when(channel.writeAndFlush(msg)).thenReturn(future);
+        when(future.isSuccess()).thenReturn(false);
+
+        service.sendPublishMsgToClient(ctx, msg);
+        captureListener().operationComplete(future);
+
+        verify(reportClient, never()).reportDroppedMsgs();
     }
 
     @Test
@@ -180,6 +227,7 @@ public class DefaultMqttPublishMsgDeliveryServiceTest {
         MqttFixedHeader fixedHeader = mock(MqttFixedHeader.class);
         when(fixedHeader.isRetain()).thenReturn(false);
         when(msg.fixedHeader()).thenReturn(fixedHeader);
+        stubPersistence(false);
         when(ctx.addInFlightMsg(msg)).thenReturn(true);
         when(channel.writeAndFlush(msg)).thenThrow(new RuntimeException("boom"));
 

--- a/application/src/test/java/org/thingsboard/mqtt/broker/service/mqtt/persistence/application/ApplicationPersistenceProcessorImplTest.java
+++ b/application/src/test/java/org/thingsboard/mqtt/broker/service/mqtt/persistence/application/ApplicationPersistenceProcessorImplTest.java
@@ -29,6 +29,7 @@ import org.thingsboard.mqtt.broker.gen.queue.PublishMsgProto;
 import org.thingsboard.mqtt.broker.queue.TbQueueAdmin;
 import org.thingsboard.mqtt.broker.queue.TbQueueControlledOffsetConsumer;
 import org.thingsboard.mqtt.broker.queue.cluster.ServiceInfoProvider;
+import org.thingsboard.mqtt.broker.queue.common.DefaultTbQueueMsgHeaders;
 import org.thingsboard.mqtt.broker.queue.common.TbProtoQueueMsg;
 import org.thingsboard.mqtt.broker.queue.provider.ApplicationPersistenceMsgQueueFactory;
 import org.thingsboard.mqtt.broker.service.analysis.ClientLogger;
@@ -512,6 +513,42 @@ class ApplicationPersistenceProcessorImplTest {
                 clientState);
 
         verify(consumer, atLeastOnce()).commitSync();
+    }
+
+    @Test
+    void processMainPack_retryAll_whenClientNeverAcksPublish_reportsDroppedOnGiveUpCommit() {
+        ApplicationAckStrategyConfiguration ackConfig = new ApplicationAckStrategyConfiguration();
+        ackConfig.setType(AckStrategyType.RETRY_ALL);
+        ackConfig.setRetries(2);
+        // Delegate to a real factory so the production RetryStrategy (with real give-up counting) is exercised.
+        ApplicationMsgAcknowledgeStrategyFactory realFactory = new ApplicationMsgAcknowledgeStrategyFactory(ackConfig);
+        when(acknowledgeStrategyFactory.newInstance("appClient")).thenAnswer(inv -> realFactory.newInstance("appClient"));
+        ReflectionTestUtils.setField(processor, "packProcessingTimeout", 30L);
+        when(submitStrategyFactory.newInstance("appClient")).thenAnswer(inv -> new BurstSubmitStrategy("appClient"));
+        // Safety net: a buggy unbounded-retry loop would never exit on its own.
+        stopProcessorAfterDeliveries(20);
+
+        TbQueueControlledOffsetConsumer<TbProtoQueueMsg<PublishMsgProto>> consumer = mockConsumer();
+        UUID sessionId = UUID.randomUUID();
+        ClientActorStateInfo clientState = activeClientState("appClient", sessionId);
+        ClientSessionCtx clientSessionCtx = clientSessionCtx("appClient", sessionId);
+
+        // A single never-acked QoS1 PUBLISH keeps the pack pending across every retry until give-up. Delivery is
+        // stubbed out (appMsgDeliveryStrategy is a no-op mock), so it is never acked and remains in publishPendingMap.
+        // The persisted-msg ctx maps the message offset to a fixed packetId, so packet assignment is deterministic.
+        List<TbProtoQueueMsg<PublishMsgProto>> messages = List.of(
+                new TbProtoQueueMsg<>("appClient",
+                        PublishMsgProto.newBuilder().setTopicName("test/topic").setQos(1).build(),
+                        new DefaultTbQueueMsgHeaders(), 0, 0L));
+        ApplicationPersistedMsgCtx persistedMsgCtx = new ApplicationPersistedMsgCtx(Map.of(0L, 1), Collections.emptyMap());
+
+        invokeProcessMainPack(new ApplicationPubRelMsgCtx(Sets.newConcurrentHashSet()), messages, clientSessionCtx,
+                persistedMsgCtx, consumer, mock(ApplicationProcessorStats.class),
+                clientState);
+
+        // The un-acked PUBLISH must be counted exactly once as dropped, on the real give-up commit path.
+        verify(consumer, atLeastOnce()).commitSync();
+        verify(tbMessageStatsReportClient, times(1)).reportDroppedMsgs(1);
     }
 
     @Test

--- a/application/src/test/java/org/thingsboard/mqtt/broker/service/mqtt/persistence/application/ApplicationPersistenceProcessorImplTest.java
+++ b/application/src/test/java/org/thingsboard/mqtt/broker/service/mqtt/persistence/application/ApplicationPersistenceProcessorImplTest.java
@@ -32,7 +32,9 @@ import org.thingsboard.mqtt.broker.queue.cluster.ServiceInfoProvider;
 import org.thingsboard.mqtt.broker.queue.common.TbProtoQueueMsg;
 import org.thingsboard.mqtt.broker.queue.provider.ApplicationPersistenceMsgQueueFactory;
 import org.thingsboard.mqtt.broker.service.analysis.ClientLogger;
+import org.thingsboard.mqtt.broker.service.historical.stats.TbMessageStatsReportClient;
 import org.thingsboard.mqtt.broker.service.mqtt.MqttMsgDeliveryService;
+import org.thingsboard.mqtt.broker.service.mqtt.PublishMsg;
 import org.thingsboard.mqtt.broker.service.mqtt.persistence.application.data.ApplicationMainProcessingState;
 import org.thingsboard.mqtt.broker.service.mqtt.persistence.application.data.ApplicationSharedSubscriptionCtx;
 import org.thingsboard.mqtt.broker.service.mqtt.persistence.application.data.ApplicationSharedSubscriptionJob;
@@ -42,6 +44,7 @@ import org.thingsboard.mqtt.broker.service.mqtt.persistence.application.processi
 import org.thingsboard.mqtt.broker.service.mqtt.persistence.application.processing.ApplicationAckStrategyConfiguration;
 import org.thingsboard.mqtt.broker.service.mqtt.persistence.application.processing.ApplicationMsgAcknowledgeStrategyFactory;
 import org.thingsboard.mqtt.broker.service.mqtt.persistence.application.processing.ApplicationPackProcessingCtx;
+import org.thingsboard.mqtt.broker.service.mqtt.persistence.application.processing.ApplicationPackProcessingResult;
 import org.thingsboard.mqtt.broker.service.mqtt.persistence.application.processing.ApplicationPersistedMsgCtx;
 import org.thingsboard.mqtt.broker.service.mqtt.persistence.application.processing.ApplicationPersistedMsgCtxService;
 import org.thingsboard.mqtt.broker.service.mqtt.persistence.application.processing.ApplicationProcessingDecision;
@@ -49,6 +52,7 @@ import org.thingsboard.mqtt.broker.service.mqtt.persistence.application.processi
 import org.thingsboard.mqtt.broker.service.mqtt.persistence.application.processing.ApplicationSubmitStrategyFactory;
 import org.thingsboard.mqtt.broker.service.mqtt.persistence.application.processing.BurstSubmitStrategy;
 import org.thingsboard.mqtt.broker.service.mqtt.persistence.application.processing.PersistedPubRelMsg;
+import org.thingsboard.mqtt.broker.service.mqtt.persistence.application.processing.PersistedPublishMsg;
 import org.thingsboard.mqtt.broker.service.mqtt.persistence.application.topic.ApplicationTopicService;
 import org.thingsboard.mqtt.broker.service.mqtt.persistence.application.util.ApplicationClientHelperService;
 import org.thingsboard.mqtt.broker.service.stats.ApplicationProcessorStats;
@@ -77,6 +81,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.doAnswer;
@@ -105,6 +110,7 @@ class ApplicationPersistenceProcessorImplTest {
     @Mock ApplicationTopicService applicationTopicService;
     @Mock ApplicationClientHelperService appClientHelperService;
     @Mock AppMsgDeliveryStrategy appMsgDeliveryStrategy;
+    @Mock TbMessageStatsReportClient tbMessageStatsReportClient;
 
     @InjectMocks
     ApplicationPersistenceProcessorImpl processor;
@@ -460,6 +466,27 @@ class ApplicationPersistenceProcessorImplTest {
     }
 
     @Test
+    void reportSkippedMessagesIfAny_whenPublishPending_thenReportsPublishCountOnly() {
+        invokeReportSkippedMessagesIfAny("appClient", resultWith(3, 2));
+
+        verify(tbMessageStatsReportClient, times(1)).reportDroppedMsgs(3);
+    }
+
+    @Test
+    void reportSkippedMessagesIfAny_whenOnlyPubRelPending_thenReportsNothing() {
+        invokeReportSkippedMessagesIfAny("appClient", resultWith(0, 2));
+
+        verify(tbMessageStatsReportClient, never()).reportDroppedMsgs(anyInt());
+    }
+
+    @Test
+    void reportSkippedMessagesIfAny_whenNothingPending_thenReportsNothing() {
+        invokeReportSkippedMessagesIfAny("appClient", resultWith(0, 0));
+
+        verify(tbMessageStatsReportClient, never()).reportDroppedMsgs(anyInt());
+    }
+
+    @Test
     void processMainPack_retryAll_whenClientNeverAcks_mustGiveUpAndCommitAfterRetryCap() {
         ApplicationAckStrategyConfiguration ackConfig = new ApplicationAckStrategyConfiguration();
         ackConfig.setType(AckStrategyType.RETRY_ALL);
@@ -554,6 +581,28 @@ class ApplicationPersistenceProcessorImplTest {
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
+    }
+
+    private void invokeReportSkippedMessagesIfAny(String clientId, ApplicationPackProcessingResult result) {
+        try {
+            var method = ApplicationPersistenceProcessorImpl.class.getDeclaredMethod(
+                    "reportSkippedMessagesIfAny", String.class, ApplicationPackProcessingResult.class);
+            method.setAccessible(true);
+            method.invoke(processor, clientId, result);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private ApplicationPackProcessingResult resultWith(int publishPending, int pubRelPending) {
+        ApplicationPackProcessingCtx ctx = new ApplicationPackProcessingCtx("appClient");
+        for (int i = 1; i <= publishPending; i++) {
+            ctx.getPublishPendingMsgMap().put(i, new PersistedPublishMsg(mock(PublishMsg.class), i, false));
+        }
+        for (int i = 1; i <= pubRelPending; i++) {
+            ctx.getPubRelPendingMsgMap().put(1000 + i, new PersistedPubRelMsg(1000 + i, i));
+        }
+        return new ApplicationPackProcessingResult(ctx);
     }
 
     private boolean invokeIsProcessorActive() {

--- a/application/src/test/java/org/thingsboard/mqtt/broker/service/mqtt/persistence/device/queue/DeviceMsgQueueConsumerImplTest.java
+++ b/application/src/test/java/org/thingsboard/mqtt/broker/service/mqtt/persistence/device/queue/DeviceMsgQueueConsumerImplTest.java
@@ -1,0 +1,110 @@
+/**
+ * Copyright © 2016-2026 The Thingsboard Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.thingsboard.mqtt.broker.service.mqtt.persistence.device.queue;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.thingsboard.mqtt.broker.common.data.DevicePublishMsg;
+import org.thingsboard.mqtt.broker.queue.cluster.ServiceInfoProvider;
+import org.thingsboard.mqtt.broker.queue.provider.DevicePersistenceMsgQueueFactory;
+import org.thingsboard.mqtt.broker.service.analysis.ClientLogger;
+import org.thingsboard.mqtt.broker.service.historical.stats.TbMessageStatsReportClient;
+import org.thingsboard.mqtt.broker.service.mqtt.persistence.device.processing.ClientIdMessagesPack;
+import org.thingsboard.mqtt.broker.service.mqtt.persistence.device.processing.DeviceMsgAcknowledgeStrategyFactory;
+import org.thingsboard.mqtt.broker.service.mqtt.persistence.device.processing.DeviceMsgPersistenceSubmitStrategyFactory;
+import org.thingsboard.mqtt.broker.service.mqtt.persistence.device.processing.DeviceMsgProcessor;
+import org.thingsboard.mqtt.broker.service.mqtt.persistence.device.processing.DevicePackProcessingContext;
+import org.thingsboard.mqtt.broker.service.mqtt.persistence.device.processing.DevicePackProcessingResult;
+import org.thingsboard.mqtt.broker.service.stats.StatsManager;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@RunWith(MockitoJUnitRunner.class)
+public class DeviceMsgQueueConsumerImplTest {
+
+    private TbMessageStatsReportClient reportClient;
+    private DeviceMsgQueueConsumerImpl consumer;
+
+    @Before
+    public void setUp() {
+        reportClient = mock(TbMessageStatsReportClient.class);
+        consumer = new DeviceMsgQueueConsumerImpl(
+                mock(DevicePersistenceMsgQueueFactory.class),
+                mock(DeviceMsgAcknowledgeStrategyFactory.class),
+                mock(DeviceMsgPersistenceSubmitStrategyFactory.class),
+                mock(DeviceMsgProcessor.class),
+                mock(StatsManager.class),
+                mock(ServiceInfoProvider.class),
+                mock(ClientLogger.class),
+                reportClient);
+    }
+
+    private ClientIdMessagesPack packWith(String clientId, int messageCount) {
+        List<DevicePublishMsg> msgs = new ArrayList<>();
+        for (int i = 0; i < messageCount; i++) {
+            msgs.add(mock(DevicePublishMsg.class));
+        }
+        return new ClientIdMessagesPack(clientId, msgs);
+    }
+
+    // Builds a result whose failedMap holds the given packs and whose pendingMap holds `pendingCount`
+    // single-message packs (which must NOT be counted).
+    private DevicePackProcessingResult resultWith(List<ClientIdMessagesPack> failedPacks, int pendingCount) {
+        ConcurrentMap<String, ClientIdMessagesPack> pending = new ConcurrentHashMap<>();
+        for (ClientIdMessagesPack pack : failedPacks) {
+            pending.put(pack.clientId(), pack);
+        }
+        for (int i = 0; i < pendingCount; i++) {
+            String cid = "pending-" + i;
+            pending.put(cid, packWith(cid, 1));
+        }
+        DevicePackProcessingContext ctx = new DevicePackProcessingContext(pending);
+        for (ClientIdMessagesPack pack : failedPacks) {
+            ctx.onFailure(pack.clientId());
+        }
+        return new DevicePackProcessingResult(ctx);
+    }
+
+    @Test
+    public void givenFailedPacks_whenReportDroppedOnGiveUp_thenReportsSumOfMessages() {
+        DevicePackProcessingResult result = resultWith(
+                List.of(packWith("c1", 2), packWith("c2", 3)), 4);
+
+        consumer.reportDroppedMsgsOnGiveUp(result);
+
+        verify(reportClient, times(1)).reportDroppedMsgs(5); // 2+3; pendingMap (4) excluded
+    }
+
+    @Test
+    public void givenNoFailures_whenReportDroppedOnGiveUp_thenReportsNothing() {
+        DevicePackProcessingResult result = resultWith(List.of(), 3);
+
+        consumer.reportDroppedMsgsOnGiveUp(result);
+
+        verify(reportClient, never()).reportDroppedMsgs(anyInt());
+    }
+}

--- a/application/src/test/java/org/thingsboard/mqtt/broker/service/processing/PublishMsgConsumerServiceImplTest.java
+++ b/application/src/test/java/org/thingsboard/mqtt/broker/service/processing/PublishMsgConsumerServiceImplTest.java
@@ -1,0 +1,88 @@
+/**
+ * Copyright © 2016-2026 The Thingsboard Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.thingsboard.mqtt.broker.service.processing;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.thingsboard.mqtt.broker.queue.cluster.ServiceInfoProvider;
+import org.thingsboard.mqtt.broker.queue.provider.PublishMsgQueueFactory;
+import org.thingsboard.mqtt.broker.service.historical.stats.TbMessageStatsReportClient;
+import org.thingsboard.mqtt.broker.service.limits.RateLimitService;
+import org.thingsboard.mqtt.broker.service.stats.StatsManager;
+
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+// PackProcessingContext, PackProcessingResult, PublishMsgWithId, MsgDispatcherService, AckStrategyFactory,
+// SubmitStrategyFactory are all in this same package (org.thingsboard.mqtt.broker.service.processing) — no import needed.
+@RunWith(MockitoJUnitRunner.class)
+public class PublishMsgConsumerServiceImplTest {
+
+    private TbMessageStatsReportClient reportClient;
+    private PublishMsgConsumerServiceImpl consumer;
+
+    @Before
+    public void setUp() {
+        reportClient = mock(TbMessageStatsReportClient.class);
+        consumer = new PublishMsgConsumerServiceImpl(
+                mock(MsgDispatcherService.class),
+                mock(PublishMsgQueueFactory.class),
+                mock(AckStrategyFactory.class),
+                mock(SubmitStrategyFactory.class),
+                mock(ServiceInfoProvider.class),
+                mock(StatsManager.class),
+                mock(RateLimitService.class),
+                reportClient);
+    }
+
+    private PackProcessingResult resultWith(int pending, int failed) {
+        ConcurrentMap<UUID, PublishMsgWithId> pendingMap = new ConcurrentHashMap<>();
+        for (int i = 0; i < pending + failed; i++) {
+            pendingMap.put(UUID.randomUUID(), mock(PublishMsgWithId.class));
+        }
+        PackProcessingContext ctx = new PackProcessingContext(pendingMap);
+        int i = 0;
+        for (UUID id : pendingMap.keySet()) {
+            if (i++ < failed) {
+                ctx.onFailure(id);
+            }
+        }
+        return new PackProcessingResult(ctx);
+    }
+
+    @Test
+    public void givenPendingAndFailed_whenReportDroppedOnGiveUp_thenReportsSum() {
+        consumer.reportDroppedMsgsOnGiveUp(resultWith(2, 3));
+
+        verify(reportClient, times(1)).reportDroppedMsgs(5);
+    }
+
+    @Test
+    public void givenCleanPack_whenReportDroppedOnGiveUp_thenReportsNothing() {
+        consumer.reportDroppedMsgsOnGiveUp(resultWith(0, 0));
+
+        verify(reportClient, never()).reportDroppedMsgs(anyInt());
+    }
+}


### PR DESCRIPTION
## Pull Request description

Makes the broker-wide `droppedMsgs` counter count every PUBLISH the broker **accepted but permanently failed to deliver — exactly once** — and stop counting recoverable/persistent losses.

**Scope of changes** — counting added/corrected at each PUBLISH-pipeline site:

| Site | Change |
|---|---|
| `MqttPublishHandler` | receive-maximum-exceeded QoS1/2 drops |
| `PublishMsgConsumerServiceImpl` | inbound give-up commit: leftover pending + failed |
| `DefaultMqttPublishMsgDeliveryService` | sync write-throw **and** async write-future failures, via `isCountableDrop` |
| `PublishedInFlightCtxImpl` | in-flight/delay-queue overflow + delayed-TTL drops (flow-control `dropsOverflow`/`dropsTtl` meters unchanged) |
| `ApplicationPersistenceProcessorImpl` | APPLICATION give-up: un-acked PUBLISH (`publishPendingMap`, excludes PUBREL) |
| `DeviceMsgQueueConsumerImpl` | DEVICE give-up: failed-persist messages (`failedMap`) |

**Counting principle** (`isCountableDrop`): count a delivery / flow-control drop only if **non-retained** and (**non-persistent session** or **QoS0**). A persistent-session QoS>0 copy is recoverable from the store (APPLICATION → Kafka, counted once at the APPLICATION give-up; DEVICE → redelivered from Redis); QoS0 is never stored; retained is recoverable from the retained store.

**Deliberately unchanged:** `DuplexTrafficHandler` too-long-frame, `MsgDispatcherServiceImpl` zero-subscriber, `BasicDownLinkProcessorImpl` session-gone, MQTT5 message-expiry.

**Documentation:** no user-facing documentation change required — `droppedMsgs` is a pre-existing untagged metric and only its coverage is broadened. Deferred follow-ups (out of scope, tracked separately): a distinct `expiredMsgs` meter for MQTT5-expiry discards.

## General checklist

- [x] You have reviewed the guidelines [document](https://docs.google.com/document/d/1A4Vc3wrHsY_159b9RG5LOtCryoH6VPwgOhrFEzJKwbI/edit?usp=sharing).
- [x] [Labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels#about-labels) that classify your pull request have been added.
- [x] The [milestone](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones) is specified and corresponds to fix version.
- [x] Description references specific [issue](https://github.com/thingsboard/tbmq/issues).
- [x] Description contains human-readable scope of changes.
- [x] Description contains brief notes about what needs to be added to the documentation.
- [x] No merge conflicts, commented blocks of code, code formatting issues.
- [x] Changes are backward compatible or upgrade script is provided.

## Front-End feature checklist

- [x] Screenshots with affected component(s) are added. The best option is to provide 2 screens: before and after changes;
  - _N/A — back-end only, no UI change._
- [x] If you change the widget or other API, ensure it is backward-compatible or upgrade script is present.
  - _N/A — no widget / API change._

## Back-End feature checklist

- [x] Added corresponding unit and/or integration test(s). Provide written explanation in the PR description if you have failed to add tests.
  - _Unit tests (JUnit 4/5 + Mockito) added/updated for all six sites — 111 tests across the 7 touched classes pass; each drop path asserted via `verify(...)` on `TbMessageStatsReportClient`. No integration test: the counting is deterministic and fully covered at unit level._
- [x] If new dependency was added: the dependency tree is checked for conflicts.
  - _N/A — no new dependency added._