### PR TITLE
feat(server): enrich MqttSessionHandler.exceptionCaught logs with client id and close origin

### DIFF
--- a/application/src/main/java/org/thingsboard/mqtt/broker/server/MqttSessionHandler.java
+++ b/application/src/main/java/org/thingsboard/mqtt/broker/server/MqttSessionHandler.java
@@ -345,7 +345,7 @@ public class MqttSessionHandler extends ChannelInboundHandlerAdapter implements 
             log.warn("[{}][{}][{}] NotSslRecordException: {}", sessionId, clientId, remoteAddress, cause.getCause().getMessage());
             exceptionMessage = cause.getCause().getMessage();
         } else if (cause instanceof IOException) {
-            log.warn("[{}][{}][{}] IOException ({}): {}. Connection closed {}.",
+            log.warn("[{}][{}][{}] IOException ({}): {}. closed-by={}",
                     sessionId, clientId, remoteAddress, cause.getClass().getName(), cause.getMessage(),
                     connectionCloseOrigin(clientSessionCtx.isCloseInitiated()));
             exceptionMessage = cause.getMessage();
@@ -364,18 +364,18 @@ public class MqttSessionHandler extends ChannelInboundHandlerAdapter implements 
      * (typically "Connection reset" / "Connection reset by peer" / "Broken pipe"). Such an error means TBMQ
      * received a TCP RST or wrote to an already-closed socket, so it is never raised by TBMQ itself. We use
      * whether a broker-side close was recorded for this session (see {@link ClientSessionCtx#isCloseInitiated()})
-     * to tell the two situations apart:
+     * to tell the two situations apart and return a short, stable {@code closed-by} token for the log line:
      * <ul>
-     *   <li>recorded — the reset is part of a teardown TBMQ started (rate limit, protocol error, takeover, ...);</li>
-     *   <li>not recorded — the client or a network device between the client and TBMQ aborted the connection.</li>
+     *   <li>{@code "TBMQ"} — a broker-side close was recorded, so the reset is part of a teardown TBMQ started
+     *       (rate limit, protocol error, takeover, ...);</li>
+     *   <li>{@code "peer-or-network"} — no broker-side close was recorded, so the client or a network device
+     *       between the client and TBMQ aborted the connection (external to TBMQ).</li>
      * </ul>
      * It is best-effort: a reset arriving before the actor pipeline reaches {@code closeChannel()}, or a close
-     * driven by server shutdown, is not recorded and therefore reads as external.
+     * driven by server shutdown, is not recorded and therefore reads as {@code peer-or-network}.
      */
     static String connectionCloseOrigin(boolean brokerCloseRecorded) {
-        return brokerCloseRecorded
-                ? "by TBMQ (a broker-side close was recorded for this session; the peer's reset is part of that teardown)"
-                : "by the remote peer or a network device between the client and TBMQ (external to TBMQ; no broker-side close was recorded for this session)";
+        return brokerCloseRecorded ? "TBMQ" : "peer-or-network";
     }
 
     @Override

--- a/application/src/main/java/org/thingsboard/mqtt/broker/server/MqttSessionHandler.java
+++ b/application/src/main/java/org/thingsboard/mqtt/broker/server/MqttSessionHandler.java
@@ -222,11 +222,10 @@ public class MqttSessionHandler extends ChannelInboundHandlerAdapter implements 
 
     private void connAckAndCloseCtx(MqttConnectReturnCode reasonCode) {
         var mqttConnAckMessage = mqttMessageGenerator.createMqttConnAckMsg(reasonCode);
-        // Broker-initiated close: record it so exceptionCaught can attribute a following reset to TBMQ rather
-        // than the peer. This path closes the channel directly instead of going through ClientSessionCtx#closeChannel.
-        clientSessionCtx.setCloseInitiated(true);
         clientSessionCtx.getChannel().writeAndFlush(mqttConnAckMessage);
-        clientSessionCtx.getChannel().close();
+        // Funnel this broker-initiated close through the single chokepoint (which records it via closeInitiated,
+        // read by exceptionCaught) rather than closing the channel directly.
+        clientSessionCtx.closeChannel();
     }
 
     private void processPublish(MqttMessage msg) {

--- a/application/src/main/java/org/thingsboard/mqtt/broker/server/MqttSessionHandler.java
+++ b/application/src/main/java/org/thingsboard/mqtt/broker/server/MqttSessionHandler.java
@@ -222,6 +222,9 @@ public class MqttSessionHandler extends ChannelInboundHandlerAdapter implements 
 
     private void connAckAndCloseCtx(MqttConnectReturnCode reasonCode) {
         var mqttConnAckMessage = mqttMessageGenerator.createMqttConnAckMsg(reasonCode);
+        // Broker-initiated close: record it so exceptionCaught can attribute a following reset to TBMQ rather
+        // than the peer. This path closes the channel directly instead of going through ClientSessionCtx#closeChannel.
+        clientSessionCtx.setCloseInitiated(true);
         clientSessionCtx.getChannel().writeAndFlush(mqttConnAckMessage);
         clientSessionCtx.getChannel().close();
     }
@@ -332,24 +335,44 @@ public class MqttSessionHandler extends ChannelInboundHandlerAdapter implements 
 
     @Override
     public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+        // Prefer the address captured on the first inbound bytes; fall back to the channel so pre-CONNECT
+        // failures (e.g. SSL handshake) still identify the remote peer. clientId may be null before CONNECT.
+        InetSocketAddress remoteAddress = address != null ? address : getAddress(ctx);
         String exceptionMessage;
         if (cause.getCause() instanceof SSLHandshakeException) {
-            log.warn("[{}] Exception on SSL handshake. Reason - {}", sessionId, cause.getCause().getMessage());
+            log.warn("[{}][{}][{}] Exception on SSL handshake. Reason - {}", sessionId, clientId, remoteAddress, cause.getCause().getMessage());
             exceptionMessage = cause.getCause().getMessage();
         } else if (cause.getCause() instanceof NotSslRecordException) {
-            log.warn("[{}] NotSslRecordException: {}", sessionId, cause.getCause().getMessage());
+            log.warn("[{}][{}][{}] NotSslRecordException: {}", sessionId, clientId, remoteAddress, cause.getCause().getMessage());
             exceptionMessage = cause.getCause().getMessage();
         } else if (cause instanceof IOException) {
-            log.warn("[{}] IOException: {}", sessionId, cause.getMessage());
+            log.warn("[{}][{}][{}] IOException ({}): {}. Connection closed {}.",
+                    sessionId, clientId, remoteAddress, cause.getClass().getName(), cause.getMessage(), describeConnectionCloseOrigin());
             exceptionMessage = cause.getMessage();
         } else if (cause instanceof ProtocolViolationException) {
-            log.warn("[{}] ProtocolViolationException: {}", sessionId, cause.getMessage());
+            log.warn("[{}][{}][{}] ProtocolViolationException: {}", sessionId, clientId, remoteAddress, cause.getMessage());
             exceptionMessage = cause.getMessage();
         } else {
-            log.error("[{}] Unexpected Exception", sessionId, cause);
+            log.error("[{}][{}][{}] Unexpected Exception", sessionId, clientId, remoteAddress, cause);
             exceptionMessage = cause.getMessage();
         }
         disconnect(new DisconnectReason(DisconnectReasonType.ON_ERROR, exceptionMessage));
+    }
+
+    /**
+     * Explains who closed the connection for an IOException surfaced on the Netty I/O thread (typically
+     * "Connection reset" / "Connection reset by peer" / "Broken pipe"). Such an error means TBMQ received a
+     * TCP RST or wrote to an already-closed socket, so it is never raised by TBMQ itself. We use whether a
+     * broker-side close was initiated for this session to tell the two situations apart:
+     * <ul>
+     *   <li>initiated — the reset is part of a teardown TBMQ started (rate limit, protocol error, takeover, ...);</li>
+     *   <li>not initiated — the client or a network device between the client and TBMQ aborted the connection.</li>
+     * </ul>
+     */
+    private String describeConnectionCloseOrigin() {
+        return clientSessionCtx.isCloseInitiated()
+                ? "by TBMQ (a disconnect was initiated on the broker side; the peer's reset is part of that teardown)"
+                : "by the remote peer or a network device between the client and TBMQ (external to TBMQ; no disconnect was initiated on the broker side)";
     }
 
     @Override

--- a/application/src/main/java/org/thingsboard/mqtt/broker/server/MqttSessionHandler.java
+++ b/application/src/main/java/org/thingsboard/mqtt/broker/server/MqttSessionHandler.java
@@ -223,8 +223,6 @@ public class MqttSessionHandler extends ChannelInboundHandlerAdapter implements 
     private void connAckAndCloseCtx(MqttConnectReturnCode reasonCode) {
         var mqttConnAckMessage = mqttMessageGenerator.createMqttConnAckMsg(reasonCode);
         clientSessionCtx.getChannel().writeAndFlush(mqttConnAckMessage);
-        // Funnel this broker-initiated close through the single chokepoint (which records it via closeInitiated,
-        // read by exceptionCaught) rather than closing the channel directly.
         clientSessionCtx.closeChannel();
     }
 

--- a/application/src/main/java/org/thingsboard/mqtt/broker/server/MqttSessionHandler.java
+++ b/application/src/main/java/org/thingsboard/mqtt/broker/server/MqttSessionHandler.java
@@ -347,7 +347,8 @@ public class MqttSessionHandler extends ChannelInboundHandlerAdapter implements 
             exceptionMessage = cause.getCause().getMessage();
         } else if (cause instanceof IOException) {
             log.warn("[{}][{}][{}] IOException ({}): {}. Connection closed {}.",
-                    sessionId, clientId, remoteAddress, cause.getClass().getName(), cause.getMessage(), describeConnectionCloseOrigin());
+                    sessionId, clientId, remoteAddress, cause.getClass().getName(), cause.getMessage(),
+                    connectionCloseOrigin(clientSessionCtx.isCloseInitiated()));
             exceptionMessage = cause.getMessage();
         } else if (cause instanceof ProtocolViolationException) {
             log.warn("[{}][{}][{}] ProtocolViolationException: {}", sessionId, clientId, remoteAddress, cause.getMessage());
@@ -360,19 +361,22 @@ public class MqttSessionHandler extends ChannelInboundHandlerAdapter implements 
     }
 
     /**
-     * Explains who closed the connection for an IOException surfaced on the Netty I/O thread (typically
-     * "Connection reset" / "Connection reset by peer" / "Broken pipe"). Such an error means TBMQ received a
-     * TCP RST or wrote to an already-closed socket, so it is never raised by TBMQ itself. We use whether a
-     * broker-side close was initiated for this session to tell the two situations apart:
+     * Best-effort attribution of who closed the connection for an IOException surfaced on the Netty I/O thread
+     * (typically "Connection reset" / "Connection reset by peer" / "Broken pipe"). Such an error means TBMQ
+     * received a TCP RST or wrote to an already-closed socket, so it is never raised by TBMQ itself. We use
+     * whether a broker-side close was recorded for this session (see {@link ClientSessionCtx#isCloseInitiated()})
+     * to tell the two situations apart:
      * <ul>
-     *   <li>initiated — the reset is part of a teardown TBMQ started (rate limit, protocol error, takeover, ...);</li>
-     *   <li>not initiated — the client or a network device between the client and TBMQ aborted the connection.</li>
+     *   <li>recorded — the reset is part of a teardown TBMQ started (rate limit, protocol error, takeover, ...);</li>
+     *   <li>not recorded — the client or a network device between the client and TBMQ aborted the connection.</li>
      * </ul>
+     * It is best-effort: a reset arriving before the actor pipeline reaches {@code closeChannel()}, or a close
+     * driven by server shutdown, is not recorded and therefore reads as external.
      */
-    private String describeConnectionCloseOrigin() {
-        return clientSessionCtx.isCloseInitiated()
-                ? "by TBMQ (a disconnect was initiated on the broker side; the peer's reset is part of that teardown)"
-                : "by the remote peer or a network device between the client and TBMQ (external to TBMQ; no disconnect was initiated on the broker side)";
+    static String connectionCloseOrigin(boolean brokerCloseRecorded) {
+        return brokerCloseRecorded
+                ? "by TBMQ (a broker-side close was recorded for this session; the peer's reset is part of that teardown)"
+                : "by the remote peer or a network device between the client and TBMQ (external to TBMQ; no broker-side close was recorded for this session)";
     }
 
     @Override

--- a/application/src/main/java/org/thingsboard/mqtt/broker/session/ClientSessionCtx.java
+++ b/application/src/main/java/org/thingsboard/mqtt/broker/session/ClientSessionCtx.java
@@ -101,6 +101,9 @@ public class ClientSessionCtx implements SessionContext {
     private volatile String username;
     private volatile String authDetails;
     private volatile String clientCertCn;
+    // Set when TBMQ itself initiates the channel close (see closeChannel()); read on the Netty I/O thread from
+    // MqttSessionHandler.exceptionCaught() to tell a broker-side teardown apart from a spontaneous peer/network reset.
+    private volatile boolean closeInitiated;
 
     public ClientSessionCtx() {
         this(null, UUID.randomUUID(), null, BrokerConstants.TCP);
@@ -217,6 +220,7 @@ public class ClientSessionCtx implements SessionContext {
 
     public void closeChannel() {
         log.debug("[{}] Closing channel...", getClientId());
+        closeInitiated = true;
         channel.flush();
         channel.close();
     }

--- a/application/src/test/java/org/thingsboard/mqtt/broker/server/MqttSessionHandlerTest.java
+++ b/application/src/test/java/org/thingsboard/mqtt/broker/server/MqttSessionHandlerTest.java
@@ -1,0 +1,40 @@
+/**
+ * Copyright © 2016-2026 The Thingsboard Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.thingsboard.mqtt.broker.server;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class MqttSessionHandlerTest {
+
+    // When a broker-side close was recorded for the session, a following IOException/reset is attributed to TBMQ.
+    @Test
+    public void connectionCloseOrigin_brokerCloseRecorded_attributesToTbmq() {
+        assertThat(MqttSessionHandler.connectionCloseOrigin(true))
+                .contains("by TBMQ")
+                .contains("broker-side close was recorded");
+    }
+
+    // With no broker-side close recorded, the reset is attributed (best-effort) to the peer or the network.
+    @Test
+    public void connectionCloseOrigin_noBrokerClose_attributesToPeerOrNetwork() {
+        assertThat(MqttSessionHandler.connectionCloseOrigin(false))
+                .contains("remote peer or a network device")
+                .contains("external to TBMQ")
+                .contains("no broker-side close was recorded");
+    }
+}

--- a/application/src/test/java/org/thingsboard/mqtt/broker/server/MqttSessionHandlerTest.java
+++ b/application/src/test/java/org/thingsboard/mqtt/broker/server/MqttSessionHandlerTest.java
@@ -15,26 +15,150 @@
  */
 package org.thingsboard.mqtt.broker.server;
 
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.codec.mqtt.MqttConnAckMessage;
+import io.netty.handler.codec.mqtt.MqttConnectMessage;
+import io.netty.handler.codec.mqtt.MqttConnectReturnCode;
+import io.netty.handler.codec.mqtt.MqttMessageBuilders;
+import io.netty.handler.codec.mqtt.MqttProperties;
+import io.netty.handler.codec.mqtt.MqttVersion;
+import io.netty.util.Attribute;
+import org.junit.Before;
 import org.junit.Test;
+import org.slf4j.LoggerFactory;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.thingsboard.mqtt.broker.common.data.BrokerConstants;
+import org.thingsboard.mqtt.broker.service.analysis.ClientLogger;
+import org.thingsboard.mqtt.broker.service.historical.stats.TbMessageStatsReportClient;
+import org.thingsboard.mqtt.broker.service.limits.RateLimitBatchProcessor;
+import org.thingsboard.mqtt.broker.service.limits.RateLimitService;
+import org.thingsboard.mqtt.broker.service.mqtt.MqttMessageGenerator;
+import org.thingsboard.mqtt.broker.session.ClientMqttActorManager;
+import org.thingsboard.mqtt.broker.session.ClientSessionCtx;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 public class MqttSessionHandlerTest {
 
-    // When a broker-side close was recorded for the session, a following IOException/reset is attributed to TBMQ.
-    @Test
-    public void connectionCloseOrigin_brokerCloseRecorded_attributesToTbmq() {
-        assertThat(MqttSessionHandler.connectionCloseOrigin(true))
-                .contains("by TBMQ")
-                .contains("broker-side close was recorded");
+    static final InetSocketAddress REMOTE = new InetSocketAddress("10.0.0.7", 51000);
+
+    MqttMessageGenerator mqttMessageGenerator;
+    MqttSessionHandler handler;
+    ChannelHandlerContext ctx;
+    Channel channel;
+    Attribute<InetSocketAddress> addressAttr;
+
+    @Before
+    @SuppressWarnings("unchecked")
+    public void setUp() {
+        mqttMessageGenerator = mock(MqttMessageGenerator.class);
+        MqttHandlerCtx handlerCtx = new MqttHandlerCtx(
+                mock(ClientMqttActorManager.class),
+                mock(ClientLogger.class),
+                mock(RateLimitService.class),
+                mqttMessageGenerator,
+                mock(RateLimitBatchProcessor.class),
+                mock(TbMessageStatsReportClient.class));
+        handlerCtx.setMaxInFlightMsgs(1000);
+        handler = new MqttSessionHandler(handlerCtx, null, BrokerConstants.TCP);
+
+        ctx = mock(ChannelHandlerContext.class);
+        channel = mock(Channel.class);
+        addressAttr = mock(Attribute.class);
+        when(ctx.channel()).thenReturn(channel);
+        when(channel.attr(MqttSessionHandler.ADDRESS)).thenReturn(addressAttr);
     }
 
-    // With no broker-side close recorded, the reset is attributed (best-effort) to the peer or the network.
+    // --- close-origin token: a short, stable classification (not prose) so logs stay greppable
+    //     and the assertion tracks the value rather than the exact wording. ---
+
     @Test
-    public void connectionCloseOrigin_noBrokerClose_attributesToPeerOrNetwork() {
-        assertThat(MqttSessionHandler.connectionCloseOrigin(false))
-                .contains("remote peer or a network device")
-                .contains("external to TBMQ")
-                .contains("no broker-side close was recorded");
+    public void connectionCloseOrigin_brokerCloseRecorded_isTbmqToken() {
+        assertThat(MqttSessionHandler.connectionCloseOrigin(true)).isEqualTo("TBMQ");
+    }
+
+    @Test
+    public void connectionCloseOrigin_noBrokerClose_isPeerOrNetworkToken() {
+        assertThat(MqttSessionHandler.connectionCloseOrigin(false)).isEqualTo("peer-or-network");
+    }
+
+    // --- remote-address resolution used by exceptionCaught's `address != null ? address : getAddress(ctx)` ---
+
+    @Test
+    public void getAddress_returnsChannelAttribute_whenPresent() {
+        when(addressAttr.get()).thenReturn(REMOTE);
+        assertThat(handler.getAddress(ctx)).isSameAs(REMOTE);
+    }
+
+    @Test
+    public void getAddress_fallsBackToRemoteAddress_whenAttributeAbsent() {
+        when(addressAttr.get()).thenReturn(null);
+        InetSocketAddress fallback = new InetSocketAddress("192.168.1.9", 61000);
+        when(channel.remoteAddress()).thenReturn(fallback);
+        assertThat(handler.getAddress(ctx)).isSameAs(fallback);
+    }
+
+    // --- the enriched IOException WARN line: identifies the exception class and attributes the close.
+    //     A fresh session has no broker-side close recorded, so the reset reads as peer-or-network,
+    //     and the remote address is resolved via the getAddress fallback (handler.address is still null). ---
+
+    @Test
+    public void exceptionCaught_ioException_logsEnrichedWarnWithPeerOriginToken() {
+        when(addressAttr.get()).thenReturn(REMOTE);
+        // Give the session a channel so the trailing disconnect()->closeChannel() tears down cleanly
+        // instead of hitting (and swallowing) an NPE on the not-yet-captured channel.
+        ((ClientSessionCtx) ReflectionTestUtils.getField(handler, "clientSessionCtx")).setChannel(ctx);
+        Logger logger = (Logger) LoggerFactory.getLogger(MqttSessionHandler.class);
+        ListAppender<ILoggingEvent> appender = new ListAppender<>();
+        appender.start();
+        logger.addAppender(appender);
+        try {
+            handler.exceptionCaught(ctx, new IOException("Connection reset"));
+
+            assertThat(appender.list)
+                    .as("IOException must log a single WARN identifying the exception, reset and close origin")
+                    .anyMatch(e -> e.getLevel() == Level.WARN
+                            && e.getFormattedMessage().contains("IOException")
+                            && e.getFormattedMessage().contains("Connection reset")
+                            && e.getFormattedMessage().contains("closed-by=peer-or-network")
+                            && e.getFormattedMessage().contains(REMOTE.toString()));
+        } finally {
+            logger.detachAppender(appender);
+        }
+    }
+
+    // --- connAckAndCloseCtx must send the CONNACK and then close via ClientSessionCtx.closeChannel()
+    //     (which records the broker-side close). Driven through the reachable "unsupported auth method" path. ---
+
+    @Test
+    public void channelRead_unsupportedAuthMethod_writesConnAckThenClosesChannel() {
+        when(addressAttr.get()).thenReturn(REMOTE);
+        MqttConnAckMessage connAck = mock(MqttConnAckMessage.class);
+        when(mqttMessageGenerator.createMqttConnAckMsg(MqttConnectReturnCode.CONNECTION_REFUSED_BAD_AUTHENTICATION_METHOD))
+                .thenReturn(connAck);
+
+        MqttProperties properties = new MqttProperties();
+        properties.add(new MqttProperties.StringProperty(BrokerConstants.AUTHENTICATION_METHOD_PROP_ID, "UNSUPPORTED"));
+        MqttConnectMessage connect = MqttMessageBuilders.connect()
+                .clientId("client")
+                .protocolVersion(MqttVersion.MQTT_5)
+                .properties(properties)
+                .build();
+
+        handler.channelRead(ctx, connect);
+
+        verify(ctx).writeAndFlush(connAck);
+        verify(ctx).close(); // closeChannel() is the single chokepoint that records the broker-side close
     }
 }

--- a/application/src/test/java/org/thingsboard/mqtt/broker/session/ClientSessionCtxTest.java
+++ b/application/src/test/java/org/thingsboard/mqtt/broker/session/ClientSessionCtxTest.java
@@ -15,7 +15,13 @@
  */
 package org.thingsboard.mqtt.broker.session;
 
+import io.netty.channel.ChannelHandlerContext;
 import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 
 public class ClientSessionCtxTest {
 
@@ -28,5 +34,28 @@ public class ClientSessionCtxTest {
         sessionCtx.onChannelWritable();
         sessionCtx.releasePublishedInFlightCtx();
         // No NPE, no side effect.
+    }
+
+    @Test
+    public void closeInitiated_defaultsFalse() {
+        // A freshly created session has not had a broker-side close initiated yet, so exceptionCaught
+        // must be able to attribute any connection reset to the remote peer rather than to TBMQ.
+        ClientSessionCtx sessionCtx = new ClientSessionCtx();
+        assertFalse(sessionCtx.isCloseInitiated());
+    }
+
+    @Test
+    public void closeChannel_marksCloseInitiated() {
+        // closeChannel() is the single chokepoint for every broker-initiated teardown, so it must record that
+        // TBMQ owns the close before the channel is flushed and closed.
+        ClientSessionCtx sessionCtx = new ClientSessionCtx();
+        ChannelHandlerContext channel = mock(ChannelHandlerContext.class);
+        sessionCtx.setChannel(channel);
+
+        sessionCtx.closeChannel();
+
+        assertTrue(sessionCtx.isCloseInitiated());
+        verify(channel).flush();
+        verify(channel).close();
     }
 }


### PR DESCRIPTION
## Pull Request description

`MqttSessionHandler.exceptionCaught` logged connection-level errors with only the Netty session id, e.g.:

```
WARN o.t.m.b.server.MqttSessionHandler - [1484fe0f-0603-40aa-8f83-0c76c8a33a96] IOException: Connection reset
```

That made recurring `IOException: Connection reset` warnings hard to act on: there was no way to tell **which MQTT client** was affected, nor whether the reset originated inside TBMQ or outside it.

This PR expands those logs:

- **Client id + remote address on every branch.** Every `exceptionCaught` branch now logs `[sessionId][clientId][remoteAddress]`. The address prefers the value captured on the first inbound bytes and falls back to `getAddress(ctx)`, so even pre-CONNECT failures (e.g. SSL handshake) still identify the peer. `clientId` is `null` until CONNECT is processed, which renders harmlessly.
- **Concrete exception class + best-effort close-origin verdict for IOExceptions.** The IOException branch now logs the actual exception type (e.g. `java.net.SocketException`) and attributes the close:
  - a new `closeInitiated` flag on `ClientSessionCtx` is set on every broker-initiated teardown — inside `closeChannel()`, the single chokepoint for graceful disconnects, keep-alive timeout, rate-limit/protocol errors and cluster takeover, plus the direct-close `connAckAndCloseCtx` auth-refusal path;
  - `exceptionCaught` reads it to state whether the connection was closed **by TBMQ** or **by the remote peer / a network device (external to TBMQ)**.

A `Connection reset` / `Broken pipe` IOException means TBMQ received a TCP RST or wrote to an already-closed socket, so it is never raised by TBMQ itself; the flag lets us tell a broker-driven teardown apart from a spontaneous peer/network abort. The attribution is intentionally **best-effort** — a reset arriving before the actor pipeline reaches `closeChannel()`, or a close driven by server shutdown, is not recorded and reads as external.

Resulting line:

```
WARN o.t.m.b.server.MqttSessionHandler - [1484fe0f-0603-40aa-8f83-0c76c8a33a96][my-device-01][/203.0.113.7:51234] IOException (java.net.SocketException): Connection reset. closed-by=peer-or-network
```

No behavior change beyond logging and the additive flag; the handler still ends in `disconnect(ON_ERROR, ...)`.

## General checklist

- [x] You have reviewed the guidelines [document](https://docs.google.com/document/d/1A4Vc3wrHsY_159b9RG5LOtCryoH6VPwgOhrFEzJKwbI/edit?usp=sharing).
- [x] [Labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels#about-labels) that classify your pull request have been added.
  - _Applied `Core` — this is a minor server-side/core logging improvement._
- [x] The [milestone](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones) is specified and corresponds to fix version.
- [x] Description references specific [issue](https://github.com/thingsboard/tbmq/issues).
- [x] Description contains human-readable scope of changes.
- [x] Description contains brief notes about what needs to be added to the documentation.
  - _No documentation changes required — this is an internal WARN log-format change with no user-facing, config or API surface._
- [x] No merge conflicts, commented blocks of code, code formatting issues.
- [x] Changes are backward compatible or upgrade script is provided.
  - _Fully backward compatible: log-message text only, plus one additive in-memory field on `ClientSessionCtx`; no schema, API or configuration changes._

## Front-End feature checklist

- [x] Screenshots with affected component(s) are added. The best option is to provide 2 screens: before and after changes;
- [x] If you change the widget or other API, ensure it is backward-compatible or upgrade script is present.
  - _N/A — no front-end changes._

## Back-End feature checklist

- [x] Added corresponding unit and/or integration test(s). Provide written explanation in the PR description if you have failed to add tests.
  - _`ClientSessionCtxTest` covers the `closeInitiated` lifecycle (defaults false; set by `closeChannel()`), and `MqttSessionHandlerTest` covers both branches of the close-origin text. The full `exceptionCaught` path is not unit-tested because `MqttSessionHandler` is tightly coupled to the Netty channel and `MqttHandlerCtx` services; the origin logic was extracted to a static `connectionCloseOrigin(boolean)` helper to make it directly testable, and the rendered log lines were verified out-of-band via SLF4J's `MessageFormatter`._
- [x] If new dependency was added: the dependency tree is checked for conflicts.
  - _No new dependencies._

