### PR TITLE
Outbound rate limiting for persistent APPLICATION clients

### DIFF
--- a/application/src/main/java/org/thingsboard/mqtt/broker/config/ApplicationPersistedMsgsRateLimitsConfiguration.java
+++ b/application/src/main/java/org/thingsboard/mqtt/broker/config/ApplicationPersistedMsgsRateLimitsConfiguration.java
@@ -1,0 +1,30 @@
+/**
+ * Copyright © 2016-2026 The Thingsboard Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.thingsboard.mqtt.broker.config;
+
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@ConfigurationProperties(prefix = "mqtt.rate-limits.application-persisted-messages")
+@Data
+public class ApplicationPersistedMsgsRateLimitsConfiguration {
+
+    private boolean enabled;
+    private String clientConfig;
+
+}

--- a/application/src/main/java/org/thingsboard/mqtt/broker/service/limits/RateLimitService.java
+++ b/application/src/main/java/org/thingsboard/mqtt/broker/service/limits/RateLimitService.java
@@ -49,7 +49,7 @@ public interface RateLimitService {
     /**
      * Non-blocking token consume for outbound persisted messages to an APPLICATION client (throttling, not dropping)
      */
-    boolean tryConsumeApplicationPersistedMsg(String clientId);
+    boolean tryConsumeApplicationPersistedMsgs(String clientId);
 
     boolean isApplicationPersistedMsgsRateLimitEnabled();
 

--- a/application/src/main/java/org/thingsboard/mqtt/broker/service/limits/RateLimitService.java
+++ b/application/src/main/java/org/thingsboard/mqtt/broker/service/limits/RateLimitService.java
@@ -46,6 +46,13 @@ public interface RateLimitService {
 
     boolean isDevicePersistedMsgsLimitEnabled();
 
+    /**
+     * Non-blocking token consume for outbound persisted messages to an APPLICATION client (throttling, not dropping)
+     */
+    boolean tryConsumeApplicationPersistedMsg(String clientId);
+
+    boolean isApplicationPersistedMsgsRateLimitEnabled();
+
     long tryConsumeTotalMsgs(long limit);
 
     boolean isTotalMsgsLimitEnabled();

--- a/application/src/main/java/org/thingsboard/mqtt/broker/service/limits/RateLimitServiceImpl.java
+++ b/application/src/main/java/org/thingsboard/mqtt/broker/service/limits/RateLimitServiceImpl.java
@@ -24,6 +24,7 @@ import org.springframework.stereotype.Service;
 import org.thingsboard.mqtt.broker.common.data.ClientSessionInfo;
 import org.thingsboard.mqtt.broker.common.data.SessionInfo;
 import org.thingsboard.mqtt.broker.common.util.TbRateLimits;
+import org.thingsboard.mqtt.broker.config.ApplicationPersistedMsgsRateLimitsConfiguration;
 import org.thingsboard.mqtt.broker.config.ClientsLimitProperties;
 import org.thingsboard.mqtt.broker.config.DevicePersistedMsgsRateLimitsConfiguration;
 import org.thingsboard.mqtt.broker.config.IncomingRateLimitsConfiguration;
@@ -44,6 +45,7 @@ public class RateLimitServiceImpl implements RateLimitService {
     private final OutgoingRateLimitsConfiguration outgoingRateLimitsConfiguration;
     private final TotalMsgsRateLimitsConfiguration totalMsgsRateLimitsConfiguration;
     private final DevicePersistedMsgsRateLimitsConfiguration devicePersistedMsgsRateLimitsConfiguration;
+    private final ApplicationPersistedMsgsRateLimitsConfiguration applicationPersistedMsgsRateLimitsConfiguration;
     private final RateLimitCacheService rateLimitCacheService;
     private final ClientsLimitProperties clientsLimitProperties;
 
@@ -51,6 +53,8 @@ public class RateLimitServiceImpl implements RateLimitService {
     private ConcurrentMap<String, TbRateLimits> incomingPublishClientLimits;
     @Getter
     private ConcurrentMap<String, TbRateLimits> outgoingPublishClientLimits;
+    @Getter
+    private ConcurrentMap<String, TbRateLimits> applicationPersistedMsgClientLimits;
 
     @PostConstruct
     public void init() {
@@ -59,6 +63,9 @@ public class RateLimitServiceImpl implements RateLimitService {
         }
         if (outgoingRateLimitsConfiguration.isEnabled()) {
             outgoingPublishClientLimits = new ConcurrentHashMap<>();
+        }
+        if (applicationPersistedMsgsRateLimitsConfiguration.isEnabled()) {
+            applicationPersistedMsgClientLimits = new ConcurrentHashMap<>();
         }
     }
 
@@ -99,6 +106,9 @@ public class RateLimitServiceImpl implements RateLimitService {
             }
             if (outgoingPublishClientLimits != null) {
                 outgoingPublishClientLimits.remove(clientId);
+            }
+            if (applicationPersistedMsgClientLimits != null) {
+                applicationPersistedMsgClientLimits.remove(clientId);
             }
         }
     }
@@ -173,6 +183,21 @@ public class RateLimitServiceImpl implements RateLimitService {
     @Override
     public boolean isDevicePersistedMsgsLimitEnabled() {
         return devicePersistedMsgsRateLimitsConfiguration.isEnabled();
+    }
+
+    @Override
+    public boolean tryConsumeApplicationPersistedMsg(String clientId) {
+        if (!applicationPersistedMsgsRateLimitsConfiguration.isEnabled()) {
+            return true;
+        }
+        TbRateLimits rateLimits = applicationPersistedMsgClientLimits.computeIfAbsent(
+                clientId, id -> new TbRateLimits(applicationPersistedMsgsRateLimitsConfiguration.getClientConfig()));
+        return rateLimits.tryConsume();
+    }
+
+    @Override
+    public boolean isApplicationPersistedMsgsRateLimitEnabled() {
+        return applicationPersistedMsgsRateLimitsConfiguration.isEnabled();
     }
 
     @Override

--- a/application/src/main/java/org/thingsboard/mqtt/broker/service/limits/RateLimitServiceImpl.java
+++ b/application/src/main/java/org/thingsboard/mqtt/broker/service/limits/RateLimitServiceImpl.java
@@ -186,7 +186,7 @@ public class RateLimitServiceImpl implements RateLimitService {
     }
 
     @Override
-    public boolean tryConsumeApplicationPersistedMsg(String clientId) {
+    public boolean tryConsumeApplicationPersistedMsgs(String clientId) {
         if (!applicationPersistedMsgsRateLimitsConfiguration.isEnabled()) {
             return true;
         }

--- a/application/src/main/java/org/thingsboard/mqtt/broker/service/mqtt/persistence/application/ApplicationPersistenceProcessorImpl.java
+++ b/application/src/main/java/org/thingsboard/mqtt/broker/service/mqtt/persistence/application/ApplicationPersistenceProcessorImpl.java
@@ -457,6 +457,7 @@ public class ApplicationPersistenceProcessorImpl implements ApplicationPersisten
 
         List<PersistedMsg> messagesToDeliver = buildMessagesToDeliver(pubRelMsgCtx, clientSessionCtx, persistedMsgCtx, messages, null);
         submitStrategy.init(messagesToDeliver);
+        throttleDelivery(clientId, messagesToDeliver, () -> isClientSessionActive(sessionId, clientState));
 
         if (isDebugEnabled) {
             log.debug("[{}] Starting main pack, {} messages to deliver", clientId, messagesToDeliver.size());
@@ -562,6 +563,7 @@ public class ApplicationPersistenceProcessorImpl implements ApplicationPersisten
 
         List<PersistedMsg> messagesToDeliver = buildMessagesToDeliver(pubRelMsgCtx, clientSessionCtx, persistedMsgCtx, messages, subscription);
         submitStrategy.init(messagesToDeliver);
+        throttleDelivery(clientId, messagesToDeliver, () -> isJobActive(job));
 
         if (log.isTraceEnabled()) {
             log.trace("[{}] Starting shared subscription pack, {} messages to deliver", clientId, messagesToDeliver.size());

--- a/application/src/main/java/org/thingsboard/mqtt/broker/service/mqtt/persistence/application/ApplicationPersistenceProcessorImpl.java
+++ b/application/src/main/java/org/thingsboard/mqtt/broker/service/mqtt/persistence/application/ApplicationPersistenceProcessorImpl.java
@@ -27,6 +27,7 @@ import org.springframework.util.CollectionUtils;
 import org.thingsboard.mqtt.broker.actors.client.messages.mqtt.MqttDisconnectMsg;
 import org.thingsboard.mqtt.broker.actors.client.state.ClientActorStateInfo;
 import org.thingsboard.mqtt.broker.adaptor.ProtoConverter;
+import org.thingsboard.mqtt.broker.common.data.PersistedPacketType;
 import org.thingsboard.mqtt.broker.common.data.mqtt.MsgExpiryResult;
 import org.thingsboard.mqtt.broker.common.util.ThingsBoardExecutors;
 import org.thingsboard.mqtt.broker.gen.queue.PublishMsgProto;
@@ -38,6 +39,7 @@ import org.thingsboard.mqtt.broker.queue.common.TbProtoQueueMsg;
 import org.thingsboard.mqtt.broker.queue.provider.ApplicationPersistenceMsgQueueFactory;
 import org.thingsboard.mqtt.broker.service.analysis.ClientLogger;
 import org.thingsboard.mqtt.broker.service.historical.stats.TbMessageStatsReportClient;
+import org.thingsboard.mqtt.broker.service.limits.RateLimitService;
 import org.thingsboard.mqtt.broker.service.mqtt.MqttMsgDeliveryService;
 import org.thingsboard.mqtt.broker.service.mqtt.PublishMsg;
 import org.thingsboard.mqtt.broker.service.mqtt.persistence.application.data.ApplicationMainProcessingState;
@@ -81,6 +83,7 @@ import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
+import java.util.function.BooleanSupplier;
 import java.util.stream.Collectors;
 
 @Service
@@ -112,6 +115,7 @@ public class ApplicationPersistenceProcessorImpl implements ApplicationPersisten
     private final ApplicationClientHelperService appClientHelperService;
     private final AppMsgDeliveryStrategy appMsgDeliveryStrategy;
     private final TbMessageStatsReportClient tbMessageStatsReportClient;
+    private final RateLimitService rateLimitService;
     private final boolean isDebugEnabled = log.isDebugEnabled();
 
     @Value("${queue.application-persisted-msg.poll-interval}")
@@ -729,6 +733,38 @@ public class ApplicationPersistenceProcessorImpl implements ApplicationPersisten
 
     private void deliverMessages(ApplicationSubmitStrategy submitStrategy, ClientSessionCtx clientSessionCtx) {
         appMsgDeliveryStrategy.process(submitStrategy, clientSessionCtx);
+    }
+
+    void throttleDelivery(String clientId, List<PersistedMsg> messagesToDeliver, BooleanSupplier isActive) {
+        if (!rateLimitService.isApplicationPersistedMsgsRateLimitEnabled()) {
+            return;
+        }
+        int remaining = countPublishMsgs(messagesToDeliver);
+        while (remaining > 0) {
+            if (!isActive.getAsBoolean()) {
+                return;
+            }
+            if (rateLimitService.tryConsumeApplicationPersistedMsgs(clientId)) {
+                remaining--;
+            } else {
+                try {
+                    Thread.sleep(pollDuration);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    return;
+                }
+            }
+        }
+    }
+
+    private static int countPublishMsgs(List<PersistedMsg> messagesToDeliver) {
+        int count = 0;
+        for (PersistedMsg msg : messagesToDeliver) {
+            if (PersistedPacketType.PUBLISH == msg.getPacketType()) {
+                count++;
+            }
+        }
+        return count;
     }
 
     private void processPubAckInSharedCtx(String clientId, int packetId, String format) {

--- a/application/src/main/java/org/thingsboard/mqtt/broker/service/mqtt/persistence/application/ApplicationPersistenceProcessorImpl.java
+++ b/application/src/main/java/org/thingsboard/mqtt/broker/service/mqtt/persistence/application/ApplicationPersistenceProcessorImpl.java
@@ -742,6 +742,7 @@ public class ApplicationPersistenceProcessorImpl implements ApplicationPersisten
             return;
         }
         int remaining = countPublishMsgs(messagesToDeliver);
+        boolean throttled = false;
         while (remaining > 0) {
             if (!isActive.getAsBoolean()) {
                 return;
@@ -749,6 +750,13 @@ public class ApplicationPersistenceProcessorImpl implements ApplicationPersisten
             if (rateLimitService.tryConsumeApplicationPersistedMsgs(clientId)) {
                 remaining--;
             } else {
+                if (!throttled) {
+                    throttled = true;
+                    if (isDebugEnabled) {
+                        log.debug("[{}] Outbound rate limit reached; pacing delivery of {} remaining message(s) in this pack", clientId, remaining);
+                    }
+                }
+                // Reuse the Kafka poll interval as the throttle back-off granularity (intentionally no separate tunable).
                 try {
                     Thread.sleep(pollDuration);
                 } catch (InterruptedException e) {

--- a/application/src/main/resources/thingsboard-mqtt-broker.yml
+++ b/application/src/main/resources/thingsboard-mqtt-broker.yml
@@ -1032,7 +1032,7 @@ mqtt:
       # Enables or disables per-client outbound rate limits for persistent APPLICATION subscribers.
       # Throttles (paces) delivery without dropping messages: the Kafka backlog is retained and
       # replayed at the configured rate. Applies to the main and shared-subscription consumers.
-      enabled: "${MQTT_APP_PERSISTED_MSGS_RATE_LIMITS_ENABLED:false}"
+      enabled: "${MQTT_APPLICATION_PERSISTED_MSGS_RATE_LIMITS_ENABLED:false}"
       # Limits the count of outgoing persisted messages per APPLICATION client per time interval (in s).
       # Comma-separated list of limit:seconds pairs.
       # Example: 100 messages per second or 5000 messages per minute.
@@ -1040,7 +1040,7 @@ mqtt:
       # draining one polled pack (up to max.poll.records) takes longer than max.poll.interval.ms (default 300s),
       # otherwise the shared-subscription consumer may be evicted and its group rebalanced. The per-client
       # (non-shared) APPLICATION consumer uses manual partition assignment and is not affected.
-      client-config: "${MQTT_APP_PERSISTED_MSGS_RATE_LIMITS_CLIENT_CONFIG:100:1,5000:60}"
+      client-config: "${MQTT_APPLICATION_PERSISTED_MSGS_RATE_LIMITS_CLIENT_CONFIG:100:1,5000:60}"
   # Total limit of sessions (connected + disconnected) stored on the broker, applied collectively across the cluster, not per node.
   # For example, when set to 1000, the entire cluster can store 1000 sessions in total. This is a soft limit, meaning slightly more sessions may be stored.
   # Defaults to 0, which disables the limit.

--- a/application/src/main/resources/thingsboard-mqtt-broker.yml
+++ b/application/src/main/resources/thingsboard-mqtt-broker.yml
@@ -1028,6 +1028,15 @@ mqtt:
       # Limits the count of Device clients persisted messages per time interval (in s). Comma-separated list of limit:seconds pairs.
       # Example: 100 messages per second or 1000 messages per minute.
       config: "${MQTT_DEVICE_PERSISTED_MSGS_RATE_LIMITS_CONFIG:100:1,1000:60}"
+    application-persisted-messages:
+      # Enables or disables per-client outbound rate limits for persistent APPLICATION subscribers.
+      # Throttles (paces) delivery without dropping messages: the Kafka backlog is retained and
+      # replayed at the configured rate. Applies to the main and shared-subscription consumers.
+      enabled: "${MQTT_APP_PERSISTED_MSGS_RATE_LIMITS_ENABLED:false}"
+      # Limits the count of outgoing persisted messages per APPLICATION client per time interval (in s).
+      # Comma-separated list of limit:seconds pairs.
+      # Example: 100 messages per second or 5000 messages per minute.
+      client-config: "${MQTT_APP_PERSISTED_MSGS_RATE_LIMITS_CLIENT_CONFIG:100:1,5000:60}"
   # Total limit of sessions (connected + disconnected) stored on the broker, applied collectively across the cluster, not per node.
   # For example, when set to 1000, the entire cluster can store 1000 sessions in total. This is a soft limit, meaning slightly more sessions may be stored.
   # Defaults to 0, which disables the limit.

--- a/application/src/main/resources/thingsboard-mqtt-broker.yml
+++ b/application/src/main/resources/thingsboard-mqtt-broker.yml
@@ -1036,6 +1036,10 @@ mqtt:
       # Limits the count of outgoing persisted messages per APPLICATION client per time interval (in s).
       # Comma-separated list of limit:seconds pairs.
       # Example: 100 messages per second or 5000 messages per minute.
+      # Note: for shared subscriptions this paces a shared Kafka consumer group. Avoid a rate so low that
+      # draining one polled pack (up to max.poll.records) takes longer than max.poll.interval.ms (default 300s),
+      # otherwise the shared-subscription consumer may be evicted and its group rebalanced. The per-client
+      # (non-shared) APPLICATION consumer uses manual partition assignment and is not affected.
       client-config: "${MQTT_APP_PERSISTED_MSGS_RATE_LIMITS_CLIENT_CONFIG:100:1,5000:60}"
   # Total limit of sessions (connected + disconnected) stored on the broker, applied collectively across the cluster, not per node.
   # For example, when set to 1000, the entire cluster can store 1000 sessions in total. This is a soft limit, meaning slightly more sessions may be stored.

--- a/application/src/test/java/org/thingsboard/mqtt/broker/service/limits/RateLimitServiceImplTest.java
+++ b/application/src/test/java/org/thingsboard/mqtt/broker/service/limits/RateLimitServiceImplTest.java
@@ -29,6 +29,7 @@ import org.thingsboard.mqtt.broker.common.data.ClientSessionInfo;
 import org.thingsboard.mqtt.broker.common.data.ClientType;
 import org.thingsboard.mqtt.broker.common.data.SessionInfo;
 import org.thingsboard.mqtt.broker.common.util.TbRateLimits;
+import org.thingsboard.mqtt.broker.config.ApplicationPersistedMsgsRateLimitsConfiguration;
 import org.thingsboard.mqtt.broker.config.ClientsLimitProperties;
 import org.thingsboard.mqtt.broker.config.DevicePersistedMsgsRateLimitsConfiguration;
 import org.thingsboard.mqtt.broker.config.IncomingRateLimitsConfiguration;
@@ -55,6 +56,8 @@ public class RateLimitServiceImplTest {
     @MockitoBean
     DevicePersistedMsgsRateLimitsConfiguration devicePersistedMsgsRateLimitsConfiguration;
     @MockitoBean
+    ApplicationPersistedMsgsRateLimitsConfiguration applicationPersistedMsgsRateLimitsConfiguration;
+    @MockitoBean
     TotalMsgsRateLimitsConfiguration totalMsgsRateLimitsConfiguration;
     @MockitoBean
     RateLimitCacheService rateLimitCacheService;
@@ -69,12 +72,14 @@ public class RateLimitServiceImplTest {
         when(incomingRateLimitsConfiguration.isEnabled()).thenReturn(true);
         when(outgoingRateLimitsConfiguration.isEnabled()).thenReturn(true);
         when(devicePersistedMsgsRateLimitsConfiguration.isEnabled()).thenReturn(true);
+        when(applicationPersistedMsgsRateLimitsConfiguration.isEnabled()).thenReturn(true);
         when(totalMsgsRateLimitsConfiguration.isEnabled()).thenReturn(true);
 
         rateLimitService.init();
 
         rateLimitService.getIncomingPublishClientLimits().put(CLIENT_ID, new TbRateLimits("1:1")); // limit 1 per 1 second
         rateLimitService.getOutgoingPublishClientLimits().put(CLIENT_ID, new TbRateLimits("1:1")); // limit 1 per 1 second
+        rateLimitService.getApplicationPersistedMsgClientLimits().put(CLIENT_ID, new TbRateLimits("1:1")); // limit 1 per 1 second
     }
 
     @After
@@ -157,6 +162,7 @@ public class RateLimitServiceImplTest {
         rateLimitService.remove(CLIENT_ID);
         assertEquals(0, rateLimitService.getIncomingPublishClientLimits().size());
         assertEquals(0, rateLimitService.getOutgoingPublishClientLimits().size());
+        assertEquals(0, rateLimitService.getApplicationPersistedMsgClientLimits().size());
     }
 
     @Test
@@ -164,6 +170,7 @@ public class RateLimitServiceImplTest {
         rateLimitService.remove(null);
         assertEquals(1, rateLimitService.getIncomingPublishClientLimits().size());
         assertEquals(1, rateLimitService.getOutgoingPublishClientLimits().size());
+        assertEquals(1, rateLimitService.getApplicationPersistedMsgClientLimits().size());
     }
 
     @Test
@@ -302,5 +309,39 @@ public class RateLimitServiceImplTest {
 
         long tokens = rateLimitService.tryConsumeTotalMsgs(10L);
         assertEquals(10L, tokens);
+    }
+
+    @Test
+    public void givenAppPersistedMsgsRateLimitsDisabled_whenTryConsume_thenAlwaysTrue() {
+        when(applicationPersistedMsgsRateLimitsConfiguration.isEnabled()).thenReturn(false);
+
+        Assert.assertTrue(rateLimitService.tryConsumeApplicationPersistedMsg(CLIENT_ID));
+        Assert.assertTrue(rateLimitService.tryConsumeApplicationPersistedMsg(CLIENT_ID));
+    }
+
+    @Test
+    public void givenAppPersistedMsgsRateLimitsEnabled_whenTryConsume_thenGetExpectedResult() {
+        when(applicationPersistedMsgsRateLimitsConfiguration.isEnabled()).thenReturn(true);
+
+        Assert.assertTrue(rateLimitService.tryConsumeApplicationPersistedMsg(CLIENT_ID));
+        Assert.assertFalse(rateLimitService.tryConsumeApplicationPersistedMsg(CLIENT_ID));
+        Assert.assertFalse(rateLimitService.tryConsumeApplicationPersistedMsg(CLIENT_ID));
+    }
+
+    @Test
+    public void givenTwoClients_whenTryConsume_thenBucketsAreIndependent() {
+        when(applicationPersistedMsgsRateLimitsConfiguration.isEnabled()).thenReturn(true);
+        rateLimitService.getApplicationPersistedMsgClientLimits().put("other", new TbRateLimits("1:1"));
+
+        Assert.assertTrue(rateLimitService.tryConsumeApplicationPersistedMsg(CLIENT_ID));
+        Assert.assertTrue(rateLimitService.tryConsumeApplicationPersistedMsg("other"));
+        Assert.assertFalse(rateLimitService.tryConsumeApplicationPersistedMsg(CLIENT_ID));
+        Assert.assertFalse(rateLimitService.tryConsumeApplicationPersistedMsg("other"));
+    }
+
+    @Test
+    public void givenEnabledConfig_whenIsApplicationPersistedMsgsRateLimitEnabled_thenTrue() {
+        when(applicationPersistedMsgsRateLimitsConfiguration.isEnabled()).thenReturn(true);
+        Assert.assertTrue(rateLimitService.isApplicationPersistedMsgsRateLimitEnabled());
     }
 }

--- a/application/src/test/java/org/thingsboard/mqtt/broker/service/limits/RateLimitServiceImplTest.java
+++ b/application/src/test/java/org/thingsboard/mqtt/broker/service/limits/RateLimitServiceImplTest.java
@@ -315,17 +315,17 @@ public class RateLimitServiceImplTest {
     public void givenAppPersistedMsgsRateLimitsDisabled_whenTryConsume_thenAlwaysTrue() {
         when(applicationPersistedMsgsRateLimitsConfiguration.isEnabled()).thenReturn(false);
 
-        Assert.assertTrue(rateLimitService.tryConsumeApplicationPersistedMsg(CLIENT_ID));
-        Assert.assertTrue(rateLimitService.tryConsumeApplicationPersistedMsg(CLIENT_ID));
+        Assert.assertTrue(rateLimitService.tryConsumeApplicationPersistedMsgs(CLIENT_ID));
+        Assert.assertTrue(rateLimitService.tryConsumeApplicationPersistedMsgs(CLIENT_ID));
     }
 
     @Test
     public void givenAppPersistedMsgsRateLimitsEnabled_whenTryConsume_thenGetExpectedResult() {
         when(applicationPersistedMsgsRateLimitsConfiguration.isEnabled()).thenReturn(true);
 
-        Assert.assertTrue(rateLimitService.tryConsumeApplicationPersistedMsg(CLIENT_ID));
-        Assert.assertFalse(rateLimitService.tryConsumeApplicationPersistedMsg(CLIENT_ID));
-        Assert.assertFalse(rateLimitService.tryConsumeApplicationPersistedMsg(CLIENT_ID));
+        Assert.assertTrue(rateLimitService.tryConsumeApplicationPersistedMsgs(CLIENT_ID));
+        Assert.assertFalse(rateLimitService.tryConsumeApplicationPersistedMsgs(CLIENT_ID));
+        Assert.assertFalse(rateLimitService.tryConsumeApplicationPersistedMsgs(CLIENT_ID));
     }
 
     @Test
@@ -333,10 +333,10 @@ public class RateLimitServiceImplTest {
         when(applicationPersistedMsgsRateLimitsConfiguration.isEnabled()).thenReturn(true);
         rateLimitService.getApplicationPersistedMsgClientLimits().put("other", new TbRateLimits("1:1"));
 
-        Assert.assertTrue(rateLimitService.tryConsumeApplicationPersistedMsg(CLIENT_ID));
-        Assert.assertTrue(rateLimitService.tryConsumeApplicationPersistedMsg("other"));
-        Assert.assertFalse(rateLimitService.tryConsumeApplicationPersistedMsg(CLIENT_ID));
-        Assert.assertFalse(rateLimitService.tryConsumeApplicationPersistedMsg("other"));
+        Assert.assertTrue(rateLimitService.tryConsumeApplicationPersistedMsgs(CLIENT_ID));
+        Assert.assertTrue(rateLimitService.tryConsumeApplicationPersistedMsgs("other"));
+        Assert.assertFalse(rateLimitService.tryConsumeApplicationPersistedMsgs(CLIENT_ID));
+        Assert.assertFalse(rateLimitService.tryConsumeApplicationPersistedMsgs("other"));
     }
 
     @Test

--- a/application/src/test/java/org/thingsboard/mqtt/broker/service/mqtt/persistence/application/ApplicationPersistenceProcessorImplTest.java
+++ b/application/src/test/java/org/thingsboard/mqtt/broker/service/mqtt/persistence/application/ApplicationPersistenceProcessorImplTest.java
@@ -25,6 +25,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.thingsboard.mqtt.broker.actors.client.state.ClientActorStateInfo;
 import org.thingsboard.mqtt.broker.actors.client.state.SessionState;
+import org.thingsboard.mqtt.broker.common.data.PersistedPacketType;
 import org.thingsboard.mqtt.broker.gen.queue.PublishMsgProto;
 import org.thingsboard.mqtt.broker.queue.TbQueueAdmin;
 import org.thingsboard.mqtt.broker.queue.TbQueueControlledOffsetConsumer;
@@ -34,6 +35,7 @@ import org.thingsboard.mqtt.broker.queue.common.TbProtoQueueMsg;
 import org.thingsboard.mqtt.broker.queue.provider.ApplicationPersistenceMsgQueueFactory;
 import org.thingsboard.mqtt.broker.service.analysis.ClientLogger;
 import org.thingsboard.mqtt.broker.service.historical.stats.TbMessageStatsReportClient;
+import org.thingsboard.mqtt.broker.service.limits.RateLimitService;
 import org.thingsboard.mqtt.broker.service.mqtt.MqttMsgDeliveryService;
 import org.thingsboard.mqtt.broker.service.mqtt.PublishMsg;
 import org.thingsboard.mqtt.broker.service.mqtt.persistence.application.data.ApplicationMainProcessingState;
@@ -52,6 +54,7 @@ import org.thingsboard.mqtt.broker.service.mqtt.persistence.application.processi
 import org.thingsboard.mqtt.broker.service.mqtt.persistence.application.processing.ApplicationPubRelMsgCtx;
 import org.thingsboard.mqtt.broker.service.mqtt.persistence.application.processing.ApplicationSubmitStrategyFactory;
 import org.thingsboard.mqtt.broker.service.mqtt.persistence.application.processing.BurstSubmitStrategy;
+import org.thingsboard.mqtt.broker.service.mqtt.persistence.application.processing.PersistedMsg;
 import org.thingsboard.mqtt.broker.service.mqtt.persistence.application.processing.PersistedPubRelMsg;
 import org.thingsboard.mqtt.broker.service.mqtt.persistence.application.processing.PersistedPublishMsg;
 import org.thingsboard.mqtt.broker.service.mqtt.persistence.application.topic.ApplicationTopicService;
@@ -83,6 +86,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.doAnswer;
@@ -112,6 +116,7 @@ class ApplicationPersistenceProcessorImplTest {
     @Mock ApplicationClientHelperService appClientHelperService;
     @Mock AppMsgDeliveryStrategy appMsgDeliveryStrategy;
     @Mock TbMessageStatsReportClient tbMessageStatsReportClient;
+    @Mock RateLimitService rateLimitService;
 
     @InjectMocks
     ApplicationPersistenceProcessorImpl processor;
@@ -573,6 +578,58 @@ class ApplicationPersistenceProcessorImplTest {
 
         // The ack strategy must be created once per pack and reused across retries so the cap accumulates.
         verify(acknowledgeStrategyFactory, times(1)).newInstance("appClient");
+    }
+
+    @Test
+    public void givenRateLimitDisabled_whenThrottleDelivery_thenNoTokensConsumed() {
+        when(rateLimitService.isApplicationPersistedMsgsRateLimitEnabled()).thenReturn(false);
+
+        PersistedMsg publish = mock(PersistedMsg.class);
+        processor.throttleDelivery("clientId", List.of(publish, publish), () -> true);
+
+        verify(rateLimitService, never()).tryConsumeApplicationPersistedMsgs(anyString());
+    }
+
+    @Test
+    public void givenRateLimitEnabled_whenThrottleDelivery_thenConsumesOneTokenPerPublish() {
+        when(rateLimitService.isApplicationPersistedMsgsRateLimitEnabled()).thenReturn(true);
+        when(rateLimitService.tryConsumeApplicationPersistedMsgs(anyString())).thenReturn(true);
+
+        PersistedMsg publish = mock(PersistedMsg.class);
+        when(publish.getPacketType()).thenReturn(PersistedPacketType.PUBLISH);
+        PersistedMsg pubRel = mock(PersistedMsg.class);
+        when(pubRel.getPacketType()).thenReturn(PersistedPacketType.PUBREL);
+
+        processor.throttleDelivery("clientId", List.of(publish, pubRel, publish), () -> true);
+
+        verify(rateLimitService, times(2)).tryConsumeApplicationPersistedMsgs("clientId");
+    }
+
+    @Test
+    public void givenSessionInactive_whenThrottleDelivery_thenReturnsWithoutConsuming() {
+        when(rateLimitService.isApplicationPersistedMsgsRateLimitEnabled()).thenReturn(true);
+
+        PersistedMsg publish = mock(PersistedMsg.class);
+        when(publish.getPacketType()).thenReturn(PersistedPacketType.PUBLISH);
+
+        processor.throttleDelivery("clientId", List.of(publish, publish), () -> false);
+
+        verify(rateLimitService, never()).tryConsumeApplicationPersistedMsgs(anyString());
+    }
+
+    @Test
+    public void givenBucketEmptyThenRefilled_whenThrottleDelivery_thenRetriesUntilConsumed() {
+        ReflectionTestUtils.setField(processor, "pollDuration", 1L);
+        when(rateLimitService.isApplicationPersistedMsgsRateLimitEnabled()).thenReturn(true);
+        when(rateLimitService.tryConsumeApplicationPersistedMsgs(anyString()))
+                .thenReturn(false, false, true);
+
+        PersistedMsg publish = mock(PersistedMsg.class);
+        when(publish.getPacketType()).thenReturn(PersistedPacketType.PUBLISH);
+
+        processor.throttleDelivery("clientId", List.of(publish), () -> true);
+
+        verify(rateLimitService, times(3)).tryConsumeApplicationPersistedMsgs("clientId");
     }
 
     // ===== Helpers =====


### PR DESCRIPTION
## Pull Request description

Closes #305.

Adds an **opt-in, per-APPLICATION-client outbound rate limit** that *paces* (throttles) delivery of persisted messages instead of dropping them. When a persistent APPLICATION subscriber reconnects after being offline, its Kafka backlog is currently replayed at full speed, which can overwhelm subscribers that auto-ACK and buffer internally. This throttles delivery to a configured rate, smoothing the replay into steady chunks. **No data loss**: offsets are committed only after acks and the backlog stays in Kafka — the per-client consumer thread is simply paced.

**Scope of changes:**
- New opt-in config `mqtt.rate-limits.application-persisted-messages` (`enabled` + `client-config`, same `limit:seconds,...` format as the other limiters; default **off**). Env vars `MQTT_APPLICATION_PERSISTED_MSGS_RATE_LIMITS_ENABLED` / `..._CLIENT_CONFIG`.
- `RateLimitService`: per-client `TbRateLimits` bucket (reusing the existing bucket4j framework) with `tryConsumeApplicationPersistedMsgs` / `isApplicationPersistedMsgsRateLimitEnabled`; cleanup rides the existing `remove(clientId)` on disconnect.
- `ApplicationPersistenceProcessorImpl`: a session-aware throttle gate applied once per pack before delivery (in both the main and shared-subscription loops, before the retry loop so QoS retransmissions don't double-count; counts PUBLISH only).

**Documentation notes:** document the new setting/env vars and the shared-subscription caveat (avoid a rate so low that draining one polled pack takes longer than `max.poll.interval.ms`, or the shared consumer group may rebalance — the per-client main consumer uses manual partition assignment and is unaffected). A follow-up ticket will add a safeguard for that shared-subscription edge case.

## General checklist

- [ ] You have reviewed the guidelines [document](https://docs.google.com/document/d/1A4Vc3wrHsY_159b9RG5LOtCryoH6VPwgOhrFEzJKwbI/edit?usp=sharing).
- [ ] [Labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels#about-labels) that classify your pull request have been added.
- [ ] The [milestone](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones) is specified and corresponds to fix version.
- [x] Description references specific [issue](https://github.com/thingsboard/tbmq/issues). (#305)
- [x] Description contains human-readable scope of changes.
- [x] Description contains brief notes about what needs to be added to the documentation.
- [x] No merge conflicts, commented blocks of code, code formatting issues.
- [x] Changes are backward compatible or upgrade script is provided. (opt-in, default off)

## Front-End feature checklist

- [x] N/A — no front-end changes.

## Back-End feature checklist

- [x] Added corresponding unit and/or integration test(s). (`RateLimitServiceImplTest`, `ApplicationPersistenceProcessorImplTest`)
- [x] If new dependency was added: the dependency tree is checked for conflicts. (no new dependency)
