### PR TITLE
fix(limits): apply a changed rate limit configuration to an existing bucket

### DIFF
--- a/application/src/main/java/org/thingsboard/mqtt/broker/service/limits/RateLimitRedisCacheServiceImpl.java
+++ b/application/src/main/java/org/thingsboard/mqtt/broker/service/limits/RateLimitRedisCacheServiceImpl.java
@@ -17,6 +17,7 @@ package org.thingsboard.mqtt.broker.service.limits;
 
 import io.github.bucket4j.Bucket;
 import io.github.bucket4j.BucketConfiguration;
+import io.github.bucket4j.TokensInheritanceStrategy;
 import io.github.bucket4j.distributed.BucketProxy;
 import io.github.bucket4j.redis.jedis.cas.JedisBasedProxyManager;
 import jakarta.annotation.PostConstruct;
@@ -63,10 +64,10 @@ public class RateLimitRedisCacheServiceImpl implements RateLimitCacheService {
         var devicePersistedMsgsLimitCacheKey = cacheProperties.prefixKey(CacheConstants.DEVICE_PERSISTED_MSGS_LIMIT_CACHE);
         var totalMsgsLimitCacheKey = cacheProperties.prefixKey(CacheConstants.TOTAL_MSGS_LIMIT_CACHE);
 
-        this.devicePersistedMsgsBucketProxy = devicePersistedMsgsBucketConfiguration == null ? null :
-                jedisBasedProxyManager.getProxy(devicePersistedMsgsLimitCacheKey, () -> devicePersistedMsgsBucketConfiguration);
-        this.totalMsgsBucketProxy = totalMsgsBucketConfiguration == null ? null :
-                jedisBasedProxyManager.getProxy(totalMsgsLimitCacheKey, () -> totalMsgsBucketConfiguration);
+        this.devicePersistedMsgsBucketProxy = initBucketProxy(devicePersistedMsgsLimitCacheKey,
+                devicePersistedMsgsBucketConfiguration, "device persisted messages");
+        this.totalMsgsBucketProxy = initBucketProxy(totalMsgsLimitCacheKey,
+                totalMsgsBucketConfiguration, "total messages");
 
         if (clientsLimitProperties.isSessionsLimitEnabled()) {
             clientSessionsLimitCacheKey = cacheProperties.prefixKey(CacheConstants.CLIENT_SESSIONS_LIMIT_CACHE_KEY);
@@ -74,6 +75,27 @@ public class RateLimitRedisCacheServiceImpl implements RateLimitCacheService {
         if (clientsLimitProperties.isApplicationClientsLimitEnabled()) {
             appClientsLimitCacheKey = cacheProperties.prefixKey(CacheConstants.APP_CLIENTS_LIMIT_CACHE_KEY);
         }
+    }
+
+    private BucketProxy initBucketProxy(String key, BucketConfiguration configuration, String name) {
+        if (configuration == null) {
+            // The limit is disabled, so there is no configuration to compare against. Any existing bucket is
+            // deliberately left in place: removing it would let a single misconfigured node wipe the bucket the
+            // rest of the cluster is metering against.
+            return null;
+        }
+        BucketProxy proxy = jedisBasedProxyManager.getProxy(key, () -> configuration);
+        // getProxy() consults the supplier ONLY when the key is absent, and the bucket key carries no TTL, so an
+        // existing bucket keeps the configuration it was first created with forever. Without the replacement
+        // below, editing mqtt.rate-limits.* has no effect on any deployment that has already run once.
+        jedisBasedProxyManager.getProxyConfiguration(key)
+                .filter(stored -> !stored.equalsByContent(configuration))
+                .ifPresent(stored -> {
+                    proxy.replaceConfiguration(configuration, TokensInheritanceStrategy.PROPORTIONALLY);
+                    log.info("[{}] Replaced stale {} rate limit configuration {} with {}", key, name, stored, configuration);
+                });
+        log.info("[{}] Effective {} rate limit configuration: {}", key, name, configuration);
+        return proxy;
     }
 
     @Override

--- a/application/src/main/java/org/thingsboard/mqtt/broker/service/limits/RateLimitRedisCacheServiceImpl.java
+++ b/application/src/main/java/org/thingsboard/mqtt/broker/service/limits/RateLimitRedisCacheServiceImpl.java
@@ -23,6 +23,7 @@ import io.github.bucket4j.redis.jedis.cas.JedisBasedProxyManager;
 import jakarta.annotation.PostConstruct;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 import org.thingsboard.mqtt.broker.cache.CacheConstants;
@@ -47,8 +48,12 @@ public class RateLimitRedisCacheServiceImpl implements RateLimitCacheService {
 
     public RateLimitRedisCacheServiceImpl(RedisTemplate<String, Object> redisTemplate,
                                           JedisBasedProxyManager<String> jedisBasedProxyManager,
-                                          @Autowired(required = false) BucketConfiguration devicePersistedMsgsBucketConfiguration,
-                                          @Autowired(required = false) BucketConfiguration totalMsgsBucketConfiguration,
+                                          @Autowired(required = false)
+                                          @Qualifier("devicePersistedMsgsBucketConfiguration")
+                                          BucketConfiguration devicePersistedMsgsBucketConfiguration,
+                                          @Autowired(required = false)
+                                          @Qualifier("totalMsgsBucketConfiguration")
+                                          BucketConfiguration totalMsgsBucketConfiguration,
                                           CacheProperties cacheProperties,
                                           ClientsLimitProperties clientsLimitProperties) {
         this.redisTemplate = redisTemplate;

--- a/application/src/main/java/org/thingsboard/mqtt/broker/service/limits/RateLimitRedisCacheServiceImpl.java
+++ b/application/src/main/java/org/thingsboard/mqtt/broker/service/limits/RateLimitRedisCacheServiceImpl.java
@@ -87,6 +87,7 @@ public class RateLimitRedisCacheServiceImpl implements RateLimitCacheService {
             // The limit is disabled, so there is no configuration to compare against. Any existing bucket is
             // deliberately left in place: removing it would let a single misconfigured node wipe the bucket the
             // rest of the cluster is metering against.
+            log.info("[{}] The {} rate limit is disabled, any bucket already stored under this key is left untouched", key, name);
             return null;
         }
         BucketProxy proxy = jedisBasedProxyManager.getProxy(key, () -> configuration);
@@ -99,7 +100,9 @@ public class RateLimitRedisCacheServiceImpl implements RateLimitCacheService {
                     proxy.replaceConfiguration(configuration, TokensInheritanceStrategy.PROPORTIONALLY);
                     log.info("[{}] Replaced stale {} rate limit configuration {} with {}", key, name, stored, configuration);
                 });
-        log.info("[{}] Effective {} rate limit configuration: {}", key, name, configuration);
+        // This is what the node asked for, not necessarily what is stored: in a cluster whose nodes disagree the
+        // last writer wins, so re-reading the key here would still not give a durable answer.
+        log.info("[{}] Configured {} rate limit configuration: {}", key, name, configuration);
         return proxy;
     }
 

--- a/application/src/main/java/org/thingsboard/mqtt/broker/service/limits/RateLimitRedisCacheServiceImpl.java
+++ b/application/src/main/java/org/thingsboard/mqtt/broker/service/limits/RateLimitRedisCacheServiceImpl.java
@@ -29,10 +29,15 @@ import org.springframework.stereotype.Service;
 import org.thingsboard.mqtt.broker.cache.CacheConstants;
 import org.thingsboard.mqtt.broker.cache.CacheProperties;
 import org.thingsboard.mqtt.broker.config.ClientsLimitProperties;
+import org.thingsboard.mqtt.broker.config.DevicePersistedMsgsRateLimitsConfiguration;
+import org.thingsboard.mqtt.broker.config.TotalMsgsRateLimitsConfiguration;
 
 @Slf4j
 @Service
 public class RateLimitRedisCacheServiceImpl implements RateLimitCacheService {
+
+    static final String DEVICE_PERSISTED_MSGS_BUCKET_CONFIGURATION_BEAN = "devicePersistedMsgsBucketConfiguration";
+    static final String TOTAL_MSGS_BUCKET_CONFIGURATION_BEAN = "totalMsgsBucketConfiguration";
 
     private final RedisTemplate<String, Object> redisTemplate;
     private final JedisBasedProxyManager<String> jedisBasedProxyManager;
@@ -40,6 +45,8 @@ public class RateLimitRedisCacheServiceImpl implements RateLimitCacheService {
     private final BucketConfiguration totalMsgsBucketConfiguration;
     private final CacheProperties cacheProperties;
     private final ClientsLimitProperties clientsLimitProperties;
+    private final DevicePersistedMsgsRateLimitsConfiguration devicePersistedMsgsRateLimitsConfiguration;
+    private final TotalMsgsRateLimitsConfiguration totalMsgsRateLimitsConfiguration;
 
     private BucketProxy devicePersistedMsgsBucketProxy;
     private BucketProxy totalMsgsBucketProxy;
@@ -49,23 +56,34 @@ public class RateLimitRedisCacheServiceImpl implements RateLimitCacheService {
     public RateLimitRedisCacheServiceImpl(RedisTemplate<String, Object> redisTemplate,
                                           JedisBasedProxyManager<String> jedisBasedProxyManager,
                                           @Autowired(required = false)
-                                          @Qualifier("devicePersistedMsgsBucketConfiguration")
+                                          @Qualifier(DEVICE_PERSISTED_MSGS_BUCKET_CONFIGURATION_BEAN)
                                           BucketConfiguration devicePersistedMsgsBucketConfiguration,
                                           @Autowired(required = false)
-                                          @Qualifier("totalMsgsBucketConfiguration")
+                                          @Qualifier(TOTAL_MSGS_BUCKET_CONFIGURATION_BEAN)
                                           BucketConfiguration totalMsgsBucketConfiguration,
                                           CacheProperties cacheProperties,
-                                          ClientsLimitProperties clientsLimitProperties) {
+                                          ClientsLimitProperties clientsLimitProperties,
+                                          DevicePersistedMsgsRateLimitsConfiguration devicePersistedMsgsRateLimitsConfiguration,
+                                          TotalMsgsRateLimitsConfiguration totalMsgsRateLimitsConfiguration) {
         this.redisTemplate = redisTemplate;
         this.jedisBasedProxyManager = jedisBasedProxyManager;
         this.devicePersistedMsgsBucketConfiguration = devicePersistedMsgsBucketConfiguration;
         this.totalMsgsBucketConfiguration = totalMsgsBucketConfiguration;
         this.cacheProperties = cacheProperties;
         this.clientsLimitProperties = clientsLimitProperties;
+        this.devicePersistedMsgsRateLimitsConfiguration = devicePersistedMsgsRateLimitsConfiguration;
+        this.totalMsgsRateLimitsConfiguration = totalMsgsRateLimitsConfiguration;
     }
 
     @PostConstruct
     public void init() {
+        verifyBucketConfigurationPresent(devicePersistedMsgsRateLimitsConfiguration.isEnabled(),
+                devicePersistedMsgsBucketConfiguration,
+                "mqtt.rate-limits.device-persisted-messages", DEVICE_PERSISTED_MSGS_BUCKET_CONFIGURATION_BEAN);
+        verifyBucketConfigurationPresent(totalMsgsRateLimitsConfiguration.isEnabled(),
+                totalMsgsBucketConfiguration,
+                "mqtt.rate-limits.total", TOTAL_MSGS_BUCKET_CONFIGURATION_BEAN);
+
         var devicePersistedMsgsLimitCacheKey = cacheProperties.prefixKey(CacheConstants.DEVICE_PERSISTED_MSGS_LIMIT_CACHE);
         var totalMsgsLimitCacheKey = cacheProperties.prefixKey(CacheConstants.TOTAL_MSGS_LIMIT_CACHE);
 
@@ -79,6 +97,22 @@ public class RateLimitRedisCacheServiceImpl implements RateLimitCacheService {
         }
         if (clientsLimitProperties.isApplicationClientsLimitEnabled()) {
             appClientsLimitCacheKey = cacheProperties.prefixKey(CacheConstants.APP_CLIENTS_LIMIT_CACHE_KEY);
+        }
+    }
+
+    /**
+     * A limit's enabled flag and its {@link BucketConfiguration} bean are two independent derivations of the same
+     * {@code mqtt.rate-limits.*.enabled} property: the flag comes from the properties bean, the configuration from a
+     * {@code @Conditional @Bean} that reaches the constructor BY NAME through {@code @Qualifier}. Nothing forces the
+     * two to agree - renaming the bean method being the obvious way to break it - and the consequence is not graceful
+     * degradation: every caller passes its {@code isXxxLimitEnabled()} guard and then meters against a null bucket,
+     * which is an NPE per published message on the hot path. Refuse to start instead.
+     */
+    private static void verifyBucketConfigurationPresent(boolean limitEnabled, BucketConfiguration configuration,
+                                                         String propertyPrefix, String expectedBeanName) {
+        if (limitEnabled && configuration == null) {
+            throw new IllegalStateException(propertyPrefix + ".enabled is true but no BucketConfiguration was injected;"
+                    + " expected a bean named '" + expectedBeanName + "'");
         }
     }
 

--- a/application/src/main/resources/thingsboard-mqtt-broker.yml
+++ b/application/src/main/resources/thingsboard-mqtt-broker.yml
@@ -1019,6 +1019,8 @@ mqtt:
       enabled: "${MQTT_TOTAL_RATE_LIMITS_ENABLED:false}"
       # Limits the total count of incoming and outgoing messages per time interval (in s). Comma-separated list of limit:seconds pairs.
       # Example: 1000 messages per second or 50000 messages per minute.
+      # Applied on broker start. Changing this value resets the token counters across the cluster when more than one
+      # limit:seconds pair is configured, granting one full interval of fresh budget.
       config: "${MQTT_TOTAL_RATE_LIMITS_CONFIG:1000:1,50000:60}"
     incoming-publish:
       # Enables or disables publish rate limits per client for incoming messages to the broker.
@@ -1037,6 +1039,8 @@ mqtt:
       enabled: "${MQTT_DEVICE_PERSISTED_MSGS_RATE_LIMITS_ENABLED:false}"
       # Limits the count of Device clients persisted messages per time interval (in s). Comma-separated list of limit:seconds pairs.
       # Example: 100 messages per second or 1000 messages per minute.
+      # Applied on broker start. Changing this value resets the token counters across the cluster when more than one
+      # limit:seconds pair is configured, granting one full interval of fresh budget.
       config: "${MQTT_DEVICE_PERSISTED_MSGS_RATE_LIMITS_CONFIG:100:1,1000:60}"
   # Total limit of sessions (connected + disconnected) stored on the broker, applied collectively across the cluster, not per node.
   # For example, when set to 1000, the entire cluster can store 1000 sessions in total. This is a soft limit, meaning slightly more sessions may be stored.

--- a/application/src/test/java/org/thingsboard/mqtt/broker/service/limits/RateLimitBucketConfigurationInjectionTest.java
+++ b/application/src/test/java/org/thingsboard/mqtt/broker/service/limits/RateLimitBucketConfigurationInjectionTest.java
@@ -15,20 +15,22 @@
  */
 package org.thingsboard.mqtt.broker.service.limits;
 
-import io.github.bucket4j.Bandwidth;
 import io.github.bucket4j.BucketConfiguration;
 import io.github.bucket4j.distributed.BucketProxy;
 import io.github.bucket4j.redis.jedis.cas.JedisBasedProxyManager;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.test.util.TestPropertyValues;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.thingsboard.mqtt.broker.cache.CacheConstants;
 import org.thingsboard.mqtt.broker.cache.CacheProperties;
 import org.thingsboard.mqtt.broker.config.ClientsLimitProperties;
+import org.thingsboard.mqtt.broker.config.DevicePersistedMsgsRateLimitsConfiguration;
+import org.thingsboard.mqtt.broker.config.TotalMsgsRateLimitsConfiguration;
 
-import java.time.Duration;
 import java.util.Optional;
 import java.util.function.Supplier;
 
@@ -46,55 +48,79 @@ import static org.mockito.Mockito.when;
  * exactly one of them is enabled there is a single candidate of the type, so the two constructor parameters must be
  * qualified by bean name - otherwise Spring injects the one surviving bean into BOTH parameters and the disabled
  * limit's Redis key gets read and rewritten with the other limit's numbers.
+ * <p>
+ * The contract under test is therefore a bean-name-to-{@code @Qualifier} one, which means the bean names have to be
+ * the production ones: {@link TotalMsgsRateLimitsConfiguration} and {@link DevicePersistedMsgsRateLimitsConfiguration}
+ * are registered here as-is and switched on through the same {@code mqtt.rate-limits.*} properties an operator sets,
+ * rather than being restated by local stand-ins. Renaming a production {@code @Bean} method has to break this test,
+ * not slip past it - which is also why each assertion compares against the bean looked up BY NAME instead of just
+ * checking the capacity that reached the parameter.
+ * <p>
+ * Both configuration classes are always registered, exactly as component scanning would have them in production; it
+ * is only their {@code @Conditional} {@code @Bean} methods that the properties below switch on and off.
  */
 public class RateLimitBucketConfigurationInjectionTest {
 
-    private static final long TOTAL_CAPACITY = 50_000L;
-    private static final long DEVICE_CAPACITY = 1_000L;
+    private static final String TOTAL_MSGS_BUCKET_CONFIGURATION_BEAN = "totalMsgsBucketConfiguration";
+    private static final String DEVICE_PERSISTED_MSGS_BUCKET_CONFIGURATION_BEAN = "devicePersistedMsgsBucketConfiguration";
+
+    private static final String[] TOTAL_MSGS_LIMIT_ENABLED = {
+            "mqtt.rate-limits.total.enabled=true",
+            "mqtt.rate-limits.total.config=1000:1,50000:60"
+    };
+    private static final String[] DEVICE_PERSISTED_MSGS_LIMIT_ENABLED = {
+            "mqtt.rate-limits.device-persisted-messages.enabled=true",
+            "mqtt.rate-limits.device-persisted-messages.config=100:1,1000:60"
+    };
 
     @Test
     public void givenOnlyTotalMsgsLimitEnabled_whenInit_thenDeviceBucketIsNeverTouched() {
-        try (AnnotationConfigApplicationContext ctx = newContext(TotalMsgsLimitBean.class)) {
+        try (AnnotationConfigApplicationContext ctx = newContext(TOTAL_MSGS_LIMIT_ENABLED)) {
             JedisBasedProxyManager<String> proxyManager = proxyManagerOf(ctx);
 
             verify(proxyManager, never()).getProxy(eq(CacheConstants.DEVICE_PERSISTED_MSGS_LIMIT_CACHE), any());
             verify(proxyManager, never()).getProxyConfiguration(CacheConstants.DEVICE_PERSISTED_MSGS_LIMIT_CACHE);
 
-            assertThat(capacityOfConfigurationPassedTo(proxyManager, CacheConstants.TOTAL_MSGS_LIMIT_CACHE))
-                    .isEqualTo(TOTAL_CAPACITY);
+            assertThat(configurationPassedTo(proxyManager, CacheConstants.TOTAL_MSGS_LIMIT_CACHE))
+                    .isSameAs(bucketConfigurationBean(ctx, TOTAL_MSGS_BUCKET_CONFIGURATION_BEAN));
         }
     }
 
     @Test
     public void givenOnlyDevicePersistedMsgsLimitEnabled_whenInit_thenTotalBucketIsNeverTouched() {
-        try (AnnotationConfigApplicationContext ctx = newContext(DevicePersistedMsgsLimitBean.class)) {
+        try (AnnotationConfigApplicationContext ctx = newContext(DEVICE_PERSISTED_MSGS_LIMIT_ENABLED)) {
             JedisBasedProxyManager<String> proxyManager = proxyManagerOf(ctx);
 
             verify(proxyManager, never()).getProxy(eq(CacheConstants.TOTAL_MSGS_LIMIT_CACHE), any());
             verify(proxyManager, never()).getProxyConfiguration(CacheConstants.TOTAL_MSGS_LIMIT_CACHE);
 
-            assertThat(capacityOfConfigurationPassedTo(proxyManager, CacheConstants.DEVICE_PERSISTED_MSGS_LIMIT_CACHE))
-                    .isEqualTo(DEVICE_CAPACITY);
+            assertThat(configurationPassedTo(proxyManager, CacheConstants.DEVICE_PERSISTED_MSGS_LIMIT_CACHE))
+                    .isSameAs(bucketConfigurationBean(ctx, DEVICE_PERSISTED_MSGS_BUCKET_CONFIGURATION_BEAN));
         }
     }
 
     @Test
     public void givenBothLimitsEnabled_whenInit_thenEachBucketGetsItsOwnConfiguration() {
         try (AnnotationConfigApplicationContext ctx =
-                     newContext(TotalMsgsLimitBean.class, DevicePersistedMsgsLimitBean.class)) {
+                     newContext(TOTAL_MSGS_LIMIT_ENABLED, DEVICE_PERSISTED_MSGS_LIMIT_ENABLED)) {
             JedisBasedProxyManager<String> proxyManager = proxyManagerOf(ctx);
 
-            assertThat(capacityOfConfigurationPassedTo(proxyManager, CacheConstants.TOTAL_MSGS_LIMIT_CACHE))
-                    .isEqualTo(TOTAL_CAPACITY);
-            assertThat(capacityOfConfigurationPassedTo(proxyManager, CacheConstants.DEVICE_PERSISTED_MSGS_LIMIT_CACHE))
-                    .isEqualTo(DEVICE_CAPACITY);
+            assertThat(configurationPassedTo(proxyManager, CacheConstants.TOTAL_MSGS_LIMIT_CACHE))
+                    .isSameAs(bucketConfigurationBean(ctx, TOTAL_MSGS_BUCKET_CONFIGURATION_BEAN));
+            assertThat(configurationPassedTo(proxyManager, CacheConstants.DEVICE_PERSISTED_MSGS_LIMIT_CACHE))
+                    .isSameAs(bucketConfigurationBean(ctx, DEVICE_PERSISTED_MSGS_BUCKET_CONFIGURATION_BEAN));
         }
     }
 
-    private static AnnotationConfigApplicationContext newContext(Class<?>... enabledLimitConfigurations) {
+    private static AnnotationConfigApplicationContext newContext(String[]... enabledLimitProperties) {
         AnnotationConfigApplicationContext ctx = new AnnotationConfigApplicationContext();
-        ctx.register(MockedInfrastructure.class, RateLimitRedisCacheServiceImpl.class);
-        ctx.register(enabledLimitConfigurations);
+        for (String[] properties : enabledLimitProperties) {
+            TestPropertyValues.of(properties).applyTo(ctx);
+        }
+        ctx.register(MockedInfrastructure.class,
+                TotalMsgsRateLimitsConfiguration.class,
+                DevicePersistedMsgsRateLimitsConfiguration.class,
+                RateLimitRedisCacheServiceImpl.class);
         ctx.refresh();
         return ctx;
     }
@@ -104,45 +130,27 @@ public class RateLimitBucketConfigurationInjectionTest {
         return ctx.getBean(JedisBasedProxyManager.class);
     }
 
-    private static long capacityOfConfigurationPassedTo(JedisBasedProxyManager<String> proxyManager, String key) {
+    /**
+     * Fails with {@code NoSuchBeanDefinitionException} if the production {@code @Bean} method is ever renamed away
+     * from the name the constructor {@code @Qualifier} asks for - which is the drift this test exists to catch.
+     */
+    private static BucketConfiguration bucketConfigurationBean(AnnotationConfigApplicationContext ctx, String beanName) {
+        return ctx.getBean(beanName, BucketConfiguration.class);
+    }
+
+    private static BucketConfiguration configurationPassedTo(JedisBasedProxyManager<String> proxyManager, String key) {
         @SuppressWarnings("unchecked")
         ArgumentCaptor<Supplier<BucketConfiguration>> captor = ArgumentCaptor.forClass(Supplier.class);
         verify(proxyManager).getProxy(eq(key), captor.capture());
-        return captor.getValue().get().getBandwidths()[0].getCapacity();
+        return captor.getValue().get();
     }
 
-    private static BucketConfiguration bucketConfiguration(long capacity) {
-        return BucketConfiguration.builder()
-                .addLimit(Bandwidth.builder()
-                        .capacity(capacity)
-                        .refillGreedy(capacity, Duration.ofSeconds(1))
-                        .build())
-                .build();
-    }
-
-    // These bean holders are deliberately NOT annotated with @Configuration: AbstractPubSubIntegrationTest scans
-    // the whole org.thingsboard.mqtt.broker package, and a stereotyped nested class here would be swept into every
-    // integration test context and override the real beans. Without the stereotype they are only picked up by the
-    // explicit register() call above, in Spring's "lite" @Bean mode.
-    static class TotalMsgsLimitBean {
-
-        // The method name is the bean name, and it is what the constructor @Qualifier asks for. Keep it in
-        // sync with TotalMsgsRateLimitsConfiguration#totalMsgsBucketConfiguration.
-        @Bean
-        public BucketConfiguration totalMsgsBucketConfiguration() {
-            return bucketConfiguration(TOTAL_CAPACITY);
-        }
-    }
-
-    static class DevicePersistedMsgsLimitBean {
-
-        // Keep in sync with DevicePersistedMsgsRateLimitsConfiguration#devicePersistedMsgsBucketConfiguration.
-        @Bean
-        public BucketConfiguration devicePersistedMsgsBucketConfiguration() {
-            return bucketConfiguration(DEVICE_CAPACITY);
-        }
-    }
-
+    // Deliberately NOT annotated with @Configuration: AbstractPubSubIntegrationTest scans the whole
+    // org.thingsboard.mqtt.broker package, and a stereotyped nested class here would be swept into every integration
+    // test context and override the real beans. Without the stereotype it is only picked up by the explicit
+    // register() call above, in Spring's "lite" @Bean mode. @EnableConfigurationProperties is not a stereotype, and
+    // is what binds mqtt.rate-limits.* onto the two registered configuration classes in a plain context.
+    @EnableConfigurationProperties
     static class MockedInfrastructure {
 
         // The mocks have to be usable from the service's @PostConstruct, which runs while the context refreshes,

--- a/application/src/test/java/org/thingsboard/mqtt/broker/service/limits/RateLimitBucketConfigurationInjectionTest.java
+++ b/application/src/test/java/org/thingsboard/mqtt/broker/service/limits/RateLimitBucketConfigurationInjectionTest.java
@@ -1,0 +1,177 @@
+/**
+ * Copyright © 2016-2026 The Thingsboard Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.thingsboard.mqtt.broker.service.limits;
+
+import io.github.bucket4j.Bandwidth;
+import io.github.bucket4j.BucketConfiguration;
+import io.github.bucket4j.distributed.BucketProxy;
+import io.github.bucket4j.redis.jedis.cas.JedisBasedProxyManager;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.thingsboard.mqtt.broker.cache.CacheConstants;
+import org.thingsboard.mqtt.broker.cache.CacheProperties;
+import org.thingsboard.mqtt.broker.config.ClientsLimitProperties;
+
+import java.time.Duration;
+import java.util.Optional;
+import java.util.function.Supplier;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Both {@code BucketConfiguration} beans are optional: each is registered only when its limit is enabled. When
+ * exactly one of them is enabled there is a single candidate of the type, so the two constructor parameters must be
+ * qualified by bean name - otherwise Spring injects the one surviving bean into BOTH parameters and the disabled
+ * limit's Redis key gets read and rewritten with the other limit's numbers.
+ */
+public class RateLimitBucketConfigurationInjectionTest {
+
+    private static final long TOTAL_CAPACITY = 50_000L;
+    private static final long DEVICE_CAPACITY = 1_000L;
+
+    @Test
+    public void givenOnlyTotalMsgsLimitEnabled_whenInit_thenDeviceBucketIsNeverTouched() {
+        try (AnnotationConfigApplicationContext ctx = newContext(TotalMsgsLimitBean.class)) {
+            JedisBasedProxyManager<String> proxyManager = proxyManagerOf(ctx);
+
+            verify(proxyManager, never()).getProxy(eq(CacheConstants.DEVICE_PERSISTED_MSGS_LIMIT_CACHE), any());
+            verify(proxyManager, never()).getProxyConfiguration(CacheConstants.DEVICE_PERSISTED_MSGS_LIMIT_CACHE);
+
+            assertThat(capacityOfConfigurationPassedTo(proxyManager, CacheConstants.TOTAL_MSGS_LIMIT_CACHE))
+                    .isEqualTo(TOTAL_CAPACITY);
+        }
+    }
+
+    @Test
+    public void givenOnlyDevicePersistedMsgsLimitEnabled_whenInit_thenTotalBucketIsNeverTouched() {
+        try (AnnotationConfigApplicationContext ctx = newContext(DevicePersistedMsgsLimitBean.class)) {
+            JedisBasedProxyManager<String> proxyManager = proxyManagerOf(ctx);
+
+            verify(proxyManager, never()).getProxy(eq(CacheConstants.TOTAL_MSGS_LIMIT_CACHE), any());
+            verify(proxyManager, never()).getProxyConfiguration(CacheConstants.TOTAL_MSGS_LIMIT_CACHE);
+
+            assertThat(capacityOfConfigurationPassedTo(proxyManager, CacheConstants.DEVICE_PERSISTED_MSGS_LIMIT_CACHE))
+                    .isEqualTo(DEVICE_CAPACITY);
+        }
+    }
+
+    @Test
+    public void givenBothLimitsEnabled_whenInit_thenEachBucketGetsItsOwnConfiguration() {
+        try (AnnotationConfigApplicationContext ctx =
+                     newContext(TotalMsgsLimitBean.class, DevicePersistedMsgsLimitBean.class)) {
+            JedisBasedProxyManager<String> proxyManager = proxyManagerOf(ctx);
+
+            assertThat(capacityOfConfigurationPassedTo(proxyManager, CacheConstants.TOTAL_MSGS_LIMIT_CACHE))
+                    .isEqualTo(TOTAL_CAPACITY);
+            assertThat(capacityOfConfigurationPassedTo(proxyManager, CacheConstants.DEVICE_PERSISTED_MSGS_LIMIT_CACHE))
+                    .isEqualTo(DEVICE_CAPACITY);
+        }
+    }
+
+    private static AnnotationConfigApplicationContext newContext(Class<?>... enabledLimitConfigurations) {
+        AnnotationConfigApplicationContext ctx = new AnnotationConfigApplicationContext();
+        ctx.register(MockedInfrastructure.class, RateLimitRedisCacheServiceImpl.class);
+        ctx.register(enabledLimitConfigurations);
+        ctx.refresh();
+        return ctx;
+    }
+
+    @SuppressWarnings("unchecked")
+    private static JedisBasedProxyManager<String> proxyManagerOf(AnnotationConfigApplicationContext ctx) {
+        return ctx.getBean(JedisBasedProxyManager.class);
+    }
+
+    private static long capacityOfConfigurationPassedTo(JedisBasedProxyManager<String> proxyManager, String key) {
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<Supplier<BucketConfiguration>> captor = ArgumentCaptor.forClass(Supplier.class);
+        verify(proxyManager).getProxy(eq(key), captor.capture());
+        return captor.getValue().get().getBandwidths()[0].getCapacity();
+    }
+
+    private static BucketConfiguration bucketConfiguration(long capacity) {
+        return BucketConfiguration.builder()
+                .addLimit(Bandwidth.builder()
+                        .capacity(capacity)
+                        .refillGreedy(capacity, Duration.ofSeconds(1))
+                        .build())
+                .build();
+    }
+
+    // These bean holders are deliberately NOT annotated with @Configuration: AbstractPubSubIntegrationTest scans
+    // the whole org.thingsboard.mqtt.broker package, and a stereotyped nested class here would be swept into every
+    // integration test context and override the real beans. Without the stereotype they are only picked up by the
+    // explicit register() call above, in Spring's "lite" @Bean mode.
+    static class TotalMsgsLimitBean {
+
+        // The method name is the bean name, and it is what the constructor @Qualifier asks for. Keep it in
+        // sync with TotalMsgsRateLimitsConfiguration#totalMsgsBucketConfiguration.
+        @Bean
+        public BucketConfiguration totalMsgsBucketConfiguration() {
+            return bucketConfiguration(TOTAL_CAPACITY);
+        }
+    }
+
+    static class DevicePersistedMsgsLimitBean {
+
+        // Keep in sync with DevicePersistedMsgsRateLimitsConfiguration#devicePersistedMsgsBucketConfiguration.
+        @Bean
+        public BucketConfiguration devicePersistedMsgsBucketConfiguration() {
+            return bucketConfiguration(DEVICE_CAPACITY);
+        }
+    }
+
+    static class MockedInfrastructure {
+
+        // The mocks have to be usable from the service's @PostConstruct, which runs while the context refreshes,
+        // so they are stubbed here rather than in a @Before method.
+        @Bean
+        @SuppressWarnings("unchecked")
+        public JedisBasedProxyManager<String> jedisBasedProxyManager() {
+            JedisBasedProxyManager<String> proxyManager = mock(JedisBasedProxyManager.class);
+            when(proxyManager.getProxy(anyString(), any())).thenReturn(mock(BucketProxy.class));
+            when(proxyManager.getProxyConfiguration(anyString())).thenReturn(Optional.empty());
+            return proxyManager;
+        }
+
+        @Bean
+        public CacheProperties cacheProperties() {
+            CacheProperties cacheProperties = mock(CacheProperties.class);
+            when(cacheProperties.prefixKey(anyString())).thenAnswer(inv -> inv.getArgument(0));
+            return cacheProperties;
+        }
+
+        @Bean
+        @SuppressWarnings("unchecked")
+        public RedisTemplate<String, Object> redisTemplate() {
+            return mock(RedisTemplate.class);
+        }
+
+        @Bean
+        public ClientsLimitProperties clientsLimitProperties() {
+            return mock(ClientsLimitProperties.class);
+        }
+    }
+}

--- a/application/src/test/java/org/thingsboard/mqtt/broker/service/limits/RateLimitRedisCacheServiceImplTest.java
+++ b/application/src/test/java/org/thingsboard/mqtt/broker/service/limits/RateLimitRedisCacheServiceImplTest.java
@@ -221,6 +221,26 @@ public class RateLimitRedisCacheServiceImplTest {
     }
 
     @Test
+    public void givenStoredDeviceConfigurationDiffers_whenInit_thenDeviceConfigurationIsReplacedOnTheDeviceKey() {
+        clearInvocations(bucketProxy);
+        BucketConfiguration devicePersistedMsgsBucketConfiguration = mock(BucketConfiguration.class);
+        when(jedisBasedProxyManager.getProxy(eq(CacheConstants.DEVICE_PERSISTED_MSGS_LIMIT_CACHE), any()))
+                .thenReturn(bucketProxy);
+        BucketConfiguration stored = mock(BucketConfiguration.class);
+        when(stored.equalsByContent(devicePersistedMsgsBucketConfiguration)).thenReturn(false);
+        when(jedisBasedProxyManager.getProxyConfiguration(CacheConstants.DEVICE_PERSISTED_MSGS_LIMIT_CACHE))
+                .thenReturn(Optional.of(stored));
+
+        new RateLimitRedisCacheServiceImpl(redisTemplate, jedisBasedProxyManager,
+                devicePersistedMsgsBucketConfiguration, null, cacheProperties, clientsLimitProperties).init();
+
+        // Both buckets go through the same helper, so what this pins is the argument pairing in init(): the device
+        // configuration must be applied to the device key, and the disabled total limit must not be touched.
+        verify(bucketProxy).replaceConfiguration(devicePersistedMsgsBucketConfiguration, TokensInheritanceStrategy.PROPORTIONALLY);
+        verify(jedisBasedProxyManager, never()).getProxy(eq(CacheConstants.TOTAL_MSGS_LIMIT_CACHE), any());
+    }
+
+    @Test
     public void givenDisabledLimit_whenInit_thenBucketProxyIsNotCreated() {
         // devicePersistedMsgsBucketConfiguration is not registered as a bean in this context, so the
         // constructor receives null for it and the device bucket must never be touched.

--- a/application/src/test/java/org/thingsboard/mqtt/broker/service/limits/RateLimitRedisCacheServiceImplTest.java
+++ b/application/src/test/java/org/thingsboard/mqtt/broker/service/limits/RateLimitRedisCacheServiceImplTest.java
@@ -31,10 +31,14 @@ import org.springframework.test.context.junit4.SpringRunner;
 import org.thingsboard.mqtt.broker.cache.CacheConstants;
 import org.thingsboard.mqtt.broker.cache.CacheProperties;
 import org.thingsboard.mqtt.broker.config.ClientsLimitProperties;
+import org.thingsboard.mqtt.broker.config.DevicePersistedMsgsRateLimitsConfiguration;
+import org.thingsboard.mqtt.broker.config.TotalMsgsRateLimitsConfiguration;
 
 import java.util.Optional;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
@@ -65,6 +69,12 @@ public class RateLimitRedisCacheServiceImplTest {
 
     @MockitoBean
     private ClientsLimitProperties clientsLimitProperties;
+
+    @MockitoBean
+    private DevicePersistedMsgsRateLimitsConfiguration devicePersistedMsgsRateLimitsConfiguration;
+
+    @MockitoBean
+    private TotalMsgsRateLimitsConfiguration totalMsgsRateLimitsConfiguration;
 
     @MockitoSpyBean
     private RateLimitRedisCacheServiceImpl rateLimitRedisCacheService;
@@ -181,7 +191,8 @@ public class RateLimitRedisCacheServiceImplTest {
                 .thenReturn(Optional.empty());
 
         new RateLimitRedisCacheServiceImpl(redisTemplate, jedisBasedProxyManager, null,
-                totalMsgsBucketConfiguration, cacheProperties, clientsLimitProperties).init();
+                totalMsgsBucketConfiguration, cacheProperties, clientsLimitProperties,
+                devicePersistedMsgsRateLimitsConfiguration, totalMsgsRateLimitsConfiguration).init();
 
         verify(bucketProxy, never()).replaceConfiguration(any(), any());
     }
@@ -198,7 +209,8 @@ public class RateLimitRedisCacheServiceImplTest {
                 .thenReturn(Optional.of(stored));
 
         new RateLimitRedisCacheServiceImpl(redisTemplate, jedisBasedProxyManager, null,
-                totalMsgsBucketConfiguration, cacheProperties, clientsLimitProperties).init();
+                totalMsgsBucketConfiguration, cacheProperties, clientsLimitProperties,
+                devicePersistedMsgsRateLimitsConfiguration, totalMsgsRateLimitsConfiguration).init();
 
         verify(bucketProxy, never()).replaceConfiguration(any(), any());
     }
@@ -215,7 +227,8 @@ public class RateLimitRedisCacheServiceImplTest {
                 .thenReturn(Optional.of(stored));
 
         new RateLimitRedisCacheServiceImpl(redisTemplate, jedisBasedProxyManager, null,
-                totalMsgsBucketConfiguration, cacheProperties, clientsLimitProperties).init();
+                totalMsgsBucketConfiguration, cacheProperties, clientsLimitProperties,
+                devicePersistedMsgsRateLimitsConfiguration, totalMsgsRateLimitsConfiguration).init();
 
         verify(bucketProxy).replaceConfiguration(totalMsgsBucketConfiguration, TokensInheritanceStrategy.PROPORTIONALLY);
     }
@@ -232,7 +245,8 @@ public class RateLimitRedisCacheServiceImplTest {
                 .thenReturn(Optional.of(stored));
 
         new RateLimitRedisCacheServiceImpl(redisTemplate, jedisBasedProxyManager,
-                devicePersistedMsgsBucketConfiguration, null, cacheProperties, clientsLimitProperties).init();
+                devicePersistedMsgsBucketConfiguration, null, cacheProperties, clientsLimitProperties,
+                devicePersistedMsgsRateLimitsConfiguration, totalMsgsRateLimitsConfiguration).init();
 
         // Both buckets go through the same helper, so what this pins is the argument pairing in init(): the device
         // configuration must be applied to the device key, and the disabled total limit must not be touched.
@@ -248,6 +262,47 @@ public class RateLimitRedisCacheServiceImplTest {
                 .getProxy(eq(CacheConstants.DEVICE_PERSISTED_MSGS_LIMIT_CACHE), any());
         verify(jedisBasedProxyManager, never())
                 .getProxyConfiguration(CacheConstants.DEVICE_PERSISTED_MSGS_LIMIT_CACHE);
+    }
+
+    @Test
+    public void givenTotalMsgsLimitEnabledButNoConfigurationInjected_whenInit_thenStartupFails() {
+        // The state a renamed @Bean method leaves behind: the properties say the limit is on, but the qualified
+        // BucketConfiguration never arrived. Starting up here would mean an NPE per published message instead.
+        when(totalMsgsRateLimitsConfiguration.isEnabled()).thenReturn(true);
+        RateLimitRedisCacheServiceImpl service = new RateLimitRedisCacheServiceImpl(redisTemplate,
+                jedisBasedProxyManager, null, null, cacheProperties, clientsLimitProperties,
+                devicePersistedMsgsRateLimitsConfiguration, totalMsgsRateLimitsConfiguration);
+
+        IllegalStateException e = assertThrows(IllegalStateException.class, service::init);
+
+        assertTrue(e.getMessage().contains("mqtt.rate-limits.total.enabled is true"));
+        assertTrue(e.getMessage().contains(RateLimitRedisCacheServiceImpl.TOTAL_MSGS_BUCKET_CONFIGURATION_BEAN));
+        verify(jedisBasedProxyManager, never()).getProxy(eq(CacheConstants.TOTAL_MSGS_LIMIT_CACHE), any());
+    }
+
+    @Test
+    public void givenDevicePersistedMsgsLimitEnabledButNoConfigurationInjected_whenInit_thenStartupFails() {
+        when(devicePersistedMsgsRateLimitsConfiguration.isEnabled()).thenReturn(true);
+        RateLimitRedisCacheServiceImpl service = new RateLimitRedisCacheServiceImpl(redisTemplate,
+                jedisBasedProxyManager, null, null, cacheProperties, clientsLimitProperties,
+                devicePersistedMsgsRateLimitsConfiguration, totalMsgsRateLimitsConfiguration);
+
+        IllegalStateException e = assertThrows(IllegalStateException.class, service::init);
+
+        assertTrue(e.getMessage().contains("mqtt.rate-limits.device-persisted-messages.enabled is true"));
+        assertTrue(e.getMessage().contains(RateLimitRedisCacheServiceImpl.DEVICE_PERSISTED_MSGS_BUCKET_CONFIGURATION_BEAN));
+    }
+
+    @Test
+    public void givenLimitDisabledAndNoConfigurationInjected_whenInit_thenStartupSucceeds() {
+        // The ordinary default deployment: both limits off, no BucketConfiguration beans at all. The guard above
+        // must not turn that into a startup failure.
+        new RateLimitRedisCacheServiceImpl(redisTemplate, jedisBasedProxyManager, null, null,
+                cacheProperties, clientsLimitProperties,
+                devicePersistedMsgsRateLimitsConfiguration, totalMsgsRateLimitsConfiguration).init();
+
+        verify(jedisBasedProxyManager, never()).getProxy(eq(CacheConstants.TOTAL_MSGS_LIMIT_CACHE), any());
+        verify(jedisBasedProxyManager, never()).getProxy(eq(CacheConstants.DEVICE_PERSISTED_MSGS_LIMIT_CACHE), any());
     }
 
 }

--- a/application/src/test/java/org/thingsboard/mqtt/broker/service/limits/RateLimitRedisCacheServiceImplTest.java
+++ b/application/src/test/java/org/thingsboard/mqtt/broker/service/limits/RateLimitRedisCacheServiceImplTest.java
@@ -15,6 +15,8 @@
  */
 package org.thingsboard.mqtt.broker.service.limits;
 
+import io.github.bucket4j.BucketConfiguration;
+import io.github.bucket4j.TokensInheritanceStrategy;
 import io.github.bucket4j.distributed.BucketProxy;
 import io.github.bucket4j.redis.jedis.cas.JedisBasedProxyManager;
 import org.junit.Before;
@@ -30,8 +32,14 @@ import org.thingsboard.mqtt.broker.cache.CacheConstants;
 import org.thingsboard.mqtt.broker.cache.CacheProperties;
 import org.thingsboard.mqtt.broker.config.ClientsLimitProperties;
 
+import java.util.Optional;
+
 import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.clearInvocations;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -67,6 +75,7 @@ public class RateLimitRedisCacheServiceImplTest {
         when(cacheProperties.prefixKey(anyString())).thenAnswer(inv -> inv.getArgument(0));
         when(clientsLimitProperties.isSessionsLimitEnabled()).thenReturn(true);
         when(clientsLimitProperties.isApplicationClientsLimitEnabled()).thenReturn(true);
+        when(jedisBasedProxyManager.getProxyConfiguration(anyString())).thenReturn(Optional.empty());
         rateLimitRedisCacheService.init();
     }
 
@@ -160,6 +169,65 @@ public class RateLimitRedisCacheServiceImplTest {
         rateLimitRedisCacheService.decrementApplicationClientsCount();
 
         verify(valueOperations, never()).decrement(anyString());
+    }
+
+    @Test
+    public void givenNoStoredConfiguration_whenInit_thenConfigurationIsNotReplaced() {
+        clearInvocations(bucketProxy);
+        BucketConfiguration totalMsgsBucketConfiguration = mock(BucketConfiguration.class);
+        when(jedisBasedProxyManager.getProxy(eq(CacheConstants.TOTAL_MSGS_LIMIT_CACHE), any()))
+                .thenReturn(bucketProxy);
+        when(jedisBasedProxyManager.getProxyConfiguration(CacheConstants.TOTAL_MSGS_LIMIT_CACHE))
+                .thenReturn(Optional.empty());
+
+        new RateLimitRedisCacheServiceImpl(redisTemplate, jedisBasedProxyManager, null,
+                totalMsgsBucketConfiguration, cacheProperties, clientsLimitProperties).init();
+
+        verify(bucketProxy, never()).replaceConfiguration(any(), any());
+    }
+
+    @Test
+    public void givenStoredConfigurationMatches_whenInit_thenConfigurationIsNotReplaced() {
+        clearInvocations(bucketProxy);
+        BucketConfiguration totalMsgsBucketConfiguration = mock(BucketConfiguration.class);
+        when(jedisBasedProxyManager.getProxy(eq(CacheConstants.TOTAL_MSGS_LIMIT_CACHE), any()))
+                .thenReturn(bucketProxy);
+        BucketConfiguration stored = mock(BucketConfiguration.class);
+        when(stored.equalsByContent(totalMsgsBucketConfiguration)).thenReturn(true);
+        when(jedisBasedProxyManager.getProxyConfiguration(CacheConstants.TOTAL_MSGS_LIMIT_CACHE))
+                .thenReturn(Optional.of(stored));
+
+        new RateLimitRedisCacheServiceImpl(redisTemplate, jedisBasedProxyManager, null,
+                totalMsgsBucketConfiguration, cacheProperties, clientsLimitProperties).init();
+
+        verify(bucketProxy, never()).replaceConfiguration(any(), any());
+    }
+
+    @Test
+    public void givenStoredConfigurationDiffers_whenInit_thenConfigurationIsReplacedProportionally() {
+        clearInvocations(bucketProxy);
+        BucketConfiguration totalMsgsBucketConfiguration = mock(BucketConfiguration.class);
+        when(jedisBasedProxyManager.getProxy(eq(CacheConstants.TOTAL_MSGS_LIMIT_CACHE), any()))
+                .thenReturn(bucketProxy);
+        BucketConfiguration stored = mock(BucketConfiguration.class);
+        when(stored.equalsByContent(totalMsgsBucketConfiguration)).thenReturn(false);
+        when(jedisBasedProxyManager.getProxyConfiguration(CacheConstants.TOTAL_MSGS_LIMIT_CACHE))
+                .thenReturn(Optional.of(stored));
+
+        new RateLimitRedisCacheServiceImpl(redisTemplate, jedisBasedProxyManager, null,
+                totalMsgsBucketConfiguration, cacheProperties, clientsLimitProperties).init();
+
+        verify(bucketProxy).replaceConfiguration(totalMsgsBucketConfiguration, TokensInheritanceStrategy.PROPORTIONALLY);
+    }
+
+    @Test
+    public void givenDisabledLimit_whenInit_thenBucketProxyIsNotCreated() {
+        // devicePersistedMsgsBucketConfiguration is not registered as a bean in this context, so the
+        // constructor receives null for it and the device bucket must never be touched.
+        verify(jedisBasedProxyManager, never())
+                .getProxy(eq(CacheConstants.DEVICE_PERSISTED_MSGS_LIMIT_CACHE), any());
+        verify(jedisBasedProxyManager, never())
+                .getProxyConfiguration(CacheConstants.DEVICE_PERSISTED_MSGS_LIMIT_CACHE);
     }
 
 }

--- a/application/src/test/java/org/thingsboard/mqtt/broker/service/testing/integration/RateLimitBucketConfigurationIntegrationTestCase.java
+++ b/application/src/test/java/org/thingsboard/mqtt/broker/service/testing/integration/RateLimitBucketConfigurationIntegrationTestCase.java
@@ -36,6 +36,7 @@ import org.thingsboard.mqtt.broker.dao.DaoSqlTest;
 import org.thingsboard.mqtt.broker.service.limits.RateLimitRedisCacheServiceImpl;
 
 import java.time.Duration;
+import java.util.Arrays;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -49,6 +50,11 @@ public class RateLimitBucketConfigurationIntegrationTestCase extends AbstractPub
 
     private static final long SMALL_CAPACITY = 1000L;
     private static final long LARGE_CAPACITY = 20000L;
+
+    private static final long SMALL_BURST_CAPACITY = 1000L;
+    private static final long SMALL_SUSTAINED_CAPACITY = 50000L;
+    private static final long LARGE_BURST_CAPACITY = 2000L;
+    private static final long LARGE_SUSTAINED_CAPACITY = 100000L;
 
     @Autowired
     private JedisBasedProxyManager<String> jedisBasedProxyManager;
@@ -72,7 +78,8 @@ public class RateLimitBucketConfigurationIntegrationTestCase extends AbstractPub
         initServiceWith(prefix, bucketConfiguration(LARGE_CAPACITY));
 
         assertThat(storedCapacity(key)).isEqualTo(LARGE_CAPACITY);
-        // PROPORTIONALLY preserves the fill ratio: half of the small bucket becomes half of the large one.
+        // PROPORTIONALLY preserves the fill ratio - but only because this configuration has a SINGLE bandwidth, so
+        // bucket4j can pair the old bandwidth with the new one. See the two-bandwidth test below for the general case.
         assertThat(jedisBasedProxyManager.getProxy(key, () -> bucketConfiguration(LARGE_CAPACITY)).getAvailableTokens())
                 .isBetween(LARGE_CAPACITY / 2 - 10, LARGE_CAPACITY / 2 + 10);
     }
@@ -95,6 +102,35 @@ public class RateLimitBucketConfigurationIntegrationTestCase extends AbstractPub
                 .isBetween(SMALL_CAPACITY / 2 - 10, SMALL_CAPACITY / 2 + 10);
     }
 
+    @Test
+    public void givenExistingTwoBandwidthBucket_whenConfiguredCapacityChanges_thenTokensAreReInitializedToFull() {
+        String prefix = "itest-" + UUID.randomUUID() + "-";
+        String key = prefix + CacheConstants.TOTAL_MSGS_LIMIT_CACHE;
+
+        // The shipped defaults are two bandwidths (mqtt.rate-limits.total.config = "1000:1,50000:60"), so this is
+        // the shape a real deployment reconfigures.
+        initServiceWith(prefix, twoBandwidthConfiguration(SMALL_BURST_CAPACITY, SMALL_SUSTAINED_CAPACITY));
+        BucketProxy proxy = jedisBasedProxyManager.getProxy(key,
+                () -> twoBandwidthConfiguration(SMALL_BURST_CAPACITY, SMALL_SUSTAINED_CAPACITY));
+        assertThat(proxy.tryConsume(SMALL_BURST_CAPACITY / 2)).isTrue();
+        assertThat(storedCapacities(key)).containsExactly(SMALL_BURST_CAPACITY, SMALL_SUSTAINED_CAPACITY);
+        assertThat(availableTokensPerBandwidth(key, SMALL_BURST_CAPACITY, SMALL_SUSTAINED_CAPACITY))
+                .containsExactly(SMALL_BURST_CAPACITY / 2, SMALL_SUSTAINED_CAPACITY - SMALL_BURST_CAPACITY / 2);
+
+        // The operator edits the yml and restarts: same key, both capacities doubled.
+        initServiceWith(prefix, twoBandwidthConfiguration(LARGE_BURST_CAPACITY, LARGE_SUSTAINED_CAPACITY));
+
+        assertThat(storedCapacities(key)).containsExactly(LARGE_BURST_CAPACITY, LARGE_SUSTAINED_CAPACITY);
+        // PROPORTIONALLY does NOT preserve the fill ratio here. BucketState64BitsInteger#replaceConfiguration pairs
+        // an old bandwidth with a new one only when the new bandwidth carries a non-null id, or when BOTH
+        // configurations have fewer than two null-id bandwidths. AbstractMsgsRateLimitsConfiguration builds
+        // bandwidths without ids, so with two of them nothing matches and every bandwidth is re-initialized to
+        // calculateInitialTokens(...) - i.e. back to full capacity. A reconfiguration therefore hands the whole
+        // cluster a fresh budget instead of carrying the spent tokens over.
+        assertThat(availableTokensPerBandwidth(key, LARGE_BURST_CAPACITY, LARGE_SUSTAINED_CAPACITY))
+                .containsExactly(LARGE_BURST_CAPACITY, LARGE_SUSTAINED_CAPACITY);
+    }
+
     private void initServiceWith(String cachePrefix, BucketConfiguration totalMsgsConfiguration) {
         CacheProperties cacheProperties = new CacheProperties();
         cacheProperties.setCachePrefix(cachePrefix);
@@ -106,12 +142,41 @@ public class RateLimitBucketConfigurationIntegrationTestCase extends AbstractPub
         return jedisBasedProxyManager.getProxyConfiguration(key).orElseThrow().getBandwidths()[0].getCapacity();
     }
 
+    private long[] storedCapacities(String key) {
+        return Arrays.stream(jedisBasedProxyManager.getProxyConfiguration(key).orElseThrow().getBandwidths())
+                .mapToLong(Bandwidth::getCapacity)
+                .toArray();
+    }
+
+    private long[] availableTokensPerBandwidth(String key, long burstCapacity, long sustainedCapacity) {
+        return jedisBasedProxyManager.getProxy(key, () -> twoBandwidthConfiguration(burstCapacity, sustainedCapacity))
+                .asVerbose().getAvailableTokens().getDiagnostics().getAvailableTokensPerEachBandwidth();
+    }
+
     private static BucketConfiguration bucketConfiguration(long capacity) {
         // A 24-hour refill period (~0.23 tokens/s) keeps the token count stable for the duration of the test.
         return BucketConfiguration.builder()
                 .addLimit(Bandwidth.builder()
                         .capacity(capacity)
                         .refillGreedy(capacity, Duration.ofHours(24))
+                        .build())
+                .build();
+    }
+
+    private static BucketConfiguration twoBandwidthConfiguration(long burstCapacity, long sustainedCapacity) {
+        // Models the SHAPE of the shipped default ("<burst>:1,<sustained>:60") - a small short-period burst
+        // bandwidth plus a large long-period sustained one - but with hour-scale periods instead of the literal
+        // 1s/60s. With the real periods a greedy refill regenerates the whole bucket within a second, so any token
+        // assertion would be meaningless; what this test pins is bandwidth MATCHING, which the period does not
+        // affect. Neither bandwidth gets an id, exactly like AbstractMsgsRateLimitsConfiguration builds them.
+        return BucketConfiguration.builder()
+                .addLimit(Bandwidth.builder()
+                        .capacity(burstCapacity)
+                        .refillGreedy(burstCapacity, Duration.ofHours(24))
+                        .build())
+                .addLimit(Bandwidth.builder()
+                        .capacity(sustainedCapacity)
+                        .refillGreedy(sustainedCapacity, Duration.ofHours(48))
                         .build())
                 .build();
     }

--- a/application/src/test/java/org/thingsboard/mqtt/broker/service/testing/integration/RateLimitBucketConfigurationIntegrationTestCase.java
+++ b/application/src/test/java/org/thingsboard/mqtt/broker/service/testing/integration/RateLimitBucketConfigurationIntegrationTestCase.java
@@ -32,6 +32,8 @@ import org.thingsboard.mqtt.broker.AbstractPubSubIntegrationTest;
 import org.thingsboard.mqtt.broker.cache.CacheConstants;
 import org.thingsboard.mqtt.broker.cache.CacheProperties;
 import org.thingsboard.mqtt.broker.config.ClientsLimitProperties;
+import org.thingsboard.mqtt.broker.config.DevicePersistedMsgsRateLimitsConfiguration;
+import org.thingsboard.mqtt.broker.config.TotalMsgsRateLimitsConfiguration;
 import org.thingsboard.mqtt.broker.dao.DaoSqlTest;
 import org.thingsboard.mqtt.broker.service.limits.RateLimitRedisCacheServiceImpl;
 
@@ -136,8 +138,11 @@ public class RateLimitBucketConfigurationIntegrationTestCase extends AbstractPub
     private void initServiceWith(String cachePrefix, BucketConfiguration totalMsgsConfiguration) {
         CacheProperties cacheProperties = new CacheProperties();
         cacheProperties.setCachePrefix(cachePrefix);
+        // The configuration is handed in directly rather than taken from the properties beans, so both limits read as
+        // disabled here; that is what keeps init()'s enabled-but-unconfigured guard out of the way.
         new RateLimitRedisCacheServiceImpl(redisTemplate, jedisBasedProxyManager, null,
-                totalMsgsConfiguration, cacheProperties, clientsLimitProperties).init();
+                totalMsgsConfiguration, cacheProperties, clientsLimitProperties,
+                new DevicePersistedMsgsRateLimitsConfiguration(), new TotalMsgsRateLimitsConfiguration()).init();
     }
 
     private long storedCapacity(String key) {

--- a/application/src/test/java/org/thingsboard/mqtt/broker/service/testing/integration/RateLimitBucketConfigurationIntegrationTestCase.java
+++ b/application/src/test/java/org/thingsboard/mqtt/broker/service/testing/integration/RateLimitBucketConfigurationIntegrationTestCase.java
@@ -56,6 +56,8 @@ public class RateLimitBucketConfigurationIntegrationTestCase extends AbstractPub
     private static final long LARGE_BURST_CAPACITY = 2000L;
     private static final long LARGE_SUSTAINED_CAPACITY = 100000L;
 
+    private static final Duration REFILL_PERIOD_PER_TOKEN = Duration.ofHours(1);
+
     @Autowired
     private JedisBasedProxyManager<String> jedisBasedProxyManager;
     @Autowired
@@ -154,30 +156,41 @@ public class RateLimitBucketConfigurationIntegrationTestCase extends AbstractPub
     }
 
     private static BucketConfiguration bucketConfiguration(long capacity) {
-        // A 24-hour refill period (~0.23 tokens/s) keeps the token count stable for the duration of the test.
         return BucketConfiguration.builder()
                 .addLimit(Bandwidth.builder()
                         .capacity(capacity)
-                        .refillGreedy(capacity, Duration.ofHours(24))
+                        .refillGreedy(capacity, refillPeriodFor(capacity))
                         .build())
                 .build();
     }
 
     private static BucketConfiguration twoBandwidthConfiguration(long burstCapacity, long sustainedCapacity) {
-        // Models the SHAPE of the shipped default ("<burst>:1,<sustained>:60") - a small short-period burst
-        // bandwidth plus a large long-period sustained one - but with hour-scale periods instead of the literal
-        // 1s/60s. With the real periods a greedy refill regenerates the whole bucket within a second, so any token
-        // assertion would be meaningless; what this test pins is bandwidth MATCHING, which the period does not
-        // affect. Neither bandwidth gets an id, exactly like AbstractMsgsRateLimitsConfiguration builds them.
+        // Models the SHAPE of the shipped default ("<burst>:1,<sustained>:60") - a small burst bandwidth plus a large
+        // sustained one - but with far longer periods than the literal 1s/60s. With the real periods a greedy refill
+        // regenerates the whole bucket within a second, so any token assertion would be meaningless; what this test
+        // pins is bandwidth MATCHING, which the period does not affect. Neither bandwidth gets an id, exactly like
+        // AbstractMsgsRateLimitsConfiguration builds them.
         return BucketConfiguration.builder()
                 .addLimit(Bandwidth.builder()
                         .capacity(burstCapacity)
-                        .refillGreedy(burstCapacity, Duration.ofHours(24))
+                        .refillGreedy(burstCapacity, refillPeriodFor(burstCapacity))
                         .build())
                 .addLimit(Bandwidth.builder()
                         .capacity(sustainedCapacity)
-                        .refillGreedy(sustainedCapacity, Duration.ofHours(48))
+                        .refillGreedy(sustainedCapacity, refillPeriodFor(sustainedCapacity))
                         .build())
                 .build();
+    }
+
+    /**
+     * A greedy refill regenerates one token every {@code refillPeriod / capacity}, so a fixed period would make a
+     * large bandwidth tick far faster than a small one - with a shared 48-hour period the 50000-token sustained
+     * bandwidth gained a token every 3.5s, which is well inside the stall budget of a CI box running Kafka, Postgres
+     * and Valkey containers, and enough to break the exact per-bandwidth token assertions in this class. Scaling the
+     * period to the capacity instead pins every bandwidth at one token per {@link #REFILL_PERIOD_PER_TOKEN}, whatever
+     * the capacities are, so no bandwidth can gain a token mid-test.
+     */
+    private static Duration refillPeriodFor(long capacity) {
+        return REFILL_PERIOD_PER_TOKEN.multipliedBy(capacity);
     }
 }

--- a/application/src/test/java/org/thingsboard/mqtt/broker/service/testing/integration/RateLimitBucketConfigurationIntegrationTestCase.java
+++ b/application/src/test/java/org/thingsboard/mqtt/broker/service/testing/integration/RateLimitBucketConfigurationIntegrationTestCase.java
@@ -1,0 +1,118 @@
+/**
+ * Copyright © 2016-2026 The Thingsboard Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.thingsboard.mqtt.broker.service.testing.integration;
+
+import io.github.bucket4j.Bandwidth;
+import io.github.bucket4j.BucketConfiguration;
+import io.github.bucket4j.distributed.BucketProxy;
+import io.github.bucket4j.redis.jedis.cas.JedisBasedProxyManager;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootContextLoader;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.thingsboard.mqtt.broker.AbstractPubSubIntegrationTest;
+import org.thingsboard.mqtt.broker.cache.CacheConstants;
+import org.thingsboard.mqtt.broker.cache.CacheProperties;
+import org.thingsboard.mqtt.broker.config.ClientsLimitProperties;
+import org.thingsboard.mqtt.broker.dao.DaoSqlTest;
+import org.thingsboard.mqtt.broker.service.limits.RateLimitRedisCacheServiceImpl;
+
+import java.time.Duration;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Slf4j
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@ContextConfiguration(classes = RateLimitBucketConfigurationIntegrationTestCase.class, loader = SpringBootContextLoader.class)
+@DaoSqlTest
+@RunWith(SpringRunner.class)
+public class RateLimitBucketConfigurationIntegrationTestCase extends AbstractPubSubIntegrationTest {
+
+    private static final long SMALL_CAPACITY = 1000L;
+    private static final long LARGE_CAPACITY = 20000L;
+
+    @Autowired
+    private JedisBasedProxyManager<String> jedisBasedProxyManager;
+    @Autowired
+    private RedisTemplate<String, Object> redisTemplate;
+    @Autowired
+    private ClientsLimitProperties clientsLimitProperties;
+
+    @Test
+    public void givenExistingBucket_whenConfiguredCapacityChanges_thenStoredConfigurationIsReplacedProportionally() {
+        String prefix = "itest-" + UUID.randomUUID() + "-";
+        String key = prefix + CacheConstants.TOTAL_MSGS_LIMIT_CACHE;
+
+        // A broker boots with the smaller limit, and half the burst allowance is spent.
+        initServiceWith(prefix, bucketConfiguration(SMALL_CAPACITY));
+        BucketProxy proxy = jedisBasedProxyManager.getProxy(key, () -> bucketConfiguration(SMALL_CAPACITY));
+        assertThat(proxy.tryConsume(SMALL_CAPACITY / 2)).isTrue();
+        assertThat(storedCapacity(key)).isEqualTo(SMALL_CAPACITY);
+
+        // The operator edits the yml and restarts: same key, larger configuration.
+        initServiceWith(prefix, bucketConfiguration(LARGE_CAPACITY));
+
+        assertThat(storedCapacity(key)).isEqualTo(LARGE_CAPACITY);
+        // PROPORTIONALLY preserves the fill ratio: half of the small bucket becomes half of the large one.
+        assertThat(jedisBasedProxyManager.getProxy(key, () -> bucketConfiguration(LARGE_CAPACITY)).getAvailableTokens())
+                .isBetween(LARGE_CAPACITY / 2 - 10, LARGE_CAPACITY / 2 + 10);
+    }
+
+    @Test
+    public void givenExistingBucket_whenConfigurationIsUnchanged_thenTokensAreNotRestored() {
+        String prefix = "itest-" + UUID.randomUUID() + "-";
+        String key = prefix + CacheConstants.TOTAL_MSGS_LIMIT_CACHE;
+
+        initServiceWith(prefix, bucketConfiguration(SMALL_CAPACITY));
+        BucketProxy proxy = jedisBasedProxyManager.getProxy(key, () -> bucketConfiguration(SMALL_CAPACITY));
+        assertThat(proxy.tryConsume(SMALL_CAPACITY / 2)).isTrue();
+
+        // Re-applying an unchanged configuration must not hand back the spent tokens: otherwise every node
+        // restart would refill the shared cluster budget.
+        initServiceWith(prefix, bucketConfiguration(SMALL_CAPACITY));
+
+        assertThat(storedCapacity(key)).isEqualTo(SMALL_CAPACITY);
+        assertThat(jedisBasedProxyManager.getProxy(key, () -> bucketConfiguration(SMALL_CAPACITY)).getAvailableTokens())
+                .isBetween(SMALL_CAPACITY / 2 - 10, SMALL_CAPACITY / 2 + 10);
+    }
+
+    private void initServiceWith(String cachePrefix, BucketConfiguration totalMsgsConfiguration) {
+        CacheProperties cacheProperties = new CacheProperties();
+        cacheProperties.setCachePrefix(cachePrefix);
+        new RateLimitRedisCacheServiceImpl(redisTemplate, jedisBasedProxyManager, null,
+                totalMsgsConfiguration, cacheProperties, clientsLimitProperties).init();
+    }
+
+    private long storedCapacity(String key) {
+        return jedisBasedProxyManager.getProxyConfiguration(key).orElseThrow().getBandwidths()[0].getCapacity();
+    }
+
+    private static BucketConfiguration bucketConfiguration(long capacity) {
+        // A 24-hour refill period (~0.23 tokens/s) keeps the token count stable for the duration of the test.
+        return BucketConfiguration.builder()
+                .addLimit(Bandwidth.builder()
+                        .capacity(capacity)
+                        .refillGreedy(capacity, Duration.ofHours(24))
+                        .build())
+                .build();
+    }
+}


### PR DESCRIPTION
## Pull Request description

Editing `mqtt.rate-limits.total.config` or `mqtt.rate-limits.device-persisted-messages.config` had no effect on any deployment that had already run once.

`RateLimitRedisCacheServiceImpl.init()` created both bucket proxies with `getProxy(key, () -> configuration)`. bucket4j consults that supplier **only when the Redis/Valkey key is absent**, and the bucket key has no TTL — so a bucket kept the configuration it was first created with forever. An operator raising a limit saw no change; an operator tightening a limit stayed unprotected. Both silently. The only workaround was deleting the bucket key by hand and restarting.

### Scope of changes

Back-end (`application`), `RateLimitRedisCacheServiceImpl`:

- Both bucket assignments now go through one `initBucketProxy(key, configuration, name)` helper. When a configuration is already stored under the key and differs by content, it calls `replaceConfiguration(configuration, TokensInheritanceStrategy.PROPORTIONALLY)` — only inside the `getProxyConfiguration(key)` present-branch, so a fresh key still takes the ordinary lazy supplier path. `RESET` would refill the bucket on every application, letting a node restart hand out free cluster budget.
- A disabled limit is left completely alone — no `removeProxy`, no rewrite. In a cluster, one node booting with `enabled: false` must not touch the bucket every other node is metering against.
- Startup now logs the configuration in force, any stale→new replacement, and an explicit line when a limit is disabled. The original failure mode was total silence.
- The two `BucketConfiguration` constructor parameters are now `@Qualifier`-annotated. Unqualified, Spring injects a *single* candidate of the type into **both** parameters — which is exactly the case when only one of the two limits is enabled. Together with the change above, that meant reading and rewriting the disabled limit's key with the other limit's numbers.

### Note on multi-bandwidth configurations

`PROPORTIONALLY` preserves the fill ratio only when bucket4j can match old bandwidths to new ones. It matches by bandwidth `id`, falling back to positional matching only when fewer than two bandwidths per side have a `null` id. TBMQ builds bandwidths without ids and both shipped defaults are two bandwidths (`1000:1,50000:60`, `100:1,1000:60`), so on the default shape every bandwidth is re-initialised to full capacity when the configuration changes: spending 500 of `1000:1,50000:60` leaves `[500, 49500]`, and re-initialising with `2000:1,100000:60` yields tokens `[2000, 100000]` rather than the proportional `[1000, 99000]`.

So an operator-initiated configuration change grants one full window. This is pre-existing bucket4j behaviour, left unchanged here but now pinned by a test. Making it proportional means giving bandwidths stable ids, which changes semantics for all deployments and still resets once on the first change after the upgrade — a separate decision.

### Tests

- `RateLimitRedisCacheServiceImplTest` — 5 new cases: no stored configuration, matching configuration, differing configuration (replaced with `PROPORTIONALLY`), a disabled limit's key never touched, and the device bucket's key/configuration pairing.
- `RateLimitBucketConfigurationInjectionTest` — new: with only one limit enabled, the other limit's parameter stays `null`.
- `RateLimitBucketConfigurationIntegrationTestCase` — new, real Valkey container. The unit tests drive a mocked `ProxyManager`, so they only prove the code *asks* for a replacement; this asserts the capacity read back out of Redis, the layer that actually failed. It fails on `develop/2.4` with `expected 20000 but was 1000`. Two further cases pin that an unchanged configuration does not restore spent tokens, and the multi-bandwidth behaviour above.

Full `application` suite: 1433 tests, 0 failures.

### Documentation notes

Drop any "delete the bucket key and restart" guidance — a changed limit now applies on the next broker start. Worth documenting that a change resets the token counters on a multi-bandwidth configuration (the shipped default).

Backward compatibility: existing buckets are preserved, not recreated, and an identical configuration skips the replacement entirely, so unedited deployments see no change.

## General checklist

- [x] You have reviewed the guidelines [document](https://docs.google.com/document/d/1A4Vc3wrHsY_159b9RG5LOtCryoH6VPwgOhrFEzJKwbI/edit?usp=sharing).
- [x] [Labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels#about-labels) that classify your pull request have been added.
- [x] The [milestone](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones) is specified and corresponds to fix version.
- [x] Description references specific [issue](https://github.com/thingsboard/tbmq/issues).
- [x] Description contains human-readable scope of changes.
- [x] Description contains brief notes about what needs to be added to the documentation.
- [x] No merge conflicts, commented blocks of code, code formatting issues.
- [x] Changes are backward compatible or upgrade script is provided.

## Front-End feature checklist

Not applicable — no front-end changes.

## Back-End feature checklist

- [x] Added corresponding unit and/or integration test(s).
- [x] If new dependency was added: the dependency tree is checked for conflicts. — no new dependencies.
