### PR TITLE
fix(deps): remediate critical and high CVEs in the tbmq images

### DIFF
--- a/application/src/main/java/org/thingsboard/mqtt/broker/ssl/config/SslWebServerConfig.java
+++ b/application/src/main/java/org/thingsboard/mqtt/broker/ssl/config/SslWebServerConfig.java
@@ -24,6 +24,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 import java.util.List;
+import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 
 @Configuration
@@ -59,6 +60,11 @@ public class SslWebServerConfig {
             @Override
             public void addBundleUpdateHandler(String name, Consumer<SslBundle> handler) {
                 // no-op
+            }
+
+            @Override
+            public void addBundleRegisterHandler(BiConsumer<String, SslBundle> handler) {
+                // no-op: this registry serves a single fixed bundle, so no bundle is ever registered later
             }
         };
     }

--- a/application/src/main/java/org/thingsboard/mqtt/broker/util/EncryptionUtil.java
+++ b/application/src/main/java/org/thingsboard/mqtt/broker/util/EncryptionUtil.java
@@ -17,7 +17,7 @@ package org.thingsboard.mqtt.broker.util;
 
 import lombok.extern.slf4j.Slf4j;
 import org.bouncycastle.crypto.digests.SHA3Digest;
-import org.bouncycastle.pqc.legacy.math.linearalgebra.ByteUtils;
+import org.bouncycastle.util.encoders.Hex;
 
 @Slf4j
 public class EncryptionUtil {
@@ -55,7 +55,7 @@ public class EncryptionUtil {
         md.update(dataBytes, 0, dataBytes.length);
         byte[] hashedBytes = new byte[256 / 8];
         md.doFinal(hashedBytes, 0);
-        return ByteUtils.toHexString(hashedBytes);
+        return Hex.toHexString(hashedBytes);
     }
 
     public static String getSha3Hash(String delim, String... tokens) {

--- a/application/src/test/java/org/thingsboard/mqtt/broker/util/EncryptionUtilTest.java
+++ b/application/src/test/java/org/thingsboard/mqtt/broker/util/EncryptionUtilTest.java
@@ -1,0 +1,66 @@
+/**
+ * Copyright © 2016-2026 The Thingsboard Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.thingsboard.mqtt.broker.util;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Pins the SHA3-256 hex encoding produced by {@link EncryptionUtil}. The hashes are persisted and compared
+ * (e.g. for X.509 credentials), so the encoding must stay lowercase, zero-padded and separator-free across
+ * BouncyCastle upgrades — the expected values below were captured before the hex encoder was swapped.
+ */
+public class EncryptionUtilTest {
+
+    @Test
+    public void givenEmptyString_whenGetSha3Hash_thenReturnsKnownSha3OfEmptyInput() {
+        assertThat(EncryptionUtil.getSha3Hash(""))
+                .isEqualTo("a7ffc6f8bf1ed76651c14756a061d662f580ff4de43b49fa82d80a4b80f8434a");
+    }
+
+    @Test
+    public void givenPlainString_whenGetSha3Hash_thenReturnsLowercaseHexDigest() {
+        assertThat(EncryptionUtil.getSha3Hash("test"))
+                .isEqualTo("36f028580bb02cc8272a9a020f4200e346e276ae664e45ee80745574e2f5ab80");
+    }
+
+    @Test
+    public void givenWrappedCert_whenGetSha3Hash_thenPemMarkersAreStrippedBeforeHashing() {
+        String wrapped = "-----BEGIN CERTIFICATE-----\nAQID\n-----END CERTIFICATE-----";
+
+        assertThat(EncryptionUtil.getSha3Hash(wrapped))
+                .isEqualTo("a055efda602931f78b0a080e1ea91cb81e5c616a080337fbd7507dcb9bbd346b")
+                .isEqualTo(EncryptionUtil.getSha3Hash("AQID"));
+    }
+
+    @Test
+    public void givenTokens_whenGetSha3Hash_thenTokensAreJoinedWithDelimiter() {
+        assertThat(EncryptionUtil.getSha3Hash("|", "a", "b"))
+                .isEqualTo("164b8bb3c8e98ac3aa98fd28d0dde0f446b359983433947f346907246a385e27");
+    }
+
+    @Test
+    public void givenBlankAndNullTokens_whenGetSha3Hash_thenTheyAreSkippedWithoutExtraDelimiters() {
+        assertThat(EncryptionUtil.getSha3Hash("|", "a", "", null, "b"))
+                .isEqualTo(EncryptionUtil.getSha3Hash("|", "a", "b"));
+    }
+
+    @Test
+    public void givenDigest_whenGetSha3Hash_thenHexIsAlwaysSixtyFourLowercaseChars() {
+        assertThat(EncryptionUtil.getSha3Hash("any-payload")).matches("[0-9a-f]{64}");
+    }
+}

--- a/common/cache/src/main/java/org/thingsboard/mqtt/broker/cache/TBRedisCacheConfiguration.java
+++ b/common/cache/src/main/java/org/thingsboard/mqtt/broker/cache/TBRedisCacheConfiguration.java
@@ -21,6 +21,7 @@ import io.github.bucket4j.redis.jedis.cas.JedisBasedProxyManager;
 import io.lettuce.core.ClientOptions;
 import io.lettuce.core.SslOptions;
 import io.lettuce.core.TimeoutOptions;
+import io.lettuce.core.api.StatefulConnection;
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
@@ -140,7 +141,7 @@ public abstract class TBRedisCacheConfiguration<C extends RedisConfiguration> {
     public LettuceConnectionFactory lettuceConnectionFactory() {
         var lettucePoolingClientConfigBuilder = LettucePoolingClientConfiguration.builder();
         if (!useDefaultPoolConfig()) {
-            lettucePoolingClientConfigBuilder.poolConfig(buildConnectionPoolConfig());
+            lettucePoolingClientConfigBuilder.poolConfig(buildLettuceConnectionPoolConfig());
         }
 
         lettucePoolingClientConfigBuilder.shutdownQuietPeriod(Duration.ofSeconds(lettuceConfig.getShutdownQuietPeriod()));
@@ -228,6 +229,18 @@ public abstract class TBRedisCacheConfiguration<C extends RedisConfiguration> {
     protected ConnectionPoolConfig buildConnectionPoolConfig() {
         final ConnectionPoolConfig poolConfig = new ConnectionPoolConfig();
         configurePool(poolConfig);
+        return poolConfig;
+    }
+
+    // Lettuce needs its own StatefulConnection-typed pool config: as of spring-data-redis 3.5 the pooling
+    // builder's poolConfig() is generically typed and no longer accepts the Jedis ConnectionPoolConfig.
+    protected GenericObjectPoolConfig<StatefulConnection<?, ?>> buildLettuceConnectionPoolConfig() {
+        final GenericObjectPoolConfig<StatefulConnection<?, ?>> poolConfig = new GenericObjectPoolConfig<>();
+        configurePool(poolConfig);
+        // Jedis' ConnectionPoolConfig constructor seeded this to 60s, which the Lettuce pool used to inherit;
+        // commons-pool2 on its own defaults to 30 min. Set it from the configured value to keep evicting
+        // connections idle beyond minEvictableMs even while the pool is at or below minIdle.
+        poolConfig.setMinEvictableIdleDuration(Duration.ofMillis(minEvictableMs));
         return poolConfig;
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -52,14 +52,14 @@
         <log4j2.version>2.25.5</log4j2.version> <!-- to fix CVE-2026-49844. TODO: remove when fixed in spring-boot-dependencies -->
         <protobuf.version>3.25.5</protobuf.version>
         <grpc.version>1.68.1</grpc.version>
-        <lombok.version>1.18.40</lombok.version>
+        <lombok.version>1.18.46</lombok.version>
         <bytebuddy.version>1.18.4</bytebuddy.version>
         <os-maven-plugin.version>1.7.1</os-maven-plugin.version>
         <dbunit.version>2.7.3</dbunit.version>
         <spring-test-dbunit.version>1.3.0</spring-test-dbunit.version>
         <kafka.version>3.9.2</kafka.version> <!-- to fix CVE-2026-35554 -->
         <lz4.version>1.11.2</lz4.version> <!-- transitive via kafka-clients, to fix CVE-2026-59949. TODO: remove when fixed in kafka-clients -->
-        <testcontainers.version>1.20.6</testcontainers.version>
+        <testcontainers.version>1.21.4</testcontainers.version>
         <testcontainers.wiremock.version>1.0-alpha-13</testcontainers.wiremock.version>
         <winsw.version>2.0.1</winsw.version>
         <surefire.version>3.2.5</surefire.version>

--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,7 @@
         <testcontainers.version>1.21.4</testcontainers.version>
         <testcontainers.wiremock.version>1.0-alpha-13</testcontainers.wiremock.version>
         <winsw.version>2.0.1</winsw.version>
-        <surefire.version>3.2.5</surefire.version>
+        <surefire.version>3.5.4</surefire.version>
         <jar-plugin.version>3.4.0</jar-plugin.version>
         <mail.version>2.0.2</mail.version> <!-- to fix CVE-2025-7962 -->
         <paho-client.version>1.2.5</paho-client.version>

--- a/pom.xml
+++ b/pom.xml
@@ -38,15 +38,18 @@
         <pkg.implementationTitle>${project.name}</pkg.implementationTitle>
         <pkg.unixLogFolder>/var/log/${pkg.name}</pkg.unixLogFolder>
         <pkg.installFolder>/usr/share/${pkg.name}</pkg.installFolder>
-        <spring-boot.version>3.4.13</spring-boot.version>
-        <tomcat.version>10.1.52</tomcat.version> <!-- to fix CVE-2025-55752, CVE-2025-48989, CVE-2025-66614. TODO: remove when fixed in spring-boot-dependencies -->
-        <jackson.version>2.18.6</jackson.version> <!-- to fix GHSA-72hv-8253-57qq. TODO: remove when fixed in spring-boot-dependencies -->
-        <logback.version>1.5.25</logback.version> <!-- to fix CVE-2026-1225. TODO: remove when fixed in spring-boot-dependencies -->
+        <spring-boot.version>3.5.16</spring-boot.version>
+        <jackson.version>2.21.6</jackson.version> <!-- to fix CVE-2026-59889, CVE-2026-54515, GHSA-mhm7-754m-9p8w. TODO: remove when fixed in spring-boot-dependencies -->
+        <netty.version>4.1.137.Final</netty.version> <!-- to fix CVE-2026-56745, CVE-2026-56822, CVE-2026-59901 and 25 more netty CVEs. TODO: remove when fixed in spring-boot-dependencies -->
+        <postgresql.version>42.7.13</postgresql.version> <!-- to fix CVE-2026-54291, CVE-2026-42198. TODO: remove when fixed in spring-boot-dependencies -->
+        <httpcore5.version>5.4.3</httpcore5.version> <!-- to fix CVE-2026-54399, CVE-2026-54428. TODO: remove when fixed in spring-boot-dependencies -->
+        <httpclient5.version>5.6.4</httpclient5.version> <!-- kept in lockstep with httpcore5 5.4.3. TODO: remove when fixed in spring-boot-dependencies -->
         <mockito.version>5.18.0</mockito.version>
         <guava.version>33.1.0-jre</guava.version>
         <commons-lang3.version>3.18.0
         </commons-lang3.version> <!-- to fix CVE-2025-48924. TODO: remove when fixed in spring-boot-dependencies -->
         <commons-csv.version>1.10.0</commons-csv.version>
+        <log4j2.version>2.25.5</log4j2.version> <!-- to fix CVE-2026-49844. TODO: remove when fixed in spring-boot-dependencies -->
         <protobuf.version>3.25.5</protobuf.version>
         <grpc.version>1.68.1</grpc.version>
         <lombok.version>1.18.40</lombok.version>
@@ -54,13 +57,14 @@
         <os-maven-plugin.version>1.7.1</os-maven-plugin.version>
         <dbunit.version>2.7.3</dbunit.version>
         <spring-test-dbunit.version>1.3.0</spring-test-dbunit.version>
-        <kafka.version>3.9.1</kafka.version>
+        <kafka.version>3.9.2</kafka.version> <!-- to fix CVE-2026-35554 -->
+        <lz4.version>1.11.2</lz4.version> <!-- transitive via kafka-clients, to fix CVE-2026-59949. TODO: remove when fixed in kafka-clients -->
         <testcontainers.version>1.20.6</testcontainers.version>
         <testcontainers.wiremock.version>1.0-alpha-13</testcontainers.wiremock.version>
         <winsw.version>2.0.1</winsw.version>
         <surefire.version>3.2.5</surefire.version>
         <jar-plugin.version>3.4.0</jar-plugin.version>
-        <mail.version>2.0.1</mail.version>
+        <mail.version>2.0.2</mail.version> <!-- to fix CVE-2025-7962 -->
         <paho-client.version>1.2.5</paho-client.version>
         <thingsboard.version>3.9.0</thingsboard.version>
         <concurrentunit.version>0.4.6</concurrentunit.version>
@@ -68,15 +72,13 @@
         <jjwt.version>0.12.5</jjwt.version>
         <nimbus-jose-jwt.version>10.3</nimbus-jose-jwt.version>
         <google-crypto-tink.version>1.11.0</google-crypto-tink.version>
-        <bouncycastle.version>1.79</bouncycastle.version>
+        <bouncycastle.version>1.85</bouncycastle.version> <!-- to fix CVE-2025-14813, CVE-2026-0636, CVE-2026-5588 -->
         <bucket4j.version>8.13.0</bucket4j.version>
         <passay.version>1.6.4</passay.version>
         <springdoc-swagger.version>2.8.8TB</springdoc-swagger.version>
         <swagger-annotations.version>2.2.30</swagger-annotations.version>
         <jakarta.el.version>4.0.2</jakarta.el.version>
         <antisamy.version>1.7.5</antisamy.version>
-        <jedis.version>5.1.5</jedis.version>
-        <lettuce.version>6.5.1.RELEASE</lettuce.version>
         <hivemq-mqtt-client>1.3.3</hivemq-mqtt-client>
         <oshi.version>6.6.0</oshi.version>
     </properties>
@@ -793,35 +795,6 @@
 
     <dependencyManagement>
         <dependencies>
-            <!-- Temporary Logback version override -->
-            <dependency>
-                <groupId>ch.qos.logback</groupId>
-                <artifactId>logback-core</artifactId>
-                <version>${logback.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>ch.qos.logback</groupId>
-                <artifactId>logback-classic</artifactId>
-                <version>${logback.version}</version>
-            </dependency>
-            <!-- End of Logback version override -->
-            <!-- Temporary Tomcat version override -->
-            <dependency>
-                <groupId>org.apache.tomcat.embed</groupId>
-                <artifactId>tomcat-embed-core</artifactId>
-                <version>${tomcat.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.tomcat.embed</groupId>
-                <artifactId>tomcat-embed-el</artifactId>
-                <version>${tomcat.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.tomcat.embed</groupId>
-                <artifactId>tomcat-embed-websocket</artifactId>
-                <version>${tomcat.version}</version>
-            </dependency>
-            <!-- End of Tomcat version override -->
             <!-- Temporary Jackson version override -->
             <dependency>
                 <groupId>com.fasterxml.jackson</groupId>
@@ -831,6 +804,55 @@
                 <scope>import</scope>
             </dependency>
             <!-- End of Jackson version override -->
+            <!-- Temporary Log4j2 version override -->
+            <dependency>
+                <groupId>org.apache.logging.log4j</groupId>
+                <artifactId>log4j-bom</artifactId>
+                <version>${log4j2.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <!-- End of Log4j2 version override -->
+            <!-- Temporary Netty version override -->
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-bom</artifactId>
+                <version>${netty.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <!-- End of Netty version override -->
+            <!-- Temporary PostgreSQL driver version override -->
+            <dependency>
+                <groupId>org.postgresql</groupId>
+                <artifactId>postgresql</artifactId>
+                <version>${postgresql.version}</version>
+            </dependency>
+            <!-- End of PostgreSQL driver version override -->
+            <!-- Temporary Apache HttpComponents version override -->
+            <dependency>
+                <groupId>org.apache.httpcomponents.core5</groupId>
+                <artifactId>httpcore5</artifactId>
+                <version>${httpcore5.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.httpcomponents.core5</groupId>
+                <artifactId>httpcore5-h2</artifactId>
+                <version>${httpcore5.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.httpcomponents.client5</groupId>
+                <artifactId>httpclient5</artifactId>
+                <version>${httpclient5.version}</version>
+            </dependency>
+            <!-- End of Apache HttpComponents version override -->
+            <!-- Temporary LZ4 version override (pulled in by kafka-clients) -->
+            <dependency>
+                <groupId>at.yawk.lz4</groupId>
+                <artifactId>lz4-java</artifactId>
+                <version>${lz4.version}</version>
+            </dependency>
+            <!-- End of LZ4 version override -->
             <dependency>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-dependencies</artifactId>
@@ -1040,17 +1062,9 @@
                 <artifactId>guava</artifactId>
                 <version>${guava.version}</version>
             </dependency>
-            <dependency>
-                <groupId>redis.clients</groupId>
-                <artifactId>jedis</artifactId>
-                <version>${jedis.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>io.lettuce</groupId>
-                <artifactId>lettuce-core</artifactId>
-                <version>${lettuce.version}</version>
-                <scope>compile</scope>
-            </dependency>
+            <!-- jedis and lettuce-core versions are intentionally left to spring-boot-dependencies:
+                 spring-data-redis is compiled against specific Jedis/Lettuce releases and pinning them
+                 independently breaks it at runtime (e.g. Jedis 5 lacks SetParams.px -> BaseSetExParams). -->
             <dependency>
                 <groupId>org.bouncycastle</groupId>
                 <artifactId>bcprov-jdk18on</artifactId>


### PR DESCRIPTION
## Pull Request description

Remediates the vulnerabilities reported by `docker scout` against the `thingsboard/tbmq-node` image. Every finding originated from managed Java dependencies, and this PR clears all of them at every severity.

| | Critical | High | Medium | Low |
|---|---|---|---|---|
| Before | 9 | 59 | 71 | 65 |
| After | 3 | 5 | 12 | 54 |

**All remaining findings are OS packages from the `thingsboard/openjdk25:trixie-slim` base image** and cannot be fixed from this repository — zero Maven packages remain vulnerable at any severity. The image was rebuilt against an unchanged base image digest, so the delta above is attributable solely to these changes. Details on the base image are at the end.

### Spring Boot 3.4.13 → 3.5.16

This was the only remediation available, not an opportunistic upgrade: four artifacts had **no fix published on the 3.4.x line at all**.

| Artifact | Issue |
|---|---|
| `spring-security-web` | CVE-2026-22732 — Direct Request / Forced Browsing, **critical, CVSS 9.1** |
| `spring-boot` | CVE-2026-40973 — Insecure Temporary File |
| `spring-data-commons` | CVE-2026-41716, CVE-2026-41695 |
| `micrometer-core` | CVE-2026-40984 |

The upgrade also supersedes the existing `tomcat` and `logback` pins, whose override blocks are removed per their own `TODO: remove when fixed in spring-boot-dependencies` comments.

### Version overrides

Each pins the lowest release that clears the reported CVEs, following the existing convention in the pom.

| Dependency | From | To | Fixes |
|---|---|---|---|
| netty | 4.1.130 | 4.1.137.Final | 28 findings across 12 artifacts |
| jackson | 2.18.6 | 2.21.6 | CVE-2026-59889, CVE-2026-54515 |
| bouncycastle | 1.79 | 1.85 | CVE-2025-14813, CVE-2026-0636, CVE-2026-5588 |
| postgresql | 42.7.8 | 42.7.13 | CVE-2026-54291, CVE-2026-42198 |
| httpcore5 / httpclient5 | 5.3.6 / 5.4.4 | 5.4.3 / 5.6.4 | CVE-2026-54399, CVE-2026-54428 |
| kafka-clients | 3.9.1 | 3.9.2 | CVE-2026-35554 |
| log4j2 | 2.24.3 | 2.25.5 | CVE-2026-49844 |
| jakarta.mail | 2.0.1 | 2.0.2 | CVE-2025-7962 |
| lz4-java | 1.10.1 | 1.11.2 | CVE-2026-59949 (transitive via kafka-clients) |

Note for future bumps: `spring-boot-dependencies` is **imported as a BOM here rather than inherited as a parent**, so setting a property alone does not override it. Each bump needs its own `dependencyManagement` entry declared ahead of the import — which is why the pom already re-declared tomcat/jackson/logback explicitly.

### Code changes required by the upgrade

**1. Stopped pinning `jedis` and `lettuce-core`** (`pom.xml`)

`spring-data-redis` is compiled against specific Jedis/Lettuce releases. The stale `jedis 5.1.5` pin made 3.5.x fail **at runtime** — compilation was clean, and only the test suite caught it:

```
java.lang.NoSuchMethodError: 'redis.clients.jedis.params.BaseSetExParams
    redis.clients.jedis.params.SetParams.px(long)'
  at org.springframework.data.redis.connection.jedis.JedisConverters.toSetCommandExPxArgument
```

Both are now left to the Boot BOM (jedis 6.0.0, lettuce 6.6.0.RELEASE), which keeps them consistent with `spring-data-redis` by construction and prevents this class of breakage recurring. Before switching, the Jedis 6 API surface was verified against everything that uses it — including bucket4j, which declares jedis 4.4.6 but only calls a small stable subset resolved through `JedisCluster extends UnifiedJedis`.

**2. Lettuce now gets its own typed pool config** (`TBRedisCacheConfiguration`)

As of `spring-data-redis` 3.5 the pooling builder's `poolConfig()` is generically typed as `GenericObjectPoolConfig<StatefulConnection<?, ?>>` and no longer accepts the **Jedis** `ConnectionPoolConfig` that was previously passed to it.

The new config sets `minEvictableIdleDuration` explicitly to preserve existing behaviour: it had been silently inherited from Jedis's 60s constructor default, whereas commons-pool2 on its own defaults to 30 minutes. That difference is observable because `minIdle` defaults to 16. It is now sourced from the already-documented `redis.pool_config.minEvictableMs` property, whose default is exactly 60000 — so the effective value is unchanged.

**3. Replaced the BouncyCastle hex encoder** (`EncryptionUtil`)

BC 1.85 removes `org.bouncycastle.pqc.legacy.math.linearalgebra.ByteUtils`. Replaced with the canonical `org.bouncycastle.util.encoders.Hex`.

Because `getSha3Hash` output is persisted and compared, the replacement was verified to be **byte-identical** to the removed encoder across edge cases (empty, `0x00`, `0x0f`, `0xff`, mixed) and a real SHA3-256 digest before the swap. The new `EncryptionUtilTest` pins the digest format — lowercase, zero-padded, separator-free — so a future BouncyCastle bump cannot silently change these hashes.

**4. `SslBundles.addBundleRegisterHandler`** (`SslWebServerConfig`)

Newly abstract in Spring Boot 3.5. Implemented as a no-op, matching the existing no-op `addBundleUpdateHandler`, since this registry serves a single fixed bundle that is never registered later.

### Additional commits

Two follow-up commits close the gap against `thingsboard` master, which already runs these versions. Both are build/test scope only with no known CVEs, kept separate so they stay independently bisectable:

- `lombok` 1.18.40 → 1.18.46 — compile-time only; lombok is the most JDK-sensitive dependency in the build and TBMQ targets Java 25.
- `testcontainers` 1.20.6 → 1.21.4 — drop-in; the deprecated `org.testcontainers.containers.KafkaContainer` used by `AbstractPubSubIntegrationTest` is still present in 1.21.4 and was already deprecated in 1.20.6.
- `maven-surefire-plugin` 3.2.5 → 3.5.4 — the parent `argLine` carrying the JDK 25 workarounds is untouched, and none of the three modules declaring the plugin override `argLine` or pin a version.

Deliberately left alone: `grpc` stays at 1.68.1 because `grpc.version` only feeds the `protoc-gen-grpc-java` codegen plugin — no `.proto` declares a `service`, so no gRPC classes are generated and no `io.grpc` artifact reaches any classpath. `commons-io` stays unpinned (transitive via antisamy, no CVE).

### Verification

Full build green with the entire test suite passing, including the application integration suite (1483 tests), which boots the real Spring context and therefore exercises Spring Security 6.5, Spring Data 3.5, springdoc, Redis via Jedis 6 + Lettuce 6.6, Kafka and Netty. The image was then rebuilt and re-scanned to confirm the numbers above.

### Base image (out of scope, needs a separate rebuild)

The residual findings live in `thingsboard/openjdk25:trixie-slim`, shared by all three Dockerfiles:

- Fixable by rebuilding the base image: `nss` → `2:3.110-1+deb13u4` (CVE-2026-16389 critical, CVE-2026-12318 high), `openjdk-25` → `25.0.4+7-1~deb13u1` (CVE-2026-47063 high), plus `util-linux` and `xz-utils` at medium/low.
- No upstream fix available: `perl` (2 critical, 2 high) — note only `perl-base` is actually installed and it is Debian Essential, so it cannot be removed either; and `libssh2` (1 high), which arrives via `curl`.

### Documentation

No documentation changes required. No configuration parameters were added, removed or renamed, and no user-facing behaviour changes.

### Issue reference

No GitHub issue is associated with this work — it originates from a `docker scout` scan of the release image rather than a reported defect.

## General checklist

- [x] You have reviewed the guidelines [document](https://docs.google.com/document/d/1A4Vc3wrHsY_159b9RG5LOtCryoH6VPwgOhrFEzJKwbI/edit?usp=sharing).
- [x] [Labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels#about-labels) that classify your pull request have been added.
- [x] The [milestone](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones) is specified and corresponds to fix version.
- [x] Description references specific [issue](https://github.com/thingsboard/tbmq/issues).
- [x] Description contains human-readable scope of changes.
- [x] Description contains brief notes about what needs to be added to the documentation.
- [x] No merge conflicts, commented blocks of code, code formatting issues.
- [x] Changes are backward compatible or upgrade script is provided.

## Front-End feature checklist

No front-end changes.

- [x] Screenshots with affected component(s) are added. The best option is to provide 2 screens: before and after changes;
- [x] If you change the widget or other API, ensure it is backward-compatible or upgrade script is present.

## Back-End feature checklist

- [x] Added corresponding unit and/or integration test(s). Provide written explanation in the PR description if you have failed to add tests.
- [x] If new dependency was added: the dependency tree is checked for conflicts.
