### PR TITLE
fix(rate-limits): bound the throughput quota's fail-open window

### DIFF
--- a/application/src/main/java/org/thingsboard/mqtt/broker/service/limits/ThroughputQuotaService.java
+++ b/application/src/main/java/org/thingsboard/mqtt/broker/service/limits/ThroughputQuotaService.java
@@ -59,8 +59,8 @@ public interface ThroughputQuotaService {
      * delivery on SUBSCRIBE. Never call it from the Netty ingress path: it would stall every socket on that event
      * loop.
      *
-     * @return the granted count in {@code [0..n]}; a remainder means the shared bucket is dry, so the caller
-     * settles it terminally
+     * @return the granted count in {@code [0..n]}; a remainder means the shared bucket is dry, or unreachable
+     * past the degraded grace, so the caller settles it terminally
      */
     int tryConsumeOutgoingBlocking(int n);
 }

--- a/application/src/main/java/org/thingsboard/mqtt/broker/service/limits/ThroughputQuotaServiceImpl.java
+++ b/application/src/main/java/org/thingsboard/mqtt/broker/service/limits/ThroughputQuotaServiceImpl.java
@@ -60,7 +60,10 @@ public class ThroughputQuotaServiceImpl implements ThroughputQuotaService {
     long degradedGraceMs;
 
     // Probe cadence while Redis is down. A seam like the executors below, so a test can shorten it instead of
-    // sleeping out the full interval.
+    // sleeping out the full interval - but unlike them deliberately NOT volatile: production never writes it after
+    // construction (init() leaves it alone), and a test assigns it on the same thread that then drives the charges,
+    // so program order already guarantees visibility. The executors are volatile because init() creates them at
+    // runtime and OTHER threads must see them fully constructed.
     long degradedProbeIntervalNanos = DEGRADED_PROBE_INTERVAL_NANOS;
 
     // test seams: init() creates them only when still null. Volatile so callers see fully constructed executors.

--- a/application/src/main/java/org/thingsboard/mqtt/broker/service/limits/ThroughputQuotaServiceImpl.java
+++ b/application/src/main/java/org/thingsboard/mqtt/broker/service/limits/ThroughputQuotaServiceImpl.java
@@ -168,7 +168,7 @@ public class ThroughputQuotaServiceImpl implements ThroughputQuotaService {
             scheduleDrawIfNeeded(blockSize);
             return granted;
         }
-        if (health.failOpenWindowActive(now)) {
+        if (health.failingOpen(now, degradedGraceNanos)) {
             return granted; // Redis degraded: tryConsume already failed open, nothing to draw
         }
         if (now - dryUntilNanos < 0) {
@@ -227,7 +227,7 @@ public class ThroughputQuotaServiceImpl implements ThroughputQuotaService {
         // window and on credit. Deliberately NOT an early return - the draw further down is the only thing that ever
         // notices Redis coming back, so short-circuiting here would make the refusal permanent.
         boolean graceExpired = health.graceExpired(now, degradedGraceNanos);
-        if (!graceExpired && health.failOpenWindowActive(now)) {
+        if (health.failingOpen(now, degradedGraceNanos)) {
             return n; // Redis is degraded but within the grace: fail open, never queue, never stall
         }
         // Grant on bounded credit while a draw may still help; once a draw confirmed the bucket dry, refuse locally
@@ -277,7 +277,7 @@ public class ThroughputQuotaServiceImpl implements ThroughputQuotaService {
         RedisHealth health = redisHealth.get();
         // Past the grace the pool lends nothing, so whatever the charge just spent was real budget and a drained
         // pool genuinely owes a refill: the fail-open window must not suppress the top-up there.
-        if (!health.graceExpired(now, degradedGraceNanos) && health.failOpenWindowActive(now)) {
+        if (health.failingOpen(now, degradedGraceNanos)) {
             return; // failing open spends no real budget, so nothing is owed
         }
         if (localTokens.get() <= 0) {
@@ -447,10 +447,20 @@ public class ThroughputQuotaServiceImpl implements ThroughputQuotaService {
             return healthy(now);
         }
 
+        /**
+         * Whether the quota is currently failing open: inside the short reprieve each failed draw arms, AND still
+         * inside the grace. The precedence lives here so no call site can consult the window alone - during an
+         * outage the probe cycle re-arms the window every few seconds, so window-without-grace is structurally the
+         * unbounded fail-open this deadline exists to end. That is why {@link #failOpenWindowActive} is private.
+         */
+        boolean failingOpen(long now, long graceNanos) {
+            return !graceExpired(now, graceNanos) && failOpenWindowActive(now);
+        }
+
         /** The short reprieve after each failed draw, derived instead of stored: while degraded it is always
          * lastFailure + FAIL_OPEN_NANOS, and recovery closes it because the flag drops - a stored copy existed
          * only to be disarmed in lockstep. */
-        boolean failOpenWindowActive(long now) {
+        private boolean failOpenWindowActive(long now) {
             // subtract rather than compare against a sum: these are nanoTime readings, so an added duration can
             // overflow and invert the test
             return degraded && now - lastFailureNanos < FAIL_OPEN_NANOS;

--- a/application/src/main/java/org/thingsboard/mqtt/broker/service/limits/ThroughputQuotaServiceImpl.java
+++ b/application/src/main/java/org/thingsboard/mqtt/broker/service/limits/ThroughputQuotaServiceImpl.java
@@ -291,11 +291,12 @@ public class ThroughputQuotaServiceImpl implements ThroughputQuotaService {
             // only at the call sites keeps a disabled service safe whatever reaches it.
             return;
         }
-        if (nanoTime.getAsLong() - dryUntilNanos < 0) {
+        long now = nanoTime.getAsLong();
+        if (now - dryUntilNanos < 0) {
             return; // bucket known dry: no Redis traffic during the backoff window
         }
         RedisHealth health = redisHealth.get();
-        if (health.degraded() && nanoTime.getAsLong() - health.lastFailureNanos() < degradedProbeIntervalNanos) {
+        if (health.degraded() && now - health.lastFailureNanos() < degradedProbeIntervalNanos) {
             return; // Redis is unreachable: one probe per interval, not one per refused packet
         }
         if (!drawInFlight.compareAndSet(false, true)) {

--- a/application/src/main/java/org/thingsboard/mqtt/broker/service/limits/ThroughputQuotaServiceImpl.java
+++ b/application/src/main/java/org/thingsboard/mqtt/broker/service/limits/ThroughputQuotaServiceImpl.java
@@ -33,6 +33,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.LongSupplier;
 
 @Slf4j
 @Service
@@ -66,6 +67,10 @@ public class ThroughputQuotaServiceImpl implements ThroughputQuotaService {
     // runtime and OTHER threads must see them fully constructed.
     long degradedProbeIntervalNanos = DEGRADED_PROBE_INTERVAL_NANOS;
 
+    // Clock seam with the same contract as the interval above: production never writes it, a test assigns it before
+    // driving traffic. It is what lets the grace and window arithmetic be tested without wall-clock sleeps.
+    LongSupplier nanoTime = System::nanoTime;
+
     // test seams: init() creates them only when still null. Volatile so callers see fully constructed executors.
     volatile ExecutorService drawExecutor;
     volatile ScheduledExecutorService leaseReturnScheduler;
@@ -92,7 +97,7 @@ public class ThroughputQuotaServiceImpl implements ThroughputQuotaService {
         if (!enabled) {
             return;
         }
-        long now = System.nanoTime();
+        long now = nanoTime.getAsLong();
         dryUntilNanos = now;
         redisHealth.set(RedisHealth.healthy(now));
 
@@ -154,7 +159,7 @@ public class ThroughputQuotaServiceImpl implements ThroughputQuotaService {
             repayCreditIfOwed();
             return granted;
         }
-        long now = System.nanoTime();
+        long now = nanoTime.getAsLong();
         RedisHealth health = redisHealth.get();
         if (health.graceExpired(now, degradedGraceNanos)) {
             // tryConsume has already refused on the deadline. Probe for recovery on the draw executor rather than
@@ -181,12 +186,12 @@ public class ThroughputQuotaServiceImpl implements ThroughputQuotaService {
         // over-draw lands in the pool, an under-draw leaves the rest for the next draw.
         long deficit = Math.max(0L, -localTokens.get());
         long drawSize = Math.max(blockSize, shortfall + deficit);
-        long startedAt = System.nanoTime();
+        long startedAt = nanoTime.getAsLong();
         try {
             long drawn = rateLimitCacheService.tryConsumeTotalMsgs(drawSize);
             markRedisAnswered(startedAt);
             if (drawn <= 0) {
-                dryUntilNanos = System.nanoTime() + DRY_BACKOFF_NANOS;
+                dryUntilNanos = nanoTime.getAsLong() + DRY_BACKOFF_NANOS;
                 warnQuotaClamped();
                 return 0;
             }
@@ -198,7 +203,7 @@ public class ThroughputQuotaServiceImpl implements ThroughputQuotaService {
             return granted;
         } catch (Exception e) {
             // fail open, consistent with tryConsume - including its deadline: bridge a blip, refuse an outage
-            return markRedisFailed(e).graceExpired(System.nanoTime(), degradedGraceNanos) ? 0 : shortfall;
+            return markRedisFailed(e).graceExpired(nanoTime.getAsLong(), degradedGraceNanos) ? 0 : shortfall;
         }
     }
 
@@ -215,7 +220,7 @@ public class ThroughputQuotaServiceImpl implements ThroughputQuotaService {
         if (!enabled || n <= 0) {
             return Math.max(0, n);
         }
-        long now = System.nanoTime();
+        long now = nanoTime.getAsLong();
         // one snapshot for the whole charge, so the grace, the window and the degraded flag cannot disagree mid-call
         RedisHealth health = redisHealth.get();
         // Redis has been unreachable long enough that this is an outage, not a blip: stop granting on the fail-open
@@ -268,7 +273,7 @@ public class ThroughputQuotaServiceImpl implements ThroughputQuotaService {
     // The blocking charge suppresses tryConsume's scheduling, so when it returns without drawing it must put the
     // top-up back: a pool at or below zero owes the shared bucket for the credit it granted.
     private void repayCreditIfOwed() {
-        long now = System.nanoTime();
+        long now = nanoTime.getAsLong();
         RedisHealth health = redisHealth.get();
         // Past the grace the pool lends nothing, so whatever the charge just spent was real budget and a drained
         // pool genuinely owes a refill: the fail-open window must not suppress the top-up there.
@@ -286,11 +291,11 @@ public class ThroughputQuotaServiceImpl implements ThroughputQuotaService {
             // only at the call sites keeps a disabled service safe whatever reaches it.
             return;
         }
-        if (System.nanoTime() - dryUntilNanos < 0) {
+        if (nanoTime.getAsLong() - dryUntilNanos < 0) {
             return; // bucket known dry: no Redis traffic during the backoff window
         }
         RedisHealth health = redisHealth.get();
-        if (health.degraded() && System.nanoTime() - health.lastFailureNanos() < degradedProbeIntervalNanos) {
+        if (health.degraded() && nanoTime.getAsLong() - health.lastFailureNanos() < degradedProbeIntervalNanos) {
             return; // Redis is unreachable: one probe per interval, not one per refused packet
         }
         if (!drawInFlight.compareAndSet(false, true)) {
@@ -313,14 +318,14 @@ public class ThroughputQuotaServiceImpl implements ThroughputQuotaService {
     }
 
     void draw(long drawSize) {
-        long startedAt = System.nanoTime();
+        long startedAt = nanoTime.getAsLong();
         try {
             long granted = rateLimitCacheService.tryConsumeTotalMsgs(drawSize);
             markRedisAnswered(startedAt);
             if (granted > 0) {
                 localTokens.addAndGet(granted); // repays any credit deficit first
             } else {
-                dryUntilNanos = System.nanoTime() + DRY_BACKOFF_NANOS;
+                dryUntilNanos = nanoTime.getAsLong() + DRY_BACKOFF_NANOS;
                 warnQuotaClamped();
             }
         } catch (Exception e) {
@@ -335,12 +340,12 @@ public class ThroughputQuotaServiceImpl implements ThroughputQuotaService {
     // it armed would grant every charge in full for the rest of the second, unmetered traffic at the exact moment
     // enforcement should resume.
     private void markRedisAnswered(long drawStartedNanos) {
-        long now = System.nanoTime();
+        long now = nanoTime.getAsLong();
         redisHealth.updateAndGet(health -> health.answered(drawStartedNanos, now));
     }
 
     private RedisHealth markRedisFailed(Exception e) {
-        long now = System.nanoTime();
+        long now = nanoTime.getAsLong();
         RedisHealth health = redisHealth.updateAndGet(h -> h.failed(now));
         stats.incrementRedisDegraded();
         // Say which way the quota is currently failing. Claiming "failing open" while the node is in fact refusing
@@ -357,7 +362,7 @@ public class ThroughputQuotaServiceImpl implements ThroughputQuotaService {
     }
 
     private void warnQuotaClamped() {
-        long now = System.nanoTime();
+        long now = nanoTime.getAsLong();
         // an exhausted bucket can bring every delivery thread through here at once, so CAS the timestamp: exactly
         // one of them per interval wins the right to log
         long last = lastClampWarnNanos.get();

--- a/application/src/main/java/org/thingsboard/mqtt/broker/service/limits/ThroughputQuotaServiceImpl.java
+++ b/application/src/main/java/org/thingsboard/mqtt/broker/service/limits/ThroughputQuotaServiceImpl.java
@@ -41,6 +41,10 @@ public class ThroughputQuotaServiceImpl implements ThroughputQuotaService {
     static final long DRY_BACKOFF_NANOS = TimeUnit.MILLISECONDS.toNanos(50);
     static final long FAIL_OPEN_NANOS = TimeUnit.SECONDS.toNanos(1);
     static final long CLAMP_WARN_INTERVAL_NANOS = TimeUnit.SECONDS.toNanos(60);
+    // Past the grace every refused charge would otherwise queue a fresh draw, and drawInFlight bounds concurrency,
+    // not frequency - against a Redis that refuses connections instantly that is one round trip and one WARN per
+    // packet. Probe on an interval instead.
+    static final long DEGRADED_PROBE_INTERVAL_NANOS = TimeUnit.SECONDS.toNanos(1);
 
     private final TotalMsgsRateLimitsConfiguration totalMsgsRateLimitsConfiguration;
     private final ThroughputLimitProvider throughputLimitProvider;
@@ -51,6 +55,8 @@ public class ThroughputQuotaServiceImpl implements ThroughputQuotaService {
     int configuredBlockSize;
     @Value("${mqtt.rate-limits.total.lease-return-ms:1000}")
     long leaseReturnMs;
+    @Value("${mqtt.rate-limits.total.degraded-grace-ms:30000}")
+    long degradedGraceMs;
 
     // test seams: init() creates them only when still null. Volatile so callers see fully constructed executors.
     volatile ExecutorService drawExecutor;
@@ -71,6 +77,10 @@ public class ThroughputQuotaServiceImpl implements ThroughputQuotaService {
     private volatile boolean redisDegraded;
     // timestamp of the last draw failure, so a draw that started earlier cannot clear redisDegraded
     private volatile long lastDrawFailureNanos;
+    // start of the CURRENT continuous outage, stamped only on the healthy -> degraded transition. Deliberately not
+    // reset when the outage ends: redisDegraded already gates every read of it, and the next failure re-stamps.
+    private volatile long degradedSinceNanos;
+    private volatile long degradedGraceNanos;
     private ThroughputQuotaStats stats;
 
     @PostConstruct
@@ -85,6 +95,13 @@ public class ThroughputQuotaServiceImpl implements ThroughputQuotaService {
         lastDrawFailureNanos = now; // no failure yet, so every draw from here on is newer than this
 
         lastClampWarnNanos.set(now - CLAMP_WARN_INTERVAL_NANOS - 1); // so the first clamp warns immediately
+        redisDegraded = false;
+        degradedSinceNanos = now; // every other piece of degraded state is reset here; these two belong with it
+        if (degradedGraceMs < 0) {
+            log.warn("mqtt.rate-limits.total.degraded-grace-ms is negative ({}), treating it as 0: the quota will " +
+                    "refuse PUBLISH packets as soon as a single draw fails", degradedGraceMs);
+        }
+        degradedGraceNanos = TimeUnit.MILLISECONDS.toNanos(Math.max(0, degradedGraceMs));
         blockSize = configuredBlockSize > 0 ? configuredBlockSize : deriveDefaultBlockSize();
         burstAllowance = deriveBurstAllowance();
         stats = statsManager.getThroughputQuotaStats();
@@ -138,6 +155,13 @@ public class ThroughputQuotaServiceImpl implements ThroughputQuotaService {
             return granted;
         }
         long now = System.nanoTime();
+        if (degradationGraceExpired(now)) {
+            // tryConsume has already refused on the deadline. Probe for recovery on the draw executor rather than
+            // here: this method runs on the CALLER's thread - an actor or consumer - and drawOnCallerThread would
+            // block it on the dead Jedis socket for the whole connect timeout to learn what it already knows.
+            scheduleDrawIfNeeded(blockSize);
+            return granted;
+        }
         if (now - failOpenUntilNanos < 0) {
             return granted; // Redis degraded: tryConsume already failed open, nothing to draw
         }
@@ -173,7 +197,8 @@ public class ThroughputQuotaServiceImpl implements ThroughputQuotaService {
             return granted;
         } catch (Exception e) {
             markRedisFailed(e);
-            return shortfall; // fail open, consistent with tryConsume
+            // fail open, consistent with tryConsume - including its deadline: bridge a blip, refuse an outage
+            return degradationGraceExpired(System.nanoTime()) ? 0 : shortfall;
         }
     }
 
@@ -191,8 +216,12 @@ public class ThroughputQuotaServiceImpl implements ThroughputQuotaService {
             return Math.max(0, n);
         }
         long now = System.nanoTime();
-        if (now - failOpenUntilNanos < 0) {
-            return n; // Redis is degraded: fail open, never queue, never stall
+        // Redis has been unreachable long enough that this is an outage, not a blip: stop granting on the fail-open
+        // window and on credit. Deliberately NOT an early return - the draw further down is the only thing that ever
+        // notices Redis coming back, so short-circuiting here would make the refusal permanent.
+        boolean graceExpired = degradationGraceExpired(now);
+        if (!graceExpired && now - failOpenUntilNanos < 0) {
+            return n; // Redis is degraded but within the grace: fail open, never queue, never stall
         }
         // Grant on bounded credit while a draw may still help; once a draw confirmed the bucket dry, refuse locally
         // until the backoff elapses.
@@ -205,13 +234,20 @@ public class ThroughputQuotaServiceImpl implements ThroughputQuotaService {
         // Enforcement is unaffected by the wider floor: a deficit is repaid out of the shared bucket before the pool
         // can turn positive again, so the licensed rate still binds over any window. Only the instantaneous overshoot
         // grows, and it is bounded by the floor.
-        long creditFloor = now - dryUntilNanos < 0 ? 0L : -(long) (scheduleDraw ? burstAllowance : blockSize);
+        // Past the grace the node lends nothing: it cannot know what the cluster has left, so it spends only tokens
+        // it has actually drawn and refuses once they run out.
+        long creditFloor = graceExpired || now - dryUntilNanos < 0
+                ? 0L
+                : -(long) (scheduleDraw ? burstAllowance : blockSize);
         while (true) {
             long current = localTokens.get();
             long available = current - creditFloor;
             if (available <= 0) {
                 if (scheduleDraw) {
                     scheduleDrawIfNeeded(n);
+                }
+                if (graceExpired) {
+                    return 0;
                 }
                 // the fail-open window lapses while the next draw still hangs on an unreachable Redis; without
                 // this check the quota would turn fail-CLOSED for that draw's whole duration
@@ -230,7 +266,9 @@ public class ThroughputQuotaServiceImpl implements ThroughputQuotaService {
     // The blocking charge suppresses tryConsume's scheduling, so when it returns without drawing it must put the
     // top-up back: a pool at or below zero owes the shared bucket for the credit it granted.
     private void repayCreditIfOwed() {
-        if (System.nanoTime() - failOpenUntilNanos < 0) {
+        // Past the grace the pool lends nothing, so whatever the charge just spent was real budget and a drained
+        // pool genuinely owes a refill: the fail-open window must not suppress the top-up there.
+        if (!degradationGraceExpired(System.nanoTime()) && System.nanoTime() - failOpenUntilNanos < 0) {
             return; // failing open spends no real budget, so nothing is owed
         }
         if (localTokens.get() <= 0) {
@@ -246,6 +284,9 @@ public class ThroughputQuotaServiceImpl implements ThroughputQuotaService {
         }
         if (System.nanoTime() - dryUntilNanos < 0) {
             return; // bucket known dry: no Redis traffic during the backoff window
+        }
+        if (redisDegraded && System.nanoTime() - lastDrawFailureNanos < DEGRADED_PROBE_INTERVAL_NANOS) {
+            return; // Redis is unreachable: one probe per interval, not one per refused packet
         }
         if (!drawInFlight.compareAndSet(false, true)) {
             return; // single-flight: one draw at a time per node
@@ -290,7 +331,25 @@ public class ThroughputQuotaServiceImpl implements ThroughputQuotaService {
     private void markRedisAnswered(long drawStartedNanos) {
         if (lastDrawFailureNanos - drawStartedNanos < 0) {
             redisDegraded = false;
+            // Disarm the window this flag owns. Leaving it armed grants every charge in full for the rest of the
+            // second - unmetered traffic at the exact moment enforcement should resume.
+            failOpenUntilNanos = System.nanoTime();
+            // Re-stamp rather than zero: if a racing failure re-raises the flag without stamping, inheriting "just
+            // now" costs one grace period, while inheriting 0 would fail the node closed instantly.
+            degradedSinceNanos = failOpenUntilNanos;
         }
+    }
+
+    /**
+     * Whether the node has been cut off from the shared bucket for longer than the configured grace. Reading
+     * {@code redisDegraded} first is what bounds the whole thing: a healthy node never consults the clock, and a
+     * recovered one stops consulting it the moment a draw lands.
+     */
+    private boolean degradationGraceExpired(long now) {
+        // subtract rather than compare against a sum: degradedSinceNanos is a nanoTime reading, so an added
+        // duration can overflow and invert the test - which would fail CLOSED on the first blip for exactly the
+        // operator who configured a very long grace to avoid that.
+        return redisDegraded && now - degradedSinceNanos >= degradedGraceNanos;
     }
 
     private void markRedisFailed(Exception e) {
@@ -298,11 +357,25 @@ public class ThroughputQuotaServiceImpl implements ThroughputQuotaService {
         // stamp before raising the flag, so a concurrently completing draw cannot read a stale timestamp and
         // clear what we are about to set
         lastDrawFailureNanos = now;
+        if (!redisDegraded) {
+            // first failure of THIS outage starts the grace clock. Guarding on the flag is what makes the deadline
+            // measure one continuous outage rather than sliding forward with every failed draw - which is exactly
+            // how the fail-open window itself never expires.
+            degradedSinceNanos = now;
+        }
         redisDegraded = true;
         failOpenUntilNanos = now + FAIL_OPEN_NANOS;
         stats.incrementRedisDegraded();
-        log.warn("Failed to draw total throughput quota tokens from Redis, failing open for {} ms",
-                TimeUnit.NANOSECONDS.toMillis(FAIL_OPEN_NANOS), e);
+        // Say which way the quota is currently failing. Claiming "failing open" while the node is in fact refusing
+        // every PUBLISH would point an operator at exactly the wrong cause during a total publish outage.
+        if (degradationGraceExpired(now)) {
+            log.warn("Failed to draw total throughput quota tokens from Redis; the {} ms degraded grace has elapsed, " +
+                    "so PUBLISH packets are refused until Redis answers again",
+                    TimeUnit.NANOSECONDS.toMillis(degradedGraceNanos), e);
+        } else {
+            log.warn("Failed to draw total throughput quota tokens from Redis, failing open for {} ms",
+                    TimeUnit.NANOSECONDS.toMillis(FAIL_OPEN_NANOS), e);
+        }
     }
 
     private void warnQuotaClamped() {
@@ -317,6 +390,12 @@ public class ThroughputQuotaServiceImpl implements ThroughputQuotaService {
     }
 
     void returnUnusedTokens() {
+        if (redisDegraded) {
+            // this zeroes the pool BEFORE the Redis call and only restores it in the catch, so against a socket that
+            // hangs rather than refuses the node would sit on an empty pool for the whole read timeout - and past the
+            // grace it lends nothing, so every packet in that window is refused although the tokens were owned.
+            return;
+        }
         long current = localTokens.get();
         if (current <= 0) {
             return; // never return a credit deficit

--- a/application/src/main/java/org/thingsboard/mqtt/broker/service/limits/ThroughputQuotaServiceImpl.java
+++ b/application/src/main/java/org/thingsboard/mqtt/broker/service/limits/ThroughputQuotaServiceImpl.java
@@ -32,6 +32,7 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
 
 @Slf4j
 @Service
@@ -76,14 +77,9 @@ public class ThroughputQuotaServiceImpl implements ThroughputQuotaService {
     // blockSize is how much to fetch per Redis round-trip, this is how big an arriving burst the node can absorb.
     private volatile int burstAllowance;
     private volatile long dryUntilNanos;
-    private volatile long failOpenUntilNanos;
-    // Redis is unreachable. Any completed draw clears it, so it can never latch on.
-    private volatile boolean redisDegraded;
-    // timestamp of the last draw failure, so a draw that started earlier cannot clear redisDegraded
-    private volatile long lastDrawFailureNanos;
-    // start of the CURRENT continuous outage, stamped only on the healthy -> degraded transition. Deliberately not
-    // reset when the outage ends: redisDegraded already gates every read of it, and the next failure re-stamps.
-    private volatile long degradedSinceNanos;
+    // one atomic snapshot instead of coordinated volatile fields, so the compound transitions (a stale success must
+    // not clear a newer failure, the grace is stamped once per outage) hold by construction - see RedisHealth
+    private final AtomicReference<RedisHealth> redisHealth = new AtomicReference<>(RedisHealth.healthy(0));
     private volatile long degradedGraceNanos;
     private ThroughputQuotaStats stats;
 
@@ -95,12 +91,9 @@ public class ThroughputQuotaServiceImpl implements ThroughputQuotaService {
         }
         long now = System.nanoTime();
         dryUntilNanos = now;
-        failOpenUntilNanos = now;
-        lastDrawFailureNanos = now; // no failure yet, so every draw from here on is newer than this
+        redisHealth.set(RedisHealth.healthy(now));
 
         lastClampWarnNanos.set(now - CLAMP_WARN_INTERVAL_NANOS - 1); // so the first clamp warns immediately
-        redisDegraded = false;
-        degradedSinceNanos = now; // every other piece of degraded state is reset here; these two belong with it
         if (degradedGraceMs < 0) {
             log.warn("mqtt.rate-limits.total.degraded-grace-ms is negative ({}), treating it as 0: the quota will " +
                     "refuse PUBLISH packets as soon as a single draw fails", degradedGraceMs);
@@ -159,14 +152,15 @@ public class ThroughputQuotaServiceImpl implements ThroughputQuotaService {
             return granted;
         }
         long now = System.nanoTime();
-        if (degradationGraceExpired(now)) {
+        RedisHealth health = redisHealth.get();
+        if (health.graceExpired(now, degradedGraceNanos)) {
             // tryConsume has already refused on the deadline. Probe for recovery on the draw executor rather than
             // here: this method runs on the CALLER's thread - an actor or consumer - and drawOnCallerThread would
             // block it on the dead Jedis socket for the whole connect timeout to learn what it already knows.
             scheduleDrawIfNeeded(blockSize);
             return granted;
         }
-        if (now - failOpenUntilNanos < 0) {
+        if (health.failOpenWindowActive(now)) {
             return granted; // Redis degraded: tryConsume already failed open, nothing to draw
         }
         if (now - dryUntilNanos < 0) {
@@ -200,9 +194,8 @@ public class ThroughputQuotaServiceImpl implements ThroughputQuotaService {
             }
             return granted;
         } catch (Exception e) {
-            markRedisFailed(e);
             // fail open, consistent with tryConsume - including its deadline: bridge a blip, refuse an outage
-            return degradationGraceExpired(System.nanoTime()) ? 0 : shortfall;
+            return markRedisFailed(e).graceExpired(System.nanoTime(), degradedGraceNanos) ? 0 : shortfall;
         }
     }
 
@@ -220,11 +213,13 @@ public class ThroughputQuotaServiceImpl implements ThroughputQuotaService {
             return Math.max(0, n);
         }
         long now = System.nanoTime();
+        // one snapshot for the whole charge, so the grace, the window and the degraded flag cannot disagree mid-call
+        RedisHealth health = redisHealth.get();
         // Redis has been unreachable long enough that this is an outage, not a blip: stop granting on the fail-open
         // window and on credit. Deliberately NOT an early return - the draw further down is the only thing that ever
         // notices Redis coming back, so short-circuiting here would make the refusal permanent.
-        boolean graceExpired = degradationGraceExpired(now);
-        if (!graceExpired && now - failOpenUntilNanos < 0) {
+        boolean graceExpired = health.graceExpired(now, degradedGraceNanos);
+        if (!graceExpired && health.failOpenWindowActive(now)) {
             return n; // Redis is degraded but within the grace: fail open, never queue, never stall
         }
         // Grant on bounded credit while a draw may still help; once a draw confirmed the bucket dry, refuse locally
@@ -255,7 +250,7 @@ public class ThroughputQuotaServiceImpl implements ThroughputQuotaService {
                 }
                 // the fail-open window lapses while the next draw still hangs on an unreachable Redis; without
                 // this check the quota would turn fail-CLOSED for that draw's whole duration
-                return redisDegraded ? n : 0;
+                return health.degraded() ? n : 0;
             }
             int granted = (int) Math.min(n, available);
             if (localTokens.compareAndSet(current, current - granted)) {
@@ -270,9 +265,11 @@ public class ThroughputQuotaServiceImpl implements ThroughputQuotaService {
     // The blocking charge suppresses tryConsume's scheduling, so when it returns without drawing it must put the
     // top-up back: a pool at or below zero owes the shared bucket for the credit it granted.
     private void repayCreditIfOwed() {
+        long now = System.nanoTime();
+        RedisHealth health = redisHealth.get();
         // Past the grace the pool lends nothing, so whatever the charge just spent was real budget and a drained
         // pool genuinely owes a refill: the fail-open window must not suppress the top-up there.
-        if (!degradationGraceExpired(System.nanoTime()) && System.nanoTime() - failOpenUntilNanos < 0) {
+        if (!health.graceExpired(now, degradedGraceNanos) && health.failOpenWindowActive(now)) {
             return; // failing open spends no real budget, so nothing is owed
         }
         if (localTokens.get() <= 0) {
@@ -289,7 +286,8 @@ public class ThroughputQuotaServiceImpl implements ThroughputQuotaService {
         if (System.nanoTime() - dryUntilNanos < 0) {
             return; // bucket known dry: no Redis traffic during the backoff window
         }
-        if (redisDegraded && System.nanoTime() - lastDrawFailureNanos < degradedProbeIntervalNanos) {
+        RedisHealth health = redisHealth.get();
+        if (health.degraded() && System.nanoTime() - health.lastFailureNanos() < degradedProbeIntervalNanos) {
             return; // Redis is unreachable: one probe per interval, not one per refused packet
         }
         if (!drawInFlight.compareAndSet(false, true)) {
@@ -329,50 +327,22 @@ public class ThroughputQuotaServiceImpl implements ThroughputQuotaService {
         }
     }
 
-    // Redis answered, so the node is not cut off. Two draws can be in flight at once (an ingress-scheduled one
-    // alongside a blocking caller's), so clear the flag only when no failure was recorded since this draw began -
-    // otherwise a slow success that started before an outage would clear a newer failure's degraded state.
+    // Redis answered, so the node is not cut off. See RedisHealth#answered for the staleness rule; recovery also
+    // closes the fail-open window by construction, because the window is derived from the degraded flag - leaving
+    // it armed would grant every charge in full for the rest of the second, unmetered traffic at the exact moment
+    // enforcement should resume.
     private void markRedisAnswered(long drawStartedNanos) {
-        if (lastDrawFailureNanos - drawStartedNanos < 0) {
-            redisDegraded = false;
-            // Disarm the window this flag owns. Leaving it armed grants every charge in full for the rest of the
-            // second - unmetered traffic at the exact moment enforcement should resume.
-            failOpenUntilNanos = System.nanoTime();
-            // Re-stamp rather than zero: if a racing failure re-raises the flag without stamping, inheriting "just
-            // now" costs one grace period, while inheriting 0 would fail the node closed instantly.
-            degradedSinceNanos = failOpenUntilNanos;
-        }
-    }
-
-    /**
-     * Whether the node has been cut off from the shared bucket for longer than the configured grace. Reading
-     * {@code redisDegraded} first is what bounds the whole thing: a healthy node never consults the clock, and a
-     * recovered one stops consulting it the moment a draw lands.
-     */
-    private boolean degradationGraceExpired(long now) {
-        // subtract rather than compare against a sum: degradedSinceNanos is a nanoTime reading, so an added
-        // duration can overflow and invert the test - which would fail CLOSED on the first blip for exactly the
-        // operator who configured a very long grace to avoid that.
-        return redisDegraded && now - degradedSinceNanos >= degradedGraceNanos;
-    }
-
-    private void markRedisFailed(Exception e) {
         long now = System.nanoTime();
-        // stamp before raising the flag, so a concurrently completing draw cannot read a stale timestamp and
-        // clear what we are about to set
-        lastDrawFailureNanos = now;
-        if (!redisDegraded) {
-            // first failure of THIS outage starts the grace clock. Guarding on the flag is what makes the deadline
-            // measure one continuous outage rather than sliding forward with every failed draw - which is exactly
-            // how the fail-open window itself never expires.
-            degradedSinceNanos = now;
-        }
-        redisDegraded = true;
-        failOpenUntilNanos = now + FAIL_OPEN_NANOS;
+        redisHealth.updateAndGet(health -> health.answered(drawStartedNanos, now));
+    }
+
+    private RedisHealth markRedisFailed(Exception e) {
+        long now = System.nanoTime();
+        RedisHealth health = redisHealth.updateAndGet(h -> h.failed(now));
         stats.incrementRedisDegraded();
         // Say which way the quota is currently failing. Claiming "failing open" while the node is in fact refusing
         // every PUBLISH would point an operator at exactly the wrong cause during a total publish outage.
-        if (degradationGraceExpired(now)) {
+        if (health.graceExpired(now, degradedGraceNanos)) {
             log.warn("Failed to draw total throughput quota tokens from Redis; the {} ms degraded grace has elapsed, " +
                     "so PUBLISH packets are refused until Redis answers again",
                     TimeUnit.NANOSECONDS.toMillis(degradedGraceNanos), e);
@@ -380,6 +350,7 @@ public class ThroughputQuotaServiceImpl implements ThroughputQuotaService {
             log.warn("Failed to draw total throughput quota tokens from Redis, failing open for {} ms",
                     TimeUnit.NANOSECONDS.toMillis(FAIL_OPEN_NANOS), e);
         }
+        return health;
     }
 
     private void warnQuotaClamped() {
@@ -394,7 +365,7 @@ public class ThroughputQuotaServiceImpl implements ThroughputQuotaService {
     }
 
     void returnUnusedTokens() {
-        if (redisDegraded) {
+        if (redisHealth.get().degraded()) {
             // this zeroes the pool BEFORE the Redis call and only restores it in the catch, so against a socket that
             // hangs rather than refuses the node would sit on an empty pool for the whole read timeout - and past the
             // grace it lends nothing, so every packet in that window is refused although the tokens were owned.
@@ -427,5 +398,60 @@ public class ThroughputQuotaServiceImpl implements ThroughputQuotaService {
     // brings it.
     int deriveBurstAllowance() {
         return (int) Math.min(Integer.MAX_VALUE, Math.max(blockSize, throughputLimitProvider.getSustainedRatePerSec()));
+    }
+
+    RedisHealth redisHealth() {
+        return redisHealth.get();
+    }
+
+    /**
+     * The node's view of Redis, kept as ONE immutable snapshot swapped by CAS. The three values carry compound
+     * rules - a stale success must not clear a newer failure, the grace clock is stamped once per continuous
+     * outage - and separate volatile fields can only keep such rules by write-ordering convention, which a
+     * preempted reader can still interleave. A CAS transition re-runs against whatever a racing writer left,
+     * so the rules hold by construction.
+     *
+     * @param degraded           Redis is unreachable; any completed draw clears it, so it can never latch on
+     * @param degradedSinceNanos start of the CURRENT continuous outage; never read while healthy
+     * @param lastFailureNanos   time of the last failed draw, so a draw that started earlier cannot clear degraded
+     */
+    record RedisHealth(boolean degraded, long degradedSinceNanos, long lastFailureNanos) {
+
+        static RedisHealth healthy(long now) {
+            return new RedisHealth(false, now, now); // lastFailure = now: every draw from here on is newer
+        }
+
+        /** A draw failed. Only the healthy -> degraded transition stamps the outage start: the grace measures one
+         * continuous outage rather than sliding forward with every failed draw - which is exactly how the fail-open
+         * window itself never expires. */
+        RedisHealth failed(long now) {
+            return new RedisHealth(true, degraded ? degradedSinceNanos : now, now);
+        }
+
+        /** A draw succeeded. Two draws can be in flight at once (an ingress-scheduled one alongside a blocking
+         * caller's), so clear degraded only when no failure was recorded since this draw began - a slow success
+         * that started before an outage must not clear the newer failure's state. */
+        RedisHealth answered(long drawStartedNanos, long now) {
+            if (lastFailureNanos - drawStartedNanos >= 0) {
+                return this; // stale success
+            }
+            return healthy(now);
+        }
+
+        /** The short reprieve after each failed draw, derived instead of stored: while degraded it is always
+         * lastFailure + FAIL_OPEN_NANOS, and recovery closes it because the flag drops - a stored copy existed
+         * only to be disarmed in lockstep. */
+        boolean failOpenWindowActive(long now) {
+            // subtract rather than compare against a sum: these are nanoTime readings, so an added duration can
+            // overflow and invert the test
+            return degraded && now - lastFailureNanos < FAIL_OPEN_NANOS;
+        }
+
+        /** Whether the node has been cut off from the shared bucket for longer than the configured grace. Reading
+         * {@code degraded} first is what bounds the whole thing: a healthy node never consults the clock, and a
+         * recovered one stops consulting it the moment a draw lands. */
+        boolean graceExpired(long now, long graceNanos) {
+            return degraded && now - degradedSinceNanos >= graceNanos;
+        }
     }
 }

--- a/application/src/main/java/org/thingsboard/mqtt/broker/service/limits/ThroughputQuotaServiceImpl.java
+++ b/application/src/main/java/org/thingsboard/mqtt/broker/service/limits/ThroughputQuotaServiceImpl.java
@@ -58,6 +58,10 @@ public class ThroughputQuotaServiceImpl implements ThroughputQuotaService {
     @Value("${mqtt.rate-limits.total.degraded-grace-ms:30000}")
     long degradedGraceMs;
 
+    // Probe cadence while Redis is down. A seam like the executors below, so a test can shorten it instead of
+    // sleeping out the full interval.
+    long degradedProbeIntervalNanos = DEGRADED_PROBE_INTERVAL_NANOS;
+
     // test seams: init() creates them only when still null. Volatile so callers see fully constructed executors.
     volatile ExecutorService drawExecutor;
     volatile ScheduledExecutorService leaseReturnScheduler;
@@ -285,7 +289,7 @@ public class ThroughputQuotaServiceImpl implements ThroughputQuotaService {
         if (System.nanoTime() - dryUntilNanos < 0) {
             return; // bucket known dry: no Redis traffic during the backoff window
         }
-        if (redisDegraded && System.nanoTime() - lastDrawFailureNanos < DEGRADED_PROBE_INTERVAL_NANOS) {
+        if (redisDegraded && System.nanoTime() - lastDrawFailureNanos < degradedProbeIntervalNanos) {
             return; // Redis is unreachable: one probe per interval, not one per refused packet
         }
         if (!drawInFlight.compareAndSet(false, true)) {

--- a/application/src/main/java/org/thingsboard/mqtt/broker/service/limits/ThroughputQuotaServiceImpl.java
+++ b/application/src/main/java/org/thingsboard/mqtt/broker/service/limits/ThroughputQuotaServiceImpl.java
@@ -78,6 +78,9 @@ public class ThroughputQuotaServiceImpl implements ThroughputQuotaService {
     private final AtomicLong localTokens = new AtomicLong(0);
     private final AtomicBoolean drawInFlight = new AtomicBoolean(false);
     private final AtomicLong lastClampWarnNanos = new AtomicLong();
+    // one atomic snapshot instead of coordinated volatile fields, so the compound transitions (a stale success must
+    // not clear a newer failure, the grace is stamped once per outage) hold by construction - see RedisHealth
+    private final AtomicReference<RedisHealth> redisHealth = new AtomicReference<>(RedisHealth.healthy(0));
 
     private volatile boolean enabled;
     private volatile int blockSize;
@@ -85,9 +88,6 @@ public class ThroughputQuotaServiceImpl implements ThroughputQuotaService {
     // blockSize is how much to fetch per Redis round-trip, this is how big an arriving burst the node can absorb.
     private volatile int burstAllowance;
     private volatile long dryUntilNanos;
-    // one atomic snapshot instead of coordinated volatile fields, so the compound transitions (a stale success must
-    // not clear a newer failure, the grace is stamped once per outage) hold by construction - see RedisHealth
-    private final AtomicReference<RedisHealth> redisHealth = new AtomicReference<>(RedisHealth.healthy(0));
     private volatile long degradedGraceNanos;
     private ThroughputQuotaStats stats;
 

--- a/application/src/main/java/org/thingsboard/mqtt/broker/service/stats/ThroughputQuotaStats.java
+++ b/application/src/main/java/org/thingsboard/mqtt/broker/service/stats/ThroughputQuotaStats.java
@@ -16,9 +16,12 @@
 package org.thingsboard.mqtt.broker.service.stats;
 
 /**
- * Counts silent degradations of the total throughput quota as {@code throughputQuotaDegraded{cause=redis}}.
- * The quota fails OPEN on Redis errors - traffic passes unmetered and nothing lands in {@code droppedMsgs} -
- * so this counter is the only signal that enforcement has stopped.
+ * Counts failed draws against the shared Redis bucket as {@code throughputQuotaDegraded{cause=redis}}.
+ * Within {@code mqtt.rate-limits.total.degraded-grace-ms} the quota fails OPEN on Redis errors - traffic passes
+ * unmetered and nothing lands in {@code droppedMsgs} - so inside that window this counter is the only signal that
+ * enforcement has stopped. Past the grace the node refuses PUBLISH packets instead, and those refusals do land in
+ * {@code droppedMsgs}. Draws run only when traffic charges the quota, so the counter stays flat on an idle node:
+ * alert on Redis reachability and treat this counter as corroboration, not as the outage alarm.
  * <p>
  * Obtained from {@link StatsManager}, so it shares the {@code stats.enabled} switch.
  */

--- a/application/src/main/resources/thingsboard-mqtt-broker.yml
+++ b/application/src/main/resources/thingsboard-mqtt-broker.yml
@@ -1019,8 +1019,9 @@ mqtt:
       # so it is charged when the subscription is made.
       # On overuse, incoming publishes are refused (MQTT 5: PUBACK/PUBREC with reason code 0x97 QUOTA_EXCEEDED;
       # MQTT 3.x: disconnect) and the copies for subscribers beyond the remaining budget are never stored, which is
-      # reported in the droppedMsgs statistic. If Redis is unavailable, the quota fails open and traffic passes
-      # unmetered (see the throughputQuotaDegraded metric).
+      # reported in the droppedMsgs statistic. If Redis becomes unavailable the quota keeps granting for
+      # degraded-grace-ms so a failover passes unnoticed, then stops granting rather than serve unmetered traffic
+      # indefinitely (see the throughputQuotaDegraded metric and degraded-grace-ms below).
       enabled: "${MQTT_TOTAL_RATE_LIMITS_ENABLED:false}"
       # Quota bucket definition. Comma-separated list of capacity:seconds bandwidths. Each bandwidth refills
       # continuously over the given period, so the sustained rate is capacity / seconds and the capacity is the volume
@@ -1050,6 +1051,16 @@ mqtt:
       # quiet then holds those tokens indefinitely, so the cluster's effective budget shrinks by the sum of every idle
       # node's lease. Leave the tick on unless traffic is even across all nodes.
       lease-return-ms: "${MQTT_TOTAL_RATE_LIMITS_LEASE_RETURN_MS:1000}"
+      # How long the quota keeps granting after it loses the shared Redis bucket (in ms). Defaults to 30000, which
+      # covers a Redis Cluster or Sentinel failover, so a node rides out the switch without refusing anything. Past
+      # this the node stops granting: it cannot tell how much budget the cluster has left, and continuing would serve
+      # unmetered traffic for as long as Redis stays away. The window measures ONE continuous outage — it starts when
+      # the first draw fails and is NOT extended by later failures — and any successful draw resets it, so an
+      # intermittent Redis never accumulates toward the deadline.
+      # Raising it trades enforcement for availability; 0 refuses the moment a draw fails. Note that once the window
+      # has elapsed, publishes are refused exactly as they are on a spent budget: reported in droppedMsgs, MQTT 5
+      # clients get 0x97 QUOTA_EXCEEDED and MQTT 3.x clients are disconnected.
+      degraded-grace-ms: "${MQTT_TOTAL_RATE_LIMITS_DEGRADED_GRACE_MS:30000}"
     incoming-publish:
       # Enables or disables publish rate limits per client for incoming messages to the broker.
       enabled: "${MQTT_INCOMING_RATE_LIMITS_ENABLED:false}"

--- a/application/src/test/java/org/thingsboard/mqtt/broker/server/MqttSessionHandlerTest.java
+++ b/application/src/test/java/org/thingsboard/mqtt/broker/server/MqttSessionHandlerTest.java
@@ -19,6 +19,7 @@ import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.Logger;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.read.ListAppender;
+import io.netty.buffer.Unpooled;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.mqtt.MqttConnAckMessage;
@@ -26,6 +27,7 @@ import io.netty.handler.codec.mqtt.MqttConnectMessage;
 import io.netty.handler.codec.mqtt.MqttConnectReturnCode;
 import io.netty.handler.codec.mqtt.MqttMessageBuilders;
 import io.netty.handler.codec.mqtt.MqttProperties;
+import io.netty.handler.codec.mqtt.MqttQoS;
 import io.netty.handler.codec.mqtt.MqttVersion;
 import io.netty.handler.ssl.NotSslRecordException;
 import io.netty.util.Attribute;
@@ -50,6 +52,7 @@ import java.io.IOException;
 import java.net.InetSocketAddress;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -60,6 +63,10 @@ public class MqttSessionHandlerTest {
     static final InetSocketAddress REMOTE = new InetSocketAddress("10.0.0.7", 51000);
 
     MqttMessageGenerator mqttMessageGenerator;
+    RateLimitService rateLimitService;
+    ThroughputQuotaService throughputQuotaService;
+    ClientMqttActorManager clientMqttActorManager;
+    TbMessageStatsReportClient tbMessageStatsReportClient;
     ConnectionStats connectionStats;
     MqttSessionHandler handler;
     ChannelHandlerContext ctx;
@@ -70,16 +77,20 @@ public class MqttSessionHandlerTest {
     @SuppressWarnings("unchecked")
     public void setUp() {
         mqttMessageGenerator = mock(MqttMessageGenerator.class);
+        rateLimitService = mock(RateLimitService.class);
+        throughputQuotaService = mock(ThroughputQuotaService.class);
         StatsManager statsManager = mock(StatsManager.class);
         connectionStats = mock(ConnectionStats.class);
         when(statsManager.getConnectionStats()).thenReturn(connectionStats);
+        clientMqttActorManager = mock(ClientMqttActorManager.class);
+        tbMessageStatsReportClient = mock(TbMessageStatsReportClient.class);
         MqttHandlerCtx handlerCtx = new MqttHandlerCtx(
-                mock(ClientMqttActorManager.class),
+                clientMqttActorManager,
                 mock(ClientLogger.class),
-                mock(RateLimitService.class),
+                rateLimitService,
                 mqttMessageGenerator,
-                mock(ThroughputQuotaService.class),
-                mock(TbMessageStatsReportClient.class),
+                throughputQuotaService,
+                tbMessageStatsReportClient,
                 statsManager);
         handlerCtx.setMaxInFlightMsgs(1000);
         handler = new MqttSessionHandler(handlerCtx, null, BrokerConstants.TCP);
@@ -89,6 +100,36 @@ public class MqttSessionHandlerTest {
         addressAttr = mock(Attribute.class);
         when(ctx.channel()).thenReturn(channel);
         when(channel.attr(MqttSessionHandler.ADDRESS)).thenReturn(addressAttr);
+    }
+
+    // --- quota refusals. MQTT 3.x has no reason code for "try again later", so a refused publish can only be
+    //     signalled by disconnecting; MQTT 5 gets 0x97 QUOTA_EXCEEDED instead. The value of pinning this is the
+    //     negative half: a refusal must never reach the actor, or the quota would not be a limit at all. ---
+
+    private void arrangeRefusedPublish() {
+        when(addressAttr.get()).thenReturn(REMOTE);
+        ClientSessionCtx sessionCtx = (ClientSessionCtx) ReflectionTestUtils.getField(handler, "clientSessionCtx");
+        sessionCtx.setChannel(ctx);
+        sessionCtx.setMqttVersion(MqttVersion.MQTT_3_1_1);
+        // a PUBLISH before CONNECT is a protocol violation, so the session has to look established
+        ReflectionTestUtils.setField(handler, "clientId", "v3-publisher");
+        when(rateLimitService.checkIncomingLimits(any(), any(), any())).thenReturn(true);
+        when(throughputQuotaService.tryConsumeIncoming()).thenReturn(false);
+    }
+
+    @Test
+    public void channelRead_publishRefusedByQuota_disconnectsMqtt3SessionAndDropsPacket() {
+        arrangeRefusedPublish();
+
+        handler.channelRead(ctx, MqttMessageBuilders.publish()
+                .topicName("test/topic")
+                .qos(MqttQoS.AT_MOST_ONCE)
+                .payload(Unpooled.EMPTY_BUFFER)
+                .build());
+
+        verify(clientMqttActorManager).disconnect(any(), any());
+        verify(clientMqttActorManager, never()).processMqttMsg(any(), any());
+        verify(tbMessageStatsReportClient).reportDroppedMsgs();
     }
 
     // --- close-origin token: a short, stable classification (not prose) so logs stay greppable

--- a/application/src/test/java/org/thingsboard/mqtt/broker/service/limits/ThroughputQuotaServiceImplTest.java
+++ b/application/src/test/java/org/thingsboard/mqtt/broker/service/limits/ThroughputQuotaServiceImplTest.java
@@ -279,7 +279,9 @@ public class ThroughputQuotaServiceImplTest {
     // down: the 1 s window is re-armed by every failed draw, so without a deadline on the CONTINUOUS outage the
     // quota would never resume enforcing.
     @Test
-    public void givenRedisDownPastGrace_whenConsuming_thenStopsGrantingFreely() throws InterruptedException {
+    public void givenRedisDownPastGrace_whenConsuming_thenStopsGrantingFreely() {
+        AtomicLong clock = new AtomicLong();
+        service.nanoTime = clock::get;
         service.drawExecutor = MoreExecutors.newDirectExecutorService();
         service.degradedGraceMs = 100;
         when(rateLimitCacheService.tryConsumeTotalMsgs(anyLong())).thenThrow(new RuntimeException("redis down"));
@@ -288,7 +290,7 @@ public class ThroughputQuotaServiceImplTest {
 
         assertTrue("within the grace the quota must still fail open", service.tryConsumeIncoming());
 
-        Thread.sleep(150); // past the grace, while the fail-open window is still being re-armed
+        clock.addAndGet(TimeUnit.MILLISECONDS.toNanos(150)); // past the grace, with the fail-open window still armed
 
         assertFalse("past the grace an unreachable shared bucket must stop granting", service.tryConsumeIncoming());
         assertEquals("no bulk charge may ride on a grace that has expired", 0, service.tryConsumeOutgoing(1000));
@@ -298,21 +300,24 @@ public class ThroughputQuotaServiceImplTest {
     // healthy between the blips, so each new outage starts its own grace rather than inheriting what an earlier one
     // already spent - otherwise an intermittent Redis eventually locks the quota permanently closed.
     @Test
-    public void givenIntermittentRedis_whenADrawSucceedsBetween_thenTheGraceClockRestarts() throws InterruptedException {
+    public void givenIntermittentRedis_whenADrawSucceedsBetween_thenTheGraceClockRestarts() {
+        AtomicLong clock = new AtomicLong();
+        service.nanoTime = clock::get;
         service.drawExecutor = MoreExecutors.newDirectExecutorService();
         service.degradedGraceMs = 200;
         when(rateLimitCacheService.tryConsumeTotalMsgs(anyLong())).thenThrow(new RuntimeException("redis down"));
         service.init(); // fails -> the first outage's grace starts here
 
-        Thread.sleep(150); // 150 of the 200 ms consumed
+        clock.addAndGet(TimeUnit.MILLISECONDS.toNanos(150)); // 150 of the 200 ms consumed
 
         doReturn(5L).when(rateLimitCacheService).tryConsumeTotalMsgs(anyLong());
         service.draw(10); // Redis answers: the outage is over, local pool holds 5
 
+        clock.addAndGet(TimeUnit.MILLISECONDS.toNanos(10));
         when(rateLimitCacheService.tryConsumeTotalMsgs(anyLong())).thenThrow(new RuntimeException("down again"));
         service.draw(10); // a NEW outage begins
 
-        Thread.sleep(100); // 250+ ms since the FIRST failure, but only ~100 into the new grace
+        clock.addAndGet(TimeUnit.MILLISECONDS.toNanos(100)); // 260 ms since the FIRST failure, 100 into the new grace
 
         // 5 local + 100 burst credit is the most a non-degraded node could grant, so 1000 proves fail-open is live
         assertEquals("a fresh outage gets a fresh grace, not the remains of the previous one",
@@ -323,17 +328,19 @@ public class ThroughputQuotaServiceImplTest {
     // draw, which is why it never ends. The grace must not inherit that property - it is anchored to when the outage
     // started, not to the most recent attempt, or traffic keeps buying itself another grace.
     @Test
-    public void givenRedisDown_whenLaterDrawsAlsoFail_thenTheGraceStillExpires() throws InterruptedException {
+    public void givenRedisDown_whenLaterDrawsAlsoFail_thenTheGraceStillExpires() {
+        AtomicLong clock = new AtomicLong();
+        service.nanoTime = clock::get;
         service.drawExecutor = MoreExecutors.newDirectExecutorService();
         service.degradedGraceMs = 1500;
         when(rateLimitCacheService.tryConsumeTotalMsgs(anyLong())).thenThrow(new RuntimeException("redis down"));
         service.init(); // stamps the start of the outage
 
-        Thread.sleep(1100); // FAIL_OPEN_NANOS is 1 s, so the window has lapsed and the next charge draws again
+        clock.addAndGet(TimeUnit.MILLISECONDS.toNanos(1100)); // FAIL_OPEN_NANOS is 1 s: the window has lapsed
 
         assertTrue("still inside the grace", service.tryConsumeIncoming()); // this charge runs another failing draw
 
-        Thread.sleep(500); // ~1.6 s into a 1.5 s grace
+        clock.addAndGet(TimeUnit.MILLISECONDS.toNanos(500)); // 1.6 s into a 1.5 s grace
 
         assertFalse("a failed draw must not push the deadline out - the grace measures the outage, not the attempt",
                 service.tryConsumeIncoming());
@@ -344,7 +351,9 @@ public class ThroughputQuotaServiceImplTest {
     // it must neither borrow nor block - but it still has to leave a probe behind, or a node whose only traffic is
     // persisted fan-out would never discover that Redis came back.
     @Test
-    public void givenGraceExpired_whenBlockingCharge_thenRefusesWithoutDrawingOnCallerThread() throws InterruptedException {
+    public void givenGraceExpired_whenBlockingCharge_thenRefusesWithoutDrawingOnCallerThread() {
+        AtomicLong clock = new AtomicLong();
+        service.nanoTime = clock::get;
         ManualExecutor executor = new ManualExecutor();
         service.drawExecutor = executor;
         service.degradedGraceMs = 1200;
@@ -352,7 +361,7 @@ public class ThroughputQuotaServiceImplTest {
         service.init();
         executor.runAll(); // the warm-up draw fails: the outage starts here
 
-        Thread.sleep(1300); // past the grace, and past the fail-open window that would otherwise short-circuit
+        clock.addAndGet(TimeUnit.MILLISECONDS.toNanos(1300)); // past the grace, and past the fail-open window
         clearInvocations(rateLimitCacheService);
 
         assertEquals("past the grace the blocking charge grants nothing", 0, service.tryConsumeOutgoingBlocking(50));
@@ -364,18 +373,20 @@ public class ThroughputQuotaServiceImplTest {
     // to be driven through the public charge methods, because those are the only things production calls - a test
     // that hand-invokes draw() would pass even if no charge could ever reach Redis again.
     @Test
-    public void givenGraceExpired_whenRedisReturns_thenEnforcementResumes() throws InterruptedException {
+    public void givenGraceExpired_whenRedisReturns_thenEnforcementResumes() {
+        AtomicLong clock = new AtomicLong();
+        service.nanoTime = clock::get;
         service.drawExecutor = MoreExecutors.newDirectExecutorService();
         service.degradedGraceMs = 100;
         service.degradedProbeIntervalNanos = TimeUnit.MILLISECONDS.toNanos(20);
         when(rateLimitCacheService.tryConsumeTotalMsgs(anyLong())).thenThrow(new RuntimeException("redis down"));
         service.init();
 
-        Thread.sleep(150);
+        clock.addAndGet(TimeUnit.MILLISECONDS.toNanos(150));
         assertFalse("past the grace the node refuses", service.tryConsumeIncoming());
 
         doReturn(10L).when(rateLimitCacheService).tryConsumeTotalMsgs(anyLong());
-        Thread.sleep(30); // let the probe interval elapse, so the next charge is allowed to reach Redis
+        clock.addAndGet(TimeUnit.MILLISECONDS.toNanos(30)); // the probe interval elapses: the next charge may reach Redis
 
         // Charges are the only thing that ever reaches Redis, so this one has to probe. It still refuses - it found
         // the pool empty - but its draw lands and clears the degraded state.
@@ -480,6 +491,47 @@ public class ThroughputQuotaServiceImplTest {
 
         assertFalse("no fail-open moment at all with a zero grace", service.tryConsumeIncoming());
         assertEquals(0, service.tryConsumeOutgoing(1000));
+    }
+
+    // The failure WARN's two wordings are operator-facing: claiming "failing open" while the node is in fact
+    // refusing every PUBLISH points the on-call at the wrong cause, so the branch selection is pinned, not
+    // just commented.
+    @Test
+    public void givenDrawFailures_whenWarning_thenTheWordingNamesTheCurrentFailureDirection() {
+        AtomicLong clock = new AtomicLong();
+        service.nanoTime = clock::get;
+        service.drawExecutor = MoreExecutors.newDirectExecutorService();
+        service.degradedGraceMs = 100;
+        when(rateLimitCacheService.tryConsumeTotalMsgs(anyLong())).thenThrow(new RuntimeException("redis down"));
+
+        Logger logger = (Logger) LoggerFactory.getLogger(ThroughputQuotaServiceImpl.class);
+        ListAppender<ILoggingEvent> appender = new ListAppender<>();
+        appender.start();
+        logger.addAppender(appender);
+        try {
+            service.init(); // the warm-up failure lands within the grace
+
+            assertEquals("within the grace the WARN must say the quota is failing open",
+                    1L, warnsContaining(appender, "failing open"));
+            assertEquals(0L, warnsContaining(appender, "refused until Redis answers"));
+
+            clock.addAndGet(TimeUnit.MILLISECONDS.toNanos(150)); // past the grace
+            service.draw(10); // another failing draw, now on the other side of the deadline
+
+            assertEquals("past the grace the WARN must say packets are refused",
+                    1L, warnsContaining(appender, "refused until Redis answers"));
+            assertEquals("and must not claim to be failing open",
+                    1L, warnsContaining(appender, "failing open"));
+        } finally {
+            logger.detachAppender(appender);
+        }
+    }
+
+    private long warnsContaining(ListAppender<ILoggingEvent> appender, String fragment) {
+        return appender.list.stream()
+                .filter(event -> event.getLevel() == Level.WARN)
+                .filter(event -> event.getFormattedMessage().contains(fragment))
+                .count();
     }
 
     @Test

--- a/application/src/test/java/org/thingsboard/mqtt/broker/service/limits/ThroughputQuotaServiceImplTest.java
+++ b/application/src/test/java/org/thingsboard/mqtt/broker/service/limits/ThroughputQuotaServiceImplTest.java
@@ -754,13 +754,24 @@ public class ThroughputQuotaServiceImplTest {
     }
 
     @Test
-    public void givenRecovered_whenTheWindowIsRead_thenItIsClosedImmediately() {
+    public void givenRecovered_whenCheckingFailingOpen_thenTheWindowIsDisarmedImmediately() {
         ThroughputQuotaServiceImpl.RedisHealth degraded =
                 ThroughputQuotaServiceImpl.RedisHealth.healthy(0).failed(100);
 
-        assertTrue("each failure arms the reprieve", degraded.failOpenWindowActive(101));
+        assertTrue("each failure arms the reprieve", degraded.failingOpen(101, Long.MAX_VALUE));
         assertFalse("recovery must disarm it, or the rest of the second passes unmetered",
-                degraded.answered(150, 200).failOpenWindowActive(201));
+                degraded.answered(150, 200).failingOpen(201, Long.MAX_VALUE));
+    }
+
+    // the precedence the combined predicate encodes: an armed window must NOT grant once the grace is over.
+    // Consulted alone, the window is re-armed by every probe failure and would fail open for the whole outage -
+    // which is why the record keeps it private.
+    @Test
+    public void givenGraceExpired_whenTheWindowIsStillArmed_thenFailingOpenIsOff() {
+        ThroughputQuotaServiceImpl.RedisHealth health = ThroughputQuotaServiceImpl.RedisHealth.healthy(0).failed(100);
+
+        assertTrue("inside both the grace and the window", health.failingOpen(150, 100));
+        assertFalse("grace expiry must trump the armed window", health.failingOpen(150, 50));
     }
 
     @Test

--- a/application/src/test/java/org/thingsboard/mqtt/broker/service/limits/ThroughputQuotaServiceImplTest.java
+++ b/application/src/test/java/org/thingsboard/mqtt/broker/service/limits/ThroughputQuotaServiceImplTest.java
@@ -387,6 +387,101 @@ public class ThroughputQuotaServiceImplTest {
                 10 + service.deriveBurstAllowance(), service.tryConsumeOutgoing(5000));
     }
 
+    private AtomicLong pool() {
+        return (AtomicLong) ReflectionTestUtils.getField(service, "localTokens");
+    }
+
+    // --- a degraded node and the tokens it already owns. A zero grace is "expired from the first failure", which
+    //     makes these deterministic: no wall-clock wait for the deadline. ---
+
+    @Test
+    public void givenDegradedNodeWithOwnedTokens_whenReturnTick_thenTokensAreKeptLocal() {
+        service.drawExecutor = MoreExecutors.newDirectExecutorService();
+        when(rateLimitCacheService.tryConsumeTotalMsgs(anyLong())).thenThrow(new RuntimeException("redis down"));
+        service.init(); // warm-up draw fails -> degraded
+        pool().set(25); // drawn before the outage
+
+        service.returnUnusedTokens();
+
+        verify(rateLimitCacheService, never()).returnTotalMsgs(anyLong());
+        assertEquals("the tick zeroes the pool before the Redis call, so against a hanging socket it would strand "
+                + "the only tokens a grace-expired node may still spend", 25, pool().get());
+    }
+
+    @Test
+    public void givenGraceExpiredWithOwnedTokens_whenConsuming_thenSpendsOnlyWhatWasDrawn() {
+        service.drawExecutor = MoreExecutors.newDirectExecutorService();
+        service.degradedGraceMs = 0;
+        when(rateLimitCacheService.tryConsumeTotalMsgs(anyLong())).thenThrow(new RuntimeException("redis down"));
+        service.init();
+        pool().set(5);
+
+        assertEquals("tokens the node actually drew must still be granted", 3, service.tryConsumeOutgoing(3));
+        assertEquals("the remainder of the pool - and not one packet of credit", 2, service.tryConsumeOutgoing(10));
+        assertFalse("pool spent: past the grace the node lends nothing", service.tryConsumeIncoming());
+    }
+
+    // repayCreditIfOwed's grace-expired side: a blocking charge that fully grants from owned tokens drains the
+    // pool, and the fail-open window - armed by the outage's own failures - must not suppress the top-up, because
+    // past the grace the spend was real budget.
+    @Test
+    public void givenGraceExpired_whenBlockingChargeGrantsFromOwnedTokens_thenTheDrainedPoolSchedulesTheTopUp() {
+        ManualExecutor executor = new ManualExecutor();
+        service.drawExecutor = executor;
+        service.degradedGraceMs = 0;
+        service.degradedProbeIntervalNanos = 0; // the probe gate must not hide the scheduling under test
+        when(rateLimitCacheService.tryConsumeTotalMsgs(anyLong())).thenThrow(new RuntimeException("redis down"));
+        service.init();
+        executor.runAll(); // warm-up draw fails: degraded, grace over, fail-open window freshly armed
+        pool().set(30);
+
+        assertEquals("owned tokens grant in full without a caller-thread draw",
+                30, service.tryConsumeOutgoingBlocking(30));
+
+        assertEquals("the drained pool owes a refill: the armed window must not suppress the top-up",
+                1, executor.tasks.size());
+        verify(rateLimitCacheService, times(1)).tryConsumeTotalMsgs(anyLong()); // the warm-up only
+    }
+
+    // --- the grace clamp's boundaries. ---
+
+    @Test
+    public void givenNegativeGrace_whenInit_thenWarnsAndBehavesAsZero() {
+        service.drawExecutor = MoreExecutors.newDirectExecutorService();
+        service.degradedGraceMs = -5;
+        when(rateLimitCacheService.tryConsumeTotalMsgs(anyLong())).thenThrow(new RuntimeException("redis down"));
+
+        Logger logger = (Logger) LoggerFactory.getLogger(ThroughputQuotaServiceImpl.class);
+        ListAppender<ILoggingEvent> appender = new ListAppender<>();
+        appender.start();
+        logger.addAppender(appender);
+        try {
+            service.init(); // the clamp warns, then the warm-up draw fails
+
+            assertEquals("a negative grace must be called out at startup", 1L,
+                    appender.list.stream()
+                            .filter(event -> event.getLevel() == Level.WARN)
+                            .filter(event -> event.getFormattedMessage().contains("degraded-grace-ms is negative"))
+                            .count());
+        } finally {
+            logger.detachAppender(appender);
+        }
+        assertFalse("clamped to 0: the first failed draw must already refuse", service.tryConsumeIncoming());
+    }
+
+    // the yml promises that 0 "refuses the moment a draw fails"
+    @Test
+    public void givenZeroGrace_whenTheFirstDrawFails_thenRefusesImmediately() {
+        service.drawExecutor = MoreExecutors.newDirectExecutorService();
+        service.degradedGraceMs = 0;
+        when(rateLimitCacheService.tryConsumeTotalMsgs(anyLong())).thenThrow(new RuntimeException("redis down"));
+
+        service.init(); // the warm-up draw fails
+
+        assertFalse("no fail-open moment at all with a zero grace", service.tryConsumeIncoming());
+        assertEquals(0, service.tryConsumeOutgoing(1000));
+    }
+
     @Test
     public void givenRedisFailure_whenDraw_thenFailsOpenAndCountsDegraded() {
         ThroughputQuotaStats quotaStats = mock(ThroughputQuotaStats.class);
@@ -630,5 +725,16 @@ public class ThroughputQuotaServiceImplTest {
     public void givenHealthy_whenTheGraceIsChecked_thenItNeverExpires() {
         assertFalse("a healthy node never consults the clock",
                 ThroughputQuotaServiceImpl.RedisHealth.healthy(0).graceExpired(Long.MAX_VALUE / 2, 0));
+    }
+
+    // elapsed == grace must count as expired: the ">=" is what makes a zero grace refuse at the failure instant,
+    // and a refactor to ">" would silently break exactly that promise
+    @Test
+    public void givenTheGraceBoundary_whenChecked_thenElapsedEqualToTheGraceIsExpired() {
+        ThroughputQuotaServiceImpl.RedisHealth health = ThroughputQuotaServiceImpl.RedisHealth.healthy(0).failed(100);
+
+        assertTrue("zero grace: already expired at the failure instant", health.graceExpired(100, 0));
+        assertFalse("one nano short of the grace is still inside it", health.graceExpired(149, 50));
+        assertTrue("exactly the grace is past it", health.graceExpired(150, 50));
     }
 }

--- a/application/src/test/java/org/thingsboard/mqtt/broker/service/limits/ThroughputQuotaServiceImplTest.java
+++ b/application/src/test/java/org/thingsboard/mqtt/broker/service/limits/ThroughputQuotaServiceImplTest.java
@@ -366,6 +366,7 @@ public class ThroughputQuotaServiceImplTest {
     public void givenGraceExpired_whenRedisReturns_thenEnforcementResumes() throws InterruptedException {
         service.drawExecutor = MoreExecutors.newDirectExecutorService();
         service.degradedGraceMs = 100;
+        service.degradedProbeIntervalNanos = TimeUnit.MILLISECONDS.toNanos(20);
         when(rateLimitCacheService.tryConsumeTotalMsgs(anyLong())).thenThrow(new RuntimeException("redis down"));
         service.init();
 
@@ -373,16 +374,16 @@ public class ThroughputQuotaServiceImplTest {
         assertFalse("past the grace the node refuses", service.tryConsumeIncoming());
 
         doReturn(10L).when(rateLimitCacheService).tryConsumeTotalMsgs(anyLong());
+        Thread.sleep(30); // let the probe interval elapse, so the next charge is allowed to reach Redis
 
-        // Redis is healthy again. Charges are the only thing that ever reaches it, so they must keep probing: this
-        // one still refuses (it found the pool empty) but its draw lands and clears the degraded state.
+        // Charges are the only thing that ever reaches Redis, so this one has to probe. It still refuses - it found
+        // the pool empty - but its draw lands and clears the degraded state.
         assertFalse("the probing charge itself is still refused", service.tryConsumeIncoming());
 
-        // Spend the drawn block EXACTLY: proving recovery means proving the grants come out of the 10 tokens the
-        // probe brought back, not out of a fail-open window left armed by the last failure. A node still failing
-        // open would hand out all 11.
-        assertEquals("a node that could not probe Redis would never recover", 10, service.tryConsumeOutgoing(11));
-        assertFalse("with the drawn block spent, enforcement binds again", service.tryConsumeIncoming());
+        // Recovered, so grants come from the drawn block plus the node's ordinary burst credit. Asking for far more
+        // than that is what separates recovery from a fail-open window: a node still failing open returns all 5000.
+        assertEquals("a node that could not probe Redis would never recover",
+                10 + service.deriveBurstAllowance(), service.tryConsumeOutgoing(5000));
     }
 
     @Test

--- a/application/src/test/java/org/thingsboard/mqtt/broker/service/limits/ThroughputQuotaServiceImplTest.java
+++ b/application/src/test/java/org/thingsboard/mqtt/broker/service/limits/ThroughputQuotaServiceImplTest.java
@@ -126,6 +126,9 @@ public class ThroughputQuotaServiceImplTest {
         when(statsManager.getThroughputQuotaStats()).thenReturn(StubThroughputQuotaStats.STUB_THROUGHPUT_QUOTA_STATS);
         service = new ThroughputQuotaServiceImpl(
                 configuration, new DefaultThroughputLimitProvider(configuration), rateLimitCacheService, statsManager);
+        // @Value is not processed here, so mirror the shipped default: without it the field would be 0, which is the
+        // "fail closed the instant Redis goes away" setting and would silently change what every fail-open test means.
+        service.degradedGraceMs = 30_000;
     }
 
     @Test
@@ -269,6 +272,117 @@ public class ThroughputQuotaServiceImplTest {
 
         Thread.sleep(60); // DRY_BACKOFF_NANOS is 50 ms
         assertTrue("after backoff, credit resumes and a new draw is scheduled", service.tryConsumeIncoming());
+    }
+
+    // Fail-open is a bridge over a Redis blip, not a licence to serve unmetered traffic for as long as Redis stays
+    // down: the 1 s window is re-armed by every failed draw, so without a deadline on the CONTINUOUS outage the
+    // quota would never resume enforcing.
+    @Test
+    public void givenRedisDownPastGrace_whenConsuming_thenStopsGrantingFreely() throws InterruptedException {
+        service.drawExecutor = MoreExecutors.newDirectExecutorService();
+        service.degradedGraceMs = 100;
+        when(rateLimitCacheService.tryConsumeTotalMsgs(anyLong())).thenThrow(new RuntimeException("redis down"));
+
+        service.init(); // warm-up draw fails -> degraded, the grace starts
+
+        assertTrue("within the grace the quota must still fail open", service.tryConsumeIncoming());
+
+        Thread.sleep(150); // past the grace, while the fail-open window is still being re-armed
+
+        assertFalse("past the grace an unreachable shared bucket must stop granting", service.tryConsumeIncoming());
+        assertEquals("no bulk charge may ride on a grace that has expired", 0, service.tryConsumeOutgoing(1000));
+    }
+
+    // The deadline must measure ONE continuous outage. A node that loses Redis for a moment every so often is
+    // healthy between the blips, so each new outage starts its own grace rather than inheriting what an earlier one
+    // already spent - otherwise an intermittent Redis eventually locks the quota permanently closed.
+    @Test
+    public void givenIntermittentRedis_whenADrawSucceedsBetween_thenTheGraceClockRestarts() throws InterruptedException {
+        service.drawExecutor = MoreExecutors.newDirectExecutorService();
+        service.degradedGraceMs = 200;
+        when(rateLimitCacheService.tryConsumeTotalMsgs(anyLong())).thenThrow(new RuntimeException("redis down"));
+        service.init(); // fails -> the first outage's grace starts here
+
+        Thread.sleep(150); // 150 of the 200 ms consumed
+
+        doReturn(5L).when(rateLimitCacheService).tryConsumeTotalMsgs(anyLong());
+        service.draw(10); // Redis answers: the outage is over, local pool holds 5
+
+        when(rateLimitCacheService.tryConsumeTotalMsgs(anyLong())).thenThrow(new RuntimeException("down again"));
+        service.draw(10); // a NEW outage begins
+
+        Thread.sleep(100); // 250+ ms since the FIRST failure, but only ~100 into the new grace
+
+        // 5 local + 100 burst credit is the most a non-degraded node could grant, so 1000 proves fail-open is live
+        assertEquals("a fresh outage gets a fresh grace, not the remains of the previous one",
+                1000, service.tryConsumeOutgoing(1000));
+    }
+
+    // The failure mode this pins is the original bug in miniature: the fail-open WINDOW is re-armed by every failed
+    // draw, which is why it never ends. The grace must not inherit that property - it is anchored to when the outage
+    // started, not to the most recent attempt, or traffic keeps buying itself another grace.
+    @Test
+    public void givenRedisDown_whenLaterDrawsAlsoFail_thenTheGraceStillExpires() throws InterruptedException {
+        service.drawExecutor = MoreExecutors.newDirectExecutorService();
+        service.degradedGraceMs = 1500;
+        when(rateLimitCacheService.tryConsumeTotalMsgs(anyLong())).thenThrow(new RuntimeException("redis down"));
+        service.init(); // stamps the start of the outage
+
+        Thread.sleep(1100); // FAIL_OPEN_NANOS is 1 s, so the window has lapsed and the next charge draws again
+
+        assertTrue("still inside the grace", service.tryConsumeIncoming()); // this charge runs another failing draw
+
+        Thread.sleep(500); // ~1.6 s into a 1.5 s grace
+
+        assertFalse("a failed draw must not push the deadline out - the grace measures the outage, not the attempt",
+                service.tryConsumeIncoming());
+    }
+
+    // The blocking charge runs on an actor or consumer thread, and drawOnCallerThread blocks it on the Jedis socket
+    // for up to redis.standalone.connectTimeout (ships at 30 s). Past the grace the answer is already "refuse", so
+    // it must neither borrow nor block - but it still has to leave a probe behind, or a node whose only traffic is
+    // persisted fan-out would never discover that Redis came back.
+    @Test
+    public void givenGraceExpired_whenBlockingCharge_thenRefusesWithoutDrawingOnCallerThread() throws InterruptedException {
+        ManualExecutor executor = new ManualExecutor();
+        service.drawExecutor = executor;
+        service.degradedGraceMs = 1200;
+        when(rateLimitCacheService.tryConsumeTotalMsgs(anyLong())).thenThrow(new RuntimeException("redis down"));
+        service.init();
+        executor.runAll(); // the warm-up draw fails: the outage starts here
+
+        Thread.sleep(1300); // past the grace, and past the fail-open window that would otherwise short-circuit
+        clearInvocations(rateLimitCacheService);
+
+        assertEquals("past the grace the blocking charge grants nothing", 0, service.tryConsumeOutgoingBlocking(50));
+        verify(rateLimitCacheService, never()).tryConsumeTotalMsgs(anyLong()); // nothing ran on this thread
+        assertEquals("a recovery probe must still be queued for the draw executor", 1, executor.tasks.size());
+    }
+
+    // Refusing past the grace is only half the contract: the node must still notice Redis coming back. Recovery has
+    // to be driven through the public charge methods, because those are the only things production calls - a test
+    // that hand-invokes draw() would pass even if no charge could ever reach Redis again.
+    @Test
+    public void givenGraceExpired_whenRedisReturns_thenEnforcementResumes() throws InterruptedException {
+        service.drawExecutor = MoreExecutors.newDirectExecutorService();
+        service.degradedGraceMs = 100;
+        when(rateLimitCacheService.tryConsumeTotalMsgs(anyLong())).thenThrow(new RuntimeException("redis down"));
+        service.init();
+
+        Thread.sleep(150);
+        assertFalse("past the grace the node refuses", service.tryConsumeIncoming());
+
+        doReturn(10L).when(rateLimitCacheService).tryConsumeTotalMsgs(anyLong());
+
+        // Redis is healthy again. Charges are the only thing that ever reaches it, so they must keep probing: this
+        // one still refuses (it found the pool empty) but its draw lands and clears the degraded state.
+        assertFalse("the probing charge itself is still refused", service.tryConsumeIncoming());
+
+        // Spend the drawn block EXACTLY: proving recovery means proving the grants come out of the 10 tokens the
+        // probe brought back, not out of a fail-open window left armed by the last failure. A node still failing
+        // open would hand out all 11.
+        assertEquals("a node that could not probe Redis would never recover", 10, service.tryConsumeOutgoing(11));
+        assertFalse("with the drawn block spent, enforcement binds again", service.tryConsumeIncoming());
     }
 
     @Test

--- a/application/src/test/java/org/thingsboard/mqtt/broker/service/limits/ThroughputQuotaServiceImplTest.java
+++ b/application/src/test/java/org/thingsboard/mqtt/broker/service/limits/ThroughputQuotaServiceImplTest.java
@@ -42,6 +42,7 @@ import java.util.concurrent.atomic.AtomicLong;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.anyLong;
@@ -473,8 +474,8 @@ public class ThroughputQuotaServiceImplTest {
             drawPool.shutdown();
             assertTrue(drawPool.awaitTermination(5, TimeUnit.SECONDS)); // the stale success has landed
 
-            assertEquals("a success that started before the failure must not clear the degraded flag",
-                    true, ReflectionTestUtils.getField(service, "redisDegraded"));
+            assertTrue("a success that started before the failure must not clear the degraded flag",
+                    service.redisHealth().degraded());
         } finally {
             drawPool.shutdownNow();
         }
@@ -561,5 +562,73 @@ public class ThroughputQuotaServiceImplTest {
         service.returnUnusedTokens();
 
         verify(rateLimitCacheService, never()).returnTotalMsgs(anyLong());
+    }
+
+    // --- RedisHealth transitions. These are the compound rules the service used to keep across four volatile
+    //     fields by write-ordering convention; as pure functions on one immutable snapshot, the interleavings that
+    //     needed latches (or were impossible to pin at all) become plain argument values. ---
+
+    @Test
+    public void givenHealthy_whenADrawFails_thenTheOutageStartsAtThatFailure() {
+        ThroughputQuotaServiceImpl.RedisHealth health =
+                ThroughputQuotaServiceImpl.RedisHealth.healthy(100).failed(500);
+
+        assertTrue(health.degraded());
+        assertEquals(500, health.degradedSinceNanos());
+        assertEquals(500, health.lastFailureNanos());
+    }
+
+    @Test
+    public void givenDegraded_whenLaterDrawsAlsoFail_thenTheOutageStartDoesNotSlide() {
+        ThroughputQuotaServiceImpl.RedisHealth health =
+                ThroughputQuotaServiceImpl.RedisHealth.healthy(0).failed(100).failed(900).failed(2_000);
+
+        assertEquals("the grace measures the outage, not the latest attempt", 100, health.degradedSinceNanos());
+        assertEquals("probing keys off the most recent attempt", 2_000, health.lastFailureNanos());
+    }
+
+    // The interleaving the old volatile fields could not exclude: a success that read the failure timestamp
+    // BEFORE the failure stamped it could still clear the flag afterwards. As a CAS transition the decision
+    // re-runs against the failed state, so the stale success leaves it untouched.
+    @Test
+    public void givenAFailureLandedAfterTheDrawStarted_whenThatDrawSucceeds_thenDegradedIsKept() {
+        ThroughputQuotaServiceImpl.RedisHealth health =
+                ThroughputQuotaServiceImpl.RedisHealth.healthy(0).failed(100);
+
+        assertSame("a stale success must leave the state untouched", health, health.answered(50, 200));
+    }
+
+    @Test
+    public void givenTheDrawStartedAfterTheLastFailure_whenItSucceeds_thenHealthyAgain() {
+        ThroughputQuotaServiceImpl.RedisHealth health =
+                ThroughputQuotaServiceImpl.RedisHealth.healthy(0).failed(100).answered(150, 200);
+
+        assertFalse(health.degraded());
+    }
+
+    @Test
+    public void givenRecovered_whenTheWindowIsRead_thenItIsClosedImmediately() {
+        ThroughputQuotaServiceImpl.RedisHealth degraded =
+                ThroughputQuotaServiceImpl.RedisHealth.healthy(0).failed(100);
+
+        assertTrue("each failure arms the reprieve", degraded.failOpenWindowActive(101));
+        assertFalse("recovery must disarm it, or the rest of the second passes unmetered",
+                degraded.answered(150, 200).failOpenWindowActive(201));
+    }
+
+    @Test
+    public void givenANewOutageAfterARecovery_whenTheGraceIsChecked_thenItRunsFromTheNewOutage() {
+        ThroughputQuotaServiceImpl.RedisHealth health = ThroughputQuotaServiceImpl.RedisHealth.healthy(0)
+                .failed(100).answered(150, 200) // the first outage ends
+                .failed(300);                   // a new one begins
+
+        assertFalse("a fresh outage gets a fresh grace", health.graceExpired(350, 100));
+        assertTrue(health.graceExpired(401, 100));
+    }
+
+    @Test
+    public void givenHealthy_whenTheGraceIsChecked_thenItNeverExpires() {
+        assertFalse("a healthy node never consults the clock",
+                ThroughputQuotaServiceImpl.RedisHealth.healthy(0).graceExpired(Long.MAX_VALUE / 2, 0));
     }
 }

--- a/application/src/test/java/org/thingsboard/mqtt/broker/service/testing/integration/TotalThroughputQuotaRedisOutageIntegrationTestCase.java
+++ b/application/src/test/java/org/thingsboard/mqtt/broker/service/testing/integration/TotalThroughputQuotaRedisOutageIntegrationTestCase.java
@@ -1,0 +1,188 @@
+/**
+ * Copyright © 2016-2026 The Thingsboard Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.thingsboard.mqtt.broker.service.testing.integration;
+
+import io.micrometer.core.instrument.Counter;
+import lombok.extern.slf4j.Slf4j;
+import org.awaitility.Awaitility;
+import org.eclipse.paho.mqttv5.client.IMqttToken;
+import org.eclipse.paho.mqttv5.client.MqttCallback;
+import org.eclipse.paho.mqttv5.client.MqttClient;
+import org.eclipse.paho.mqttv5.client.MqttConnectionOptions;
+import org.eclipse.paho.mqttv5.client.MqttDisconnectResponse;
+import org.eclipse.paho.mqttv5.common.MqttException;
+import org.eclipse.paho.mqttv5.common.MqttMessage;
+import org.eclipse.paho.mqttv5.common.packet.MqttProperties;
+import org.junit.After;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.boot.test.context.SpringBootContextLoader;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.thingsboard.mqtt.broker.common.stats.StatsType;
+import org.thingsboard.mqtt.broker.dao.DaoSqlTest;
+
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * The headline outage arc end to end, against a real Jedis failure rather than a mock: Valkey is PAUSED - the
+ * socket blackholes, so draws hang for the client timeout, the harsh detection path - the quota degrades and
+ * refuses through the real {@code droppedMsgs} counter and a real {@code 0x97} PUBACK, then Valkey is unpaused
+ * and enforcement resumes through a real probe draw. Pause rather than stop/start, because a restarted container
+ * maps a new port the already-built Spring context would never find.
+ */
+@Slf4j
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@ContextConfiguration(classes = TotalThroughputQuotaRedisOutageIntegrationTestCase.class, loader = SpringBootContextLoader.class)
+@TestPropertySource(properties = {
+        // one token per second sustained keeps the node-local pool and credit tiny, so the outage is felt within a
+        // handful of publishes - while the 600-token capacity guarantees no refusal here can be a spent-budget
+        // refusal: every drop this suite asserts is attributable to the outage path alone
+        "mqtt.rate-limits.total.config=600:600",
+        "mqtt.rate-limits.total.block-size=1",
+        // refuse from the first failed draw. The grace DURATION arithmetic is pinned deterministically at the unit
+        // level against the nanoTime seam; a wall-clock grace here would re-introduce exactly the CI flakiness
+        // those tests avoid. What this suite adds is the wiring a mock cannot: the Jedis timeout, the refusal
+        // surfacing to a real client, and recovery once the container answers again.
+        "mqtt.rate-limits.total.degraded-grace-ms=0"
+})
+@DaoSqlTest
+@RunWith(SpringRunner.class)
+public class TotalThroughputQuotaRedisOutageIntegrationTestCase extends AbstractTotalThroughputQuotaIntegrationTest {
+
+    private static final int QUOTA_EXCEEDED = 151; // MQTT 5 reason code 0x97
+
+    private boolean valkeyPaused;
+
+    @After
+    public void unpauseValkeyIfStillPaused() {
+        unpauseValkey();
+    }
+
+    @Test
+    public void givenRedisOutage_whenPublishingPastTheGrace_thenRefusesAndRecoversWhenRedisReturns() throws Throwable {
+        MqttClient pubClient = new MqttClient(SERVER_URI + mqttPort, "quota_redis_outage");
+        List<Integer> reasonCodes = new CopyOnWriteArrayList<>();
+        pubClient.setCallback(new ReasonCodeCollector(reasonCodes));
+        pubClient.connect(new MqttConnectionOptions());
+        AtomicInteger seq = new AtomicInteger();
+        try {
+            // healthy baseline: a publish is charged against the real shared bucket and stored
+            double processedBefore = publishesProcessed();
+            publish(pubClient, seq.getAndIncrement());
+            Awaitility.await("the baseline publish is charged and stored")
+                    .atMost(AWAIT_TIMEOUT_SEC, TimeUnit.SECONDS)
+                    .until(() -> publishesProcessed() >= processedBefore + 1);
+
+            pauseValkey();
+
+            // drive traffic until a draw actually FAILS: only then is the node degraded and the (zero) grace over.
+            // Refusals before that instant belong to the bounded onset gap, not to the deadline under test.
+            Awaitility.await("the first failed draw marks the node degraded")
+                    .atMost(AWAIT_TIMEOUT_SEC, TimeUnit.SECONDS)
+                    .until(() -> {
+                        publish(pubClient, seq.getAndIncrement());
+                        return degradedCount() >= 1;
+                    });
+
+            // past the grace every publish must be refused: a droppedMsgs record and 0x97 to the MQTT 5 publisher
+            double droppedBefore = droppedMsgs();
+            reasonCodes.clear();
+            Awaitility.await("a publish past the grace is refused with QUOTA_EXCEEDED and lands in droppedMsgs")
+                    .atMost(AWAIT_TIMEOUT_SEC, TimeUnit.SECONDS)
+                    .until(() -> {
+                        publish(pubClient, seq.getAndIncrement());
+                        return droppedMsgs() > droppedBefore && reasonCodes.contains(QUOTA_EXCEEDED);
+                    });
+
+            double processedAtOutage = publishesProcessed();
+            unpauseValkey();
+
+            // recovery is driven through the same public charge path production uses: a probing draw lands against
+            // the resumed socket and granting resumes - a node that could not probe would refuse forever
+            Awaitility.await("after Redis returns, a publish is granted and stored again")
+                    .atMost(AWAIT_TIMEOUT_SEC, TimeUnit.SECONDS)
+                    .until(() -> {
+                        publish(pubClient, seq.getAndIncrement());
+                        return publishesProcessed() > processedAtOutage;
+                    });
+        } finally {
+            unpauseValkey(); // before the client teardown, so the disconnect never races a paused broker dependency
+            pubClient.disconnect();
+            pubClient.close();
+        }
+    }
+
+    private void publish(MqttClient client, int seq) throws MqttException {
+        client.publish("quota/redis/outage", ("data_" + seq).getBytes(StandardCharsets.UTF_8), 1, false);
+    }
+
+    private double degradedCount() {
+        Counter counter = meterRegistry.find(StatsType.THROUGHPUT_QUOTA_DEGRADED.getPrintName()).counter();
+        return counter == null ? 0 : counter.count();
+    }
+
+    private void pauseValkey() {
+        valkey.getDockerClient().pauseContainerCmd(valkey.getContainerId()).exec();
+        valkeyPaused = true;
+        log.info("Paused the Valkey container: the shared bucket is now a black hole");
+    }
+
+    private void unpauseValkey() {
+        if (valkeyPaused) {
+            valkey.getDockerClient().unpauseContainerCmd(valkey.getContainerId()).exec();
+            valkeyPaused = false;
+            log.info("Unpaused the Valkey container");
+        }
+    }
+
+    /** Collects PUBACK reason codes off Paho's callback thread; everything else is irrelevant to this suite. */
+    private record ReasonCodeCollector(List<Integer> reasonCodes) implements MqttCallback {
+
+        @Override
+        public void deliveryComplete(IMqttToken token) {
+            for (int code : token.getReasonCodes()) {
+                reasonCodes.add(code);
+            }
+        }
+
+        @Override
+        public void disconnected(MqttDisconnectResponse response) {
+        }
+
+        @Override
+        public void mqttErrorOccurred(MqttException e) {
+        }
+
+        @Override
+        public void messageArrived(String topic, MqttMessage message) {
+        }
+
+        @Override
+        public void connectComplete(boolean reconnect, String serverURI) {
+        }
+
+        @Override
+        public void authPacketArrived(int reasonCode, MqttProperties properties) {
+        }
+    }
+}


### PR DESCRIPTION
## Pull Request description

The cluster-wide total throughput quota fails open when it cannot reach the shared Redis bucket. That is deliberate for a Redis blip, but the 1-second fail-open window was re-armed by every failed draw, so a longer outage never ended it: for as long as Redis stayed unreachable, every node granted every charge in full. Nothing was refused, nothing landed in `droppedMsgs`, and `throughputQuotaDegraded` only moved while traffic drove draws. Since Redis is required to start the broker but not to keep it running, stopping Redis after clients had connected bypassed the quota for an unbounded period.

This PR bounds the fail-open to one continuous outage:

- New `mqtt.rate-limits.total.degraded-grace-ms` (default `30000` — enough to ride out a Redis Cluster/Sentinel failover). The grace clock starts at the first failed draw of an outage and is not extended by later failures; any successful draw resets it, so an intermittent Redis never accumulates toward the deadline.
- Within the grace, behaviour is unchanged: charges are granted freely and the blip is absorbed.
- Past the grace the node lends nothing: the credit floor drops to 0, so it spends only tokens it actually drew and then refuses — reported in `droppedMsgs`; MQTT 5 publishers get `0x97 QUOTA_EXCEEDED`, MQTT 3.x publishers are disconnected.
- Refusing never stops probing: refusals still fall through to the draw path (limited to one probe per second) because a completed draw is the only thing that can notice Redis returning. The blocking bulk charge queues its probe on the draw executor instead of blocking an actor/consumer thread on the dead socket.
- The lease-return tick is skipped while degraded, so a hanging Redis call cannot strand the node's remaining tokens.
- The draw-failure WARN now says which way the quota is currently failing (open within the grace / refusing past it), and the quota javadocs were aligned with the bounded behaviour.
- The Redis-health state (degraded flag, outage start, last failure, fail-open window) is consolidated into one immutable `RedisHealth` snapshot swapped by CAS instead of four coordinated volatile fields, so the compound transition rules — a stale success must not clear a newer failure, the grace is stamped once per continuous outage — hold by construction rather than by write-ordering convention. The fail-open window is derived from the snapshot rather than stored, which removes the disarm-on-recovery bookkeeping.

Documentation notes: document `degraded-grace-ms`, and add a release note for the behaviour change — a Redis outage longer than the grace now refuses PUBLISH packets instead of passing unmetered traffic indefinitely.

Covered by unit tests: the grace ends fail-open; it measures one continuous outage (restarts after a successful draw, is not pushed out by repeated failures); the blocking charge refuses without a caller-thread draw but leaves a probe queued; enforcement resumes through the public charge methods once Redis answers; an MQTT 3.x publisher refused by the quota is disconnected without the packet reaching the actor; and the `RedisHealth` transitions are pinned deterministically (stale-success staleness rule, per-outage grace stamping, window disarm on recovery).

## General checklist

- [x] You have reviewed the guidelines [document](https://docs.google.com/document/d/1A4Vc3wrHsY_159b9RG5LOtCryoH6VPwgOhrFEzJKwbI/edit?usp=sharing).
- [x] [Labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels#about-labels) that classify your pull request have been added.
- [x] The [milestone](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones) is specified and corresponds to fix version.
- [x] Description references specific [issue](https://github.com/thingsboard/tbmq/issues).
- [x] Description contains human-readable scope of changes.
- [x] Description contains brief notes about what needs to be added to the documentation.
- [x] No merge conflicts, commented blocks of code, code formatting issues.
- [x] Changes are backward compatible or upgrade script is provided.

## Front-End feature checklist

- [x] Screenshots with affected component(s) are added. The best option is to provide 2 screens: before and after changes;
- [x] If you change the widget or other API, ensure it is backward-compatible or upgrade script is present.

## Back-End feature checklist

- [x] Added corresponding unit and/or integration test(s). Provide written explanation in the PR description if you have failed to add tests.
- [x] If new dependency was added: the dependency tree is checked for conflicts.
