### PR TITLE
fix: update site links to new tbmq.io domain and docs structure

### DIFF
--- a/ui-ngx/src/app/modules/home/components/home/version-card.component.html
+++ b/ui-ngx/src/app/modules/home/components/home/version-card.component.html
@@ -18,7 +18,7 @@
 <div class="tb-home-card-container tb-home-padding flex flex-col">
   <section class="title-container mb-1 flex flex-row items-center justify-between">
     <tb-card-title-button [cardType]="cardType" [disabled]="true"></tb-card-title-button>
-    <a (click)="gotoDocs('docs/contact-us')" translate>version.contact-us</a>
+    <a (click)="gotoDocs(contactUsLink)" translate>version.contact-us</a>
   </section>
   <section class="cards">
     @if (updatesAvailable) {
@@ -49,7 +49,7 @@
           <span>{{ latestReleaseVersion }}</span>
           <button [class.lt-md:!hidden]="true" mat-raised-button color="primary"
             [disabled]="!updatesAvailable"
-            (click)="gotoDocs('docs/mqtt-broker/install/upgrade-instructions')"
+            (click)="gotoDocs(upgradeInstructionsLink)"
             matTooltip="{{'version.upgrade-instructions' | translate}}">
             {{'version.upgrade' | translate}}
           </button>

--- a/ui-ngx/src/app/modules/home/components/home/version-card.component.ts
+++ b/ui-ngx/src/app/modules/home/components/home/version-card.component.ts
@@ -16,6 +16,7 @@
 
 import { Component, OnInit } from '@angular/core';
 import { HomePageTitleType } from '@shared/models/home-page.model';
+import { HelpLinks } from '@shared/models/constants';
 import { ConfigService } from '@core/http/config.service';
 import { CardTitleButtonComponent } from '@shared/components/button/card-title-button.component';
 import { TranslateModule } from '@ngx-translate/core';
@@ -32,6 +33,8 @@ import { MatTooltip } from '@angular/material/tooltip';
 export class VersionCardComponent implements OnInit {
 
   cardType = HomePageTitleType.VERSION;
+  contactUsLink = HelpLinks.linksMap.contactUs;
+  upgradeInstructionsLink = HelpLinks.linksMap.upgradeInstructions;
   updatesAvailable: boolean;
   currentReleaseVersion: string;
   latestReleaseVersion: string;
@@ -50,8 +53,8 @@ export class VersionCardComponent implements OnInit {
       });
     }
 
-  gotoDocs(page: string){
-    window.open(`https://thingsboard.io/${page}`, '_blank');
+  gotoDocs(link: string){
+    window.open(link, '_blank');
   }
 
   gotoGithub(version: string){

--- a/ui-ngx/src/app/modules/home/pages/ws-client/ws-client.component.html
+++ b/ui-ngx/src/app/modules/home/pages/ws-client/ws-client.component.html
@@ -76,7 +76,7 @@
       <tb-ws-subscriptions></tb-ws-subscriptions>
     </section>
     <section class="client-section">
-      <tb-help-page [page]="'https://thingsboard.io/docs/mqtt-broker/user-guide/ui/websocket-client'"></tb-help-page>
+      <tb-help-page [page]="connectionHelpLink"></tb-help-page>
     </section>
   </section>
 </ng-template>

--- a/ui-ngx/src/app/modules/login/pages/login/login.component.html
+++ b/ui-ngx/src/app/modules/login/pages/login/login.component.html
@@ -21,7 +21,7 @@
       <form class="tb-login-form" [formGroup]="loginFormGroup" (ngSubmit)="login()">
         <fieldset class="flex flex-col">
           <div class="flex flex-col items-center" style="padding: 15px 0;">
-            <tb-logo link="https://thingsboard.io/products/mqtt-broker" target="_blank" class="login-logo"></tb-logo>
+            <tb-logo [link]="siteBaseUrl" target="_blank" class="login-logo"></tb-logo>
           </div>
           @if (isLoading$ | async) {
             <mat-progress-bar color="warn" mode="indeterminate">

--- a/ui-ngx/src/app/modules/login/pages/login/login.component.ts
+++ b/ui-ngx/src/app/modules/login/pages/login/login.component.ts
@@ -20,7 +20,7 @@ import { AppState } from '@core/core.state';
 import { PageComponent } from '@shared/components/page.component';
 import { UntypedFormBuilder, FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { HttpErrorResponse } from '@angular/common/http';
-import { Constants } from '@shared/models/constants';
+import { Constants, helpBaseUrl } from '@shared/models/constants';
 import { Router, RouterLink } from '@angular/router';
 import { AuthService } from '@core/http/auth.service';
 import { MatCard, MatCardContent } from '@angular/material/card';
@@ -45,6 +45,7 @@ import { MatTooltip } from '@angular/material/tooltip';
 })
 export class LoginComponent extends PageComponent {
 
+  siteBaseUrl = helpBaseUrl;
   passwordViolation = false;
 
   loginFormGroup = this.fb.group({

--- a/ui-ngx/src/app/shared/models/constants.ts
+++ b/ui-ngx/src/app/shared/models/constants.ts
@@ -54,8 +54,8 @@ export const MediaBreakpoints = {
   'md-lg': 'screen and (min-width: 960px) and (max-width: 1819px)'
 };
 
-export const helpBaseUrl = 'https://thingsboard.io';
-export const docsPath = '/docs/mqtt-broker';
+export const helpBaseUrl = 'https://tbmq.io';
+export const docsPath = '/docs';
 export const HelpLinks = {
   linksMap: {
     outgoingMailSettings: helpBaseUrl + docsPath + '/user-guide/ui/settings/#mail-server-settings',
@@ -92,15 +92,17 @@ export const HelpLinks = {
     mqttProtocol: helpBaseUrl + docsPath + '/user-guide/mqtt-protocol/',
     troubleshooting: helpBaseUrl + docsPath + '/troubleshooting/',
     monitoring: helpBaseUrl + docsPath + '/user-guide/ui/monitoring/',
-    monitoringKafkaBrokers: helpBaseUrl + docsPath + '/user-guide/ui/monitoring/#kafka-brokers',
-    monitoringConfig: helpBaseUrl + docsPath + '/user-guide/ui/monitoring/#config',
+    monitoringKafkaBrokers: helpBaseUrl + docsPath + '/user-guide/ui/monitoring/',
+    monitoringConfig: helpBaseUrl + docsPath + '/user-guide/ui/monitoring/#broker-settings',
     clientType: helpBaseUrl + docsPath + '/user-guide/mqtt-client-type/',
     connectToThingsBoard: helpBaseUrl + docsPath + '/user-guide/integrations/how-to-connect-thingsboard-to-tbmq/',
     perfTest100m: helpBaseUrl + docsPath + '/reference/100m-connections-performance-test/',
     configuration: helpBaseUrl + docsPath + '/installation/config/',
     architecture: helpBaseUrl + docsPath + '/architecture/',
-    pricing: helpBaseUrl + '/pricing/?section=tbmq-options&product=tbmq-ce',
+    pricing: helpBaseUrl + '/pricing/?product=tbmq-ce',
     cleanPersistentSessions: helpBaseUrl + docsPath + '/user-guide/clean-persistent-sessions/',
+    contactUs: helpBaseUrl + '/contact-us/',
+    upgradeInstructions: helpBaseUrl + docsPath + '/installation/upgrade-instructions/',
     releases: 'https://github.com/thingsboard/tbmq/releases'
   }
 };

--- a/ui-ngx/src/assets/getting-started/guide-javascript.md
+++ b/ui-ngx/src/assets/getting-started/guide-javascript.md
@@ -103,4 +103,4 @@ Packet send cmd:  puback
 #### See also
 On the official MQTT.js <a target="_blank" href="https://github.com/mqttjs/MQTT.js">GitHub page</a> you can find detailed information about using JavaScript library, including its extensive features and usage examples.
 
-Additionally, might be useful our guide on <a target="_blank" href="https://thingsboard.io/docs/mqtt-broker/user-guide/mqtt-over-ws/">MQTT over WebSocket</a>, featuring an example of using the aforementioned library with the <a target="_blank" href="/ws-client">TBMQ WebSocket Client</a>.
+Additionally, might be useful our guide on <a target="_blank" href="https://tbmq.io/docs/user-guide/mqtt-over-ws/">MQTT over WebSocket</a>, featuring an example of using the aforementioned library with the <a target="_blank" href="/ws-client">TBMQ WebSocket Client</a>.

--- a/ui-ngx/src/assets/locale/locale.constant-de_DE.json
+++ b/ui-ngx/src/assets/locale/locale.constant-de_DE.json
@@ -156,7 +156,7 @@
         "authorization-dynamic-hint": "Sie können optional Autorisierungsregeln für Publish/Subscribe aus JWT-Claims extrahieren:<ul><li>Falls gesetzt, verwendet der Broker die in den Claims gefundenen Topic zur Steuerung der Client-Autorisierung.</li><li>Falls nicht vorhanden oder ungültig, werden die Standard-Autorisierungsregeln als Fallback verwendet.</li><li>Der Claim-Wert muss ein <b>JSON-Array von Strings</b> sein, das Topic darstellt, z. B. <code>[\"sensors/.*\", \"updates/.*\"]</code></li></ul>",
         "authorization-default": "Standard-Autorisierungsregeln",
         "client-type": "Client-Typ",
-        "client-type-hint": "Konfigurieren Sie, wie der Broker den <a href='https://thingsboard.io/docs/mqtt-broker/user-guide/mqtt-client-type/' target='_blank'>Client-Typ</a> anhand von JWT-Claims bestimmt:<ul><li>Standardmäßig wird allen Clients der ausgewählte Typ zugewiesen – <b>{{type}}</b>.</li><li>Wenn alle konfigurierten Claim-Bedingungen zutreffen, wird dem Client der alternative Typ zugewiesen – <b>{{targetType}}</b>.</li></ul>Beispiel: Ist der Standardtyp <b>{{type}}</b> und die Bedingung <code>{your_claim} = {your_value}</code> gesetzt, wird der Client als <b>{{targetType}}</b> klassifiziert, wenn <code>{your_claim}</code> existiert und den Wert <code>{your_value}</code> hat.",
+        "client-type-hint": "Konfigurieren Sie, wie der Broker den <a href='https://tbmq.io/docs/user-guide/mqtt-client-type/' target='_blank'>Client-Typ</a> anhand von JWT-Claims bestimmt:<ul><li>Standardmäßig wird allen Clients der ausgewählte Typ zugewiesen – <b>{{type}}</b>.</li><li>Wenn alle konfigurierten Claim-Bedingungen zutreffen, wird dem Client der alternative Typ zugewiesen – <b>{{targetType}}</b>.</li></ul>Beispiel: Ist der Standardtyp <b>{{type}}</b> und die Bedingung <code>{your_claim} = {your_value}</code> gesetzt, wird der Client als <b>{{targetType}}</b> klassifiziert, wenn <code>{your_claim}</code> existiert und den Wert <code>{your_value}</code> hat.",
         "claim": "Claim",
         "claims": "Authentifizierungsansprüche",
         "claims-hint": "Claim-basierte Authentifizierungsbedingungen erlauben zusätzliche Sicherheitsprüfungen basierend auf JWT-Claims:<ul><li>Nach Signatur- und Ablaufprüfung prüft der Broker, ob jeder konfigurierte Claim mit dem erwarteten Wert übereinstimmt.</li><li>Platzhalter wie <b>${username}</b> oder <b>${clientId}</b> können verwendet werden, um zur Laufzeit Benutzername oder Client-ID zuzuordnen.</li><li>Stimmt ein Claim nicht, schlägt die Authentifizierung fehl.</li></ul>Beispiele: <ul><li><code>sub = ${clientId}</code> — prüft, ob das Token-Subject der Client-ID entspricht.</li><li><code>env = prod</code> — erlaubt nur Tokens mit <code>env</code>-Claim = <code>prod</code>.</li></ul>",
@@ -777,7 +777,7 @@
         "user-name-required": "Username ist erforderlich.",
         "hint-client-type-application": "Verwenden Sie den Typ 'Application' für Clients, die in der Regel Nachrichten mit hoher Frequenz empfangen und Persistenz benötigen (z. B. <b>IoT-Anwendungen</b>).",
         "hint-client-type-device": "Verwenden Sie den Typ 'Device' für Clients, die in der Regel viele Nachrichten veröffentlichen, aber nur wenige Topics mit geringer Frequenz abonnieren (z. B. <b>IoT-Geräte</b>).",
-        "hint-client-type-read-more": "<a href='https://thingsboard.io/docs/mqtt-broker/user-guide/mqtt-client-type/' target='_blank'>Mehr erfahren</a>.",
+        "hint-client-type-read-more": "<a href='https://tbmq.io/docs/user-guide/mqtt-client-type/' target='_blank'>Mehr erfahren</a>.",
         "hint-credentials-type-basic": "<b>'Basic'</b> ist ein einseitiges Authentifizierungsverfahren auf Basis verschiedener Kombinationen aus <b>Client ID, Username und/oder Password</b>:<ul><li><b>Client ID</b> – prüft, ob die Verbindung eine Client ID enthält</li><li><b>Username</b> – prüft, ob ein Username angegeben wurde</li><li><b>Client ID und Username</b> – prüft, ob beide angegeben sind</li><li><b>Username und Password</b> – prüft, ob beide angegeben sind</li><li><b>Client ID und Password</b> – prüft, ob beide angegeben sind</li><li><b>Client ID, Username und Password</b> – prüft, ob alle drei angegeben sind</li></ul>",
         "hint-credentials-type-ssl": "<b>'X.509 Certificate Chain'</b> ist ein sicheres, zweiseitiges Authentifizierungsverfahren über TLS mit einer Kette von öffentlichen Schlüsseln.",
         "hint-credentials-type-scram": "<b>'SCRAM'</b> (Salted Challenge Response Authentication Mechanism) ist ein erweitertes Authentifizierungsverfahren für MQTT 5, das eine sichere, passwortbasierte Authentifizierung bietet.",
@@ -921,7 +921,7 @@
         "name": "Name",
         "name-required": "Name ist erforderlich.",
         "name-max-length": "Name darf höchstens 256 Zeichen lang sein",
-        "hint-application-shared-subscription": "<b>Application Shared Subscriptions</b> sind TBMQ-Entities zur effektiven Verwaltung der Funktion <b>Shared Subscriptions</b> im MQTT. Bereitstellen, wenn Sie <b>Shared Subscriptions mit Application Clients</b> nutzen möchten. <a href='https://thingsboard.io/docs/mqtt-broker/user-guide/shared-subscriptions/' target='_blank'>Mehr erfahren.</a>",
+        "hint-application-shared-subscription": "<b>Application Shared Subscriptions</b> sind TBMQ-Entities zur effektiven Verwaltung der Funktion <b>Shared Subscriptions</b> im MQTT. Bereitstellen, wenn Sie <b>Shared Subscriptions mit Application Clients</b> nutzen möchten. <a href='https://tbmq.io/docs/user-guide/shared-subscriptions/' target='_blank'>Mehr erfahren.</a>",
         "hint-topic-filter": "Das Format für einen Shared Subscription Topic Filter ist <code>$share/ShareName/TopicFilter</code>. Ist der Filter e.g. <code>$share/group1/city/+/home/#</code>, setzen Sie Topic Filter auf <code>city/+/home/#</code>.",
         "hint-partitions": "Es wird empfohlen, die Anzahl der Partitions gleich oder ein Vielfaches der erwarteten Anzahl an Clients der Shared Subscription zu wählen. Beispiel: Für 5 Clients – 5, 10 oder 15 Partitions – für eine gleichmäßige Lastverteilung.",
         "hint-shared-subscription-notes": "<li><i>Topic Filter</i> und <i>Partitions</i> können nach der Erstellung nicht geändert werden.</li><li>Application Shared Subscriptions funktionieren mit MQTT v5 und v3.x</li>",
@@ -948,7 +948,7 @@
         "delete-retained-messages-text": "Achtung: Nach der Bestätigung werden alle ausgewählten Retained Messages gelöscht und alle zugehörigen Daten unwiederbringlich entfernt.",
         "clear-empty-retained-message-nodes": "Leere Retained Message-Knoten löschen",
         "clear-empty-retained-message-nodes-title": "Leere Retained Message-Knoten löschen?",
-        "clear-empty-retained-message-nodes-text": "Achtung: Nach der Bestätigung werden alle leeren <a target='_blank' href='https://thingsboard.io/docs/mqtt-broker/user-guide/retained-messages/#clearing-empty-retained-message-nodes'>Retained Message-Knoten</a> gelöscht.",
+        "clear-empty-retained-message-nodes-text": "Achtung: Nach der Bestätigung werden alle leeren <a target='_blank' href='https://tbmq.io/docs/user-guide/retained-messages/#clearing-empty-retained-message-nodes'>Retained Message-Knoten</a> gelöscht.",
         "details": "Details zur Retained Message",
         "search": "Nach Topic suchen",
         "selected-retained-messages": "{ count, plural, =1 {1 Retained Message} other {# Retained Messages} } ausgewählt",
@@ -1171,19 +1171,19 @@
             },
             "step-2": {
                 "title": "Application Credentials hinzufügen",
-                "text": "Lassen Sie uns Credentials hinzufügen, um den <a target='_blank' href='https://thingsboard.io/docs/mqtt-broker/user-guide/mqtt-client-type/#application-client'>Application</a> Client zu verbinden.\nDiese Credentials werden verwendet, um Nachrichten zu abonnieren, die von anderen MQTT Clients veröffentlicht werden.\n\nUm fortzufahren, klicken Sie bitte unten auf die Schaltfläche <b>Add Application Credentials</b> und bestätigen Sie die Aktion durch Klicken auf <b>Add</b>.\n"
+                "text": "Lassen Sie uns Credentials hinzufügen, um den <a target='_blank' href='https://tbmq.io/docs/user-guide/mqtt-client-type/#application-client'>Application</a> Client zu verbinden.\nDiese Credentials werden verwendet, um Nachrichten zu abonnieren, die von anderen MQTT Clients veröffentlicht werden.\n\nUm fortzufahren, klicken Sie bitte unten auf die Schaltfläche <b>Add Application Credentials</b> und bestätigen Sie die Aktion durch Klicken auf <b>Add</b>.\n"
             },
             "step-3": {
                 "title": "Device Credentials hinzufügen",
-                "text": "Lassen Sie uns nun Credentials hinzufügen, um den <a target='_blank' href='https://thingsboard.io/docs/mqtt-broker/user-guide/mqtt-client-type/#device-client'>Device</a> Client zu verbinden.\nDies ermöglicht das Veröffentlichen von Nachrichten an <b>TBMQ</b>.\nBitte klicken Sie auf die Schaltfläche <b>Add Device Credentials</b>.\n"
+                "text": "Lassen Sie uns nun Credentials hinzufügen, um den <a target='_blank' href='https://tbmq.io/docs/user-guide/mqtt-client-type/#device-client'>Device</a> Client zu verbinden.\nDies ermöglicht das Veröffentlichen von Nachrichten an <b>TBMQ</b>.\nBitte klicken Sie auf die Schaltfläche <b>Add Device Credentials</b>.\n"
             },
             "step-4": {
                 "title": "Topic abonnieren",
-                "text": "Um den <a target='_blank' href='https://thingsboard.io/docs/mqtt-broker/user-guide/mqtt-client-type/#application-client'>Application</a> Client\nfür das MQTT Topic `tbmq/demo/+` zu abonnieren, verwenden wir den MQTT Client <a href='https://mosquitto.org/man/mosquitto_sub-1.html' target=\"_blank\">mosquitto_sub</a>.\nBitte kopieren Sie den folgenden Code und fügen Sie ihn in einen Terminal-Tab ein:"
+                "text": "Um den <a target='_blank' href='https://tbmq.io/docs/user-guide/mqtt-client-type/#application-client'>Application</a> Client\nfür das MQTT Topic `tbmq/demo/+` zu abonnieren, verwenden wir den MQTT Client <a href='https://mosquitto.org/man/mosquitto_sub-1.html' target=\"_blank\">mosquitto_sub</a>.\nBitte kopieren Sie den folgenden Code und fügen Sie ihn in einen Terminal-Tab ein:"
             },
             "step-5": {
                 "title": "Nachricht veröffentlichen",
-                "text": "Um eine Nachricht vom <a target='_blank' rel='noopener noreferrer' href='https://thingsboard.io/docs/mqtt-broker/user-guide/mqtt-client-type/#device-client'>Device</a> Client\nan das Topic `tbmq/demo/topic` zu veröffentlichen, öffnen Sie einen neuen Tab im Terminal und fügen Sie den folgenden Befehl ein:",
+                "text": "Um eine Nachricht vom <a target='_blank' rel='noopener noreferrer' href='https://tbmq.io/docs/user-guide/mqtt-client-type/#device-client'>Device</a> Client\nan das Topic `tbmq/demo/topic` zu veröffentlichen, öffnen Sie einen neuen Tab im Terminal und fügen Sie den folgenden Befehl ein:",
                 "after-command": "Sobald Sie diesen Befehl ausführen, sollten Sie die veröffentlichte Nachricht im Terminal-Tab des abonnierten Clients sehen."
             },
             "step-6": {
@@ -1342,7 +1342,7 @@
     "subscription": {
         "add-subscription": "Subscription hinzufügen",
         "clear-empty-subscription-nodes": "Leere Subscription-Knoten löschen",
-        "clear-empty-subscription-nodes-text": "Achtung: Nach der Bestätigung werden alle leeren <a target='_blank' href='https://thingsboard.io/docs/mqtt-broker/user-guide/ui/subscriptions/#clearing-empty-subscription-nodes'>Subscription</a>-Knoten gelöscht.",
+        "clear-empty-subscription-nodes-text": "Achtung: Nach der Bestätigung werden alle leeren <a target='_blank' href='https://tbmq.io/docs/user-guide/ui/subscriptions/#clearing-empty-subscription-nodes'>Subscription</a>-Knoten gelöscht.",
         "clear-empty-subscription-nodes-title": "Leere Subscription-Knoten löschen?",
         "color": "Farbe",
         "copy-topic": "Topic-Filter kopieren",

--- a/ui-ngx/src/assets/locale/locale.constant-en_US.json
+++ b/ui-ngx/src/assets/locale/locale.constant-en_US.json
@@ -173,7 +173,7 @@
         "expected-response-json": "<code>{</br>\n&nbsp;&nbsp;\"result\": \"success\",</br>\n&nbsp;&nbsp;\"clientType\": \"application\",</br>\n&nbsp;&nbsp;\"authRules\": {</br>\n&nbsp;&nbsp;&nbsp;&nbsp;\"pub\": [\"telemetry/.*\", \"alerts/.*\"],</br>\n&nbsp;&nbsp;&nbsp;&nbsp;\"sub\": [\"commands/.*\"]</br>\n&nbsp;&nbsp;}</br>\n}</code>",
         "expected-response-interpretation": "Server response interpretation:<ul><li><b>result</b> — <b>success</b> (authenticated), <b>failure</b> (denied), or <b>skipped</b> (try next provider). If the field is missing, it defaults to <b>success</b>; if the value is unrecognized, it is treated as <b>skipped</b>. Values are case-insensitive (e.g., <b>'SUCCESS'</b> is treated as <b>success</b>).</li><li><b>clientType</b> — <b>application</b> or <b>device</b>. If missing, unrecognized or empty, the <b>Default client type</b> from the configuration is used. Values are case-insensitive (e.g., <b>'DEVICE'</b> is treated as <b>device</b>).</li><li><b>authRules</b> — if missing or unparsable, <b>Default authorization rules</b> are applied. If <b>pub</b> or <b>sub</b> lists are explicitly <b>null</b> or <b>empty</b>, the respective action is strictly <b>forbidden</b>.</li><li><b>HTTP Status Code</b> — only successful responses (<b>2xx</b>) trigger the body parsing described above. If the response body is empty or null, the client is <b>authenticated</b> and assigned the default type and authorization rules. Other responses (<b>3xx, 4xx, 5xx</b>) are automatically treated as <b>skipped</b>.</li></ul>",
         "client-type": "Client type",
-        "client-type-hint": "Configure how the broker determines the <a href='https://thingsboard.io/docs/mqtt-broker/user-guide/mqtt-client-type/' target='_blank'>client type</a> during authentication based on JWT claims:<ul><li>By default, all clients are assigned the selected type - <b>{{type}}</b>.</li><li>If all defined claim conditions match, the broker will assign the opposite client type - <b>{{targetType}}</b>.</li></ul>Example: If the default type is <b>{{type}}</b> and the condition <code>{your_claim} = {your_value}</code> is configured, the client will be classified as <b>{{targetType}}</b> when <code>{your_claim}</code> exists and matches <code>{your_value}</code>.",
+        "client-type-hint": "Configure how the broker determines the <a href='https://tbmq.io/docs/user-guide/mqtt-client-type/' target='_blank'>client type</a> during authentication based on JWT claims:<ul><li>By default, all clients are assigned the selected type - <b>{{type}}</b>.</li><li>If all defined claim conditions match, the broker will assign the opposite client type - <b>{{targetType}}</b>.</li></ul>Example: If the default type is <b>{{type}}</b> and the condition <code>{your_claim} = {your_value}</code> is configured, the client will be classified as <b>{{targetType}}</b> when <code>{your_claim}</code> exists and matches <code>{your_value}</code>.",
         "claim": "Claim",
         "claims": "Authentication claims",
         "claims-hint": "Claim-based authentication conditions allow you to add extra security checks based on JWT claims:<ul><li>After signature and lifetime validation, the broker verifies that each configured claim matches its expected value.</li><li>You can use placeholders like <b>${username}</b> and <b>${clientId}</b> to dynamically match the MQTT client's username or client ID during authentication.</li><li>If any listed claim does not match, authentication will fail.</li></ul>Examples: <ul><li><code>sub = ${clientId}</code> — ensures the token subject matches the client ID.</li><li><code>env = prod</code> — allows the token only if the <code>env</code> claim equals <code>prod</code>.</li></ul>",
@@ -830,7 +830,7 @@
         "user-name-required": "User Name is required.",
         "hint-client-type-application": "Use 'Application' type for clients that usually subscribe to topics with high message rates and with the requirement to persist messages when the client is offline, i.e. <b>IoT applications</b>.",
         "hint-client-type-device": "Use 'Device' type for clients that usually publish a lot of messages, but subscribe to a few topics with low message rate, i.e. <b>IoT devices</b>.",
-        "hint-client-type-read-more": "<a href='https://thingsboard.io/docs/mqtt-broker/user-guide/mqtt-client-type/' target='_blank'>Read more</a>.",
+        "hint-client-type-read-more": "<a href='https://tbmq.io/docs/user-guide/mqtt-client-type/' target='_blank'>Read more</a>.",
         "hint-credentials-type-basic": "<b>'Basic'</b> is a one-way authentication method based on different combinations of <b>Client ID, Username and/or Password</b>:<ul><li><b>Client ID</b> - will check if connecting client has specified clientId;</li><li><b>Username</b> - will check if connecting client has specified username;</li><li><b>Client ID and username</b>- will check if connecting client has both specified clientId and username;</li><li><b>Username and password</b> - will check if connecting client has both specified username and password;</li><li><b>Client ID and password</b> - will check if connecting client has both specified clientId and password;</li><li><b>Client ID, username and password</b> - will check if connecting client has specified clientId, username and password</li></ul>",
         "hint-credentials-type-ssl": "<b>'X.509 Certificate Chain'</b> is a secure two-way authentication method over TLS with chain of public-key certificates.",
         "hint-credentials-type-scram": "<b>'SCRAM'</b> (Salted Challenge Response Authentication Mechanism) is an enhanced authentication method for MQTT 5 clients that provides secure, password-based authentication. It uses a challenge-response process to exchange hashed credentials, ensuring the password is never sent in plain text.",
@@ -978,7 +978,7 @@
         "name": "Name",
         "name-required": "Name is required.",
         "name-max-length": "Name should be less than 256",
-        "hint-application-shared-subscription": "<b>Application Shared Subscriptions</b> are the TBMQ entities used for effective management of the MQTT shared</br> subscriptions feature. Provision such entities if you plan to use <b>shared subscriptions with Application clients</b>. <a href='https://thingsboard.io/docs/mqtt-broker/user-guide/shared-subscriptions/' target='_blank'>Read more.</a>",
+        "hint-application-shared-subscription": "<b>Application Shared Subscriptions</b> are the TBMQ entities used for effective management of the MQTT shared</br> subscriptions feature. Provision such entities if you plan to use <b>shared subscriptions with Application clients</b>. <a href='https://tbmq.io/docs/user-guide/shared-subscriptions/' target='_blank'>Read more.</a>",
         "hint-topic-filter": "The format for a shared subscription topic filter is '$share/ShareName/TopicFilter'. If shared subscription topic filter is '$share/group1/city/+/home/#', set Topic Filter as 'city/+/home/#'",
         "hint-partitions": "It is recommended that the number of partitions is equal to or X times more than the expected number of clients of the shared subscription. For example, if 5 clients are going to be subscribed to the shared subscription, set the Partitions value to 5, 10 or 15. This will guarantee even load distribution between the subscribers.",
         "hint-shared-subscription-notes": "<li><i>Topic Filter</i> and <i>Partitions</i> fields can not be changed after creation.</li><li>Application Shared Subscription feature works with MQTT v5 and v3.x</li>",
@@ -1005,7 +1005,7 @@
         "delete-retained-messages-text": "Be careful, after the confirmation all selected retained messages will be removed and all related data will become unrecoverable.",
         "clear-empty-retained-message-nodes": "Clear empty retained message nodes",
         "clear-empty-retained-message-nodes-title": "Clear empty retained message nodes?",
-        "clear-empty-retained-message-nodes-text": "Be careful, after the confirmation, all empty <a target='_blank' href='https://thingsboard.io/docs/mqtt-broker/user-guide/retained-messages/#clearing-empty-retained-message-nodes'>retained message nodes</a> will be cleared.",
+        "clear-empty-retained-message-nodes-text": "Be careful, after the confirmation, all empty <a target='_blank' href='https://tbmq.io/docs/user-guide/retained-messages/#clearing-empty-retained-message-nodes'>retained message nodes</a> will be cleared.",
         "details": "Retained message details",
         "search": "Search by topic",
         "selected-retained-messages": "{ count, plural, =1 {1 Retained message} other {# Retained messages} } selected",
@@ -1226,19 +1226,19 @@
             },
             "step-2": {
                 "title": "Add Application credentials",
-                "text": "Let's add credentials to connect \n<a target='_blank' href='https://thingsboard.io/docs/mqtt-broker/user-guide/mqtt-client-type/#application-client'>Application</a> client.\nThese credentials will be utilized to subscribe to the messages published from other MQTT clients.\n\nTo proceed, please click on the <b>Add Application credentials</b> button below and confirm the action by clicking on the <b>Add</b> button.\n"
+                "text": "Let's add credentials to connect \n<a target='_blank' href='https://tbmq.io/docs/user-guide/mqtt-client-type/#application-client'>Application</a> client.\nThese credentials will be utilized to subscribe to the messages published from other MQTT clients.\n\nTo proceed, please click on the <b>Add Application credentials</b> button below and confirm the action by clicking on the <b>Add</b> button.\n"
             },
             "step-3": {
                 "title": "Add Device credentials",
-                "text": "Now let's add credentials to connect \n<a target='_blank' href='https://thingsboard.io/docs/mqtt-broker/user-guide/mqtt-client-type/#device-client'>Device</a> client.\nThis will allow publishing messages to the <b>TBMQ</b>.\nPlease click on the button <b>Add Device credentials</b>.\n"
+                "text": "Now let's add credentials to connect \n<a target='_blank' href='https://tbmq.io/docs/user-guide/mqtt-client-type/#device-client'>Device</a> client.\nThis will allow publishing messages to the <b>TBMQ</b>.\nPlease click on the button <b>Add Device credentials</b>.\n"
             },
             "step-4": {
                 "title": "Subscribe to topic",
-                "text": "To subscribe <a target='_blank' href='https://thingsboard.io/docs/mqtt-broker/user-guide/mqtt-client-type/#application-client'>Application</a> \nclient to the MQTT topic `tbmq/demo/+` we will use the <a href='https://mosquitto.org/man/mosquitto_sub-1.html' target=\"_blank\">mosquitto_sub</a> MQTT client.\nPlease copy and paste the following code into a terminal tab:"
+                "text": "To subscribe <a target='_blank' href='https://tbmq.io/docs/user-guide/mqtt-client-type/#application-client'>Application</a> \nclient to the MQTT topic `tbmq/demo/+` we will use the <a href='https://mosquitto.org/man/mosquitto_sub-1.html' target=\"_blank\">mosquitto_sub</a> MQTT client.\nPlease copy and paste the following code into a terminal tab:"
             },
             "step-5": {
                 "title": "Publish message",
-                "text": "To publish a message from the <a target='_blank' rel='noopener noreferrer' href='https://thingsboard.io/docs/mqtt-broker/user-guide/mqtt-client-type/#device-client'>Device</a> \nclient to the topic `tbmq/demo/topic` open a new tab in the terminal and paste the following command:",
+                "text": "To publish a message from the <a target='_blank' rel='noopener noreferrer' href='https://tbmq.io/docs/user-guide/mqtt-client-type/#device-client'>Device</a> \nclient to the topic `tbmq/demo/topic` open a new tab in the terminal and paste the following command:",
                 "after-command": "Once you run this command, you should see the published message in the terminal tab of the subscribed client."
             },
             "step-6": {
@@ -1403,7 +1403,7 @@
     "subscription": {
         "add-subscription": "Add subscription",
         "clear-empty-subscription-nodes": "Clear empty subscription nodes",
-        "clear-empty-subscription-nodes-text": "Be careful, after the confirmation, all empty <a target='_blank' href='https://thingsboard.io/docs/mqtt-broker/user-guide/ui/subscriptions/#clearing-empty-subscription-nodes'>subscription</a> nodes will be cleared.",
+        "clear-empty-subscription-nodes-text": "Be careful, after the confirmation, all empty <a target='_blank' href='https://tbmq.io/docs/user-guide/ui/subscriptions/#clearing-empty-subscription-nodes'>subscription</a> nodes will be cleared.",
         "clear-empty-subscription-nodes-title": "Clear empty subscription nodes?",
         "color": "Color",
         "copy-topic": "Copy topic filter",

--- a/ui-ngx/src/assets/locale/locale.constant-es_ES.json
+++ b/ui-ngx/src/assets/locale/locale.constant-es_ES.json
@@ -156,7 +156,7 @@
         "authorization-dynamic-hint": "Opcionalmente puedes extraer reglas de publicación y suscripción desde claims de JWT:<ul><li>Si están presentes, el broker usa los patrones de topic para autorizar.</li><li>Si faltan o son inválidos, se usarán las Reglas por defecto.</li><li>El valor debe ser un <b>array JSON de strings</b> con patrones de topic, p. ej., <code>[\"sensors/.*\", \"updates/.*\"]</code></li></ul>",
         "authorization-default": "Reglas de autorización por defecto",
         "client-type": "Tipo de cliente",
-        "client-type-hint": "Configura cómo el broker determina el <a href='https://thingsboard.io/docs/mqtt-broker/user-guide/mqtt-client-type/' target='_blank'>tipo de cliente</a> durante la autenticación basándose en claims de JWT:<ul><li>Por defecto, todos los clientes reciben el tipo seleccionado - <b>{{type}}</b>.</li><li>Si coinciden todas las condiciones, se asigna el tipo opuesto - <b>{{targetType}}</b>.</li></ul>Ejemplo: si el tipo por defecto es <b>{{type}}</b> y la condición <code>{your_claim} = {your_value}</code> está configurada, el cliente será <b>{{targetType}}</b> cuando <code>{your_claim}</code> exista y coincida con <code>{your_value}</code>.",
+        "client-type-hint": "Configura cómo el broker determina el <a href='https://tbmq.io/docs/user-guide/mqtt-client-type/' target='_blank'>tipo de cliente</a> durante la autenticación basándose en claims de JWT:<ul><li>Por defecto, todos los clientes reciben el tipo seleccionado - <b>{{type}}</b>.</li><li>Si coinciden todas las condiciones, se asigna el tipo opuesto - <b>{{targetType}}</b>.</li></ul>Ejemplo: si el tipo por defecto es <b>{{type}}</b> y la condición <code>{your_claim} = {your_value}</code> está configurada, el cliente será <b>{{targetType}}</b> cuando <code>{your_claim}</code> exista y coincida con <code>{your_value}</code>.",
         "claim": "Claim",
         "claims": "Claims de autenticación",
         "claims-hint": "Las condiciones basadas en claims permiten verificaciones adicionales:<ul><li>Tras validar firma y vigencia, el broker verifica que cada claim coincida con su valor esperado.</li><li>Usa <b>${username}</b> y <b>${clientId}</b> para coincidir dinámicamente.</li><li>Si algún claim no coincide, la autenticación falla.</li></ul>Ejemplos:<ul><li><code>sub = ${clientId}</code> — asegura que el subject del token coincida con el client ID.</li><li><code>env = prod</code> — permite el token solo si <code>env</code> es <code>prod</code>.</li></ul>",
@@ -777,7 +777,7 @@
         "user-name-required": "User Name es obligatorio.",
         "hint-client-type-application": "Usa tipo 'Application' para clientes que suelen suscribirse a topics con alta tasa de mensajes y requieren persistencia, p. ej., <b>aplicaciones IoT</b>.",
         "hint-client-type-device": "Usa tipo 'Device' para clientes que suelen publicar muchos mensajes y suscribirse a pocos topics, p. ej., <b>dispositivos IoT</b>.",
-        "hint-client-type-read-more": "<a href='https://thingsboard.io/docs/mqtt-broker/user-guide/mqtt-client-type/' target='_blank'>Leer más</a>.",
+        "hint-client-type-read-more": "<a href='https://tbmq.io/docs/user-guide/mqtt-client-type/' target='_blank'>Leer más</a>.",
         "hint-credentials-type-basic": "<b>'Basic'</b> es autenticación basada en combinaciones de <b>Client ID, Username y/o Password</b>:<ul><li><b>Client ID</b> - verifica que el cliente tenga ese clientId;</li><li><b>Username</b> - verifica que tenga ese username;</li><li><b>Client ID y username</b>;</li><li><b>Username y password</b>;</li><li><b>Client ID y password</b>;</li><li><b>Client ID, username y password</b>.</li></ul>",
         "hint-credentials-type-ssl": "<b>'X.509 Certificate Chain'</b> es autenticación bidireccional segura sobre TLS.",
         "hint-credentials-type-scram": "<b>'SCRAM'</b> es un método mejorado para clientes MQTT 5 que usa desafío-respuesta con credenciales hasheadas.",
@@ -921,7 +921,7 @@
         "name": "Nombre",
         "name-required": "Nombre es obligatorio.",
         "name-max-length": "El nombre debe tener menos de 256",
-        "hint-application-shared-subscription": "<b>Application Shared Subscriptions</b> son entidades TBMQ para gestionar la función de suscripciones compartidas MQTT. Úsalas con clientes <b>Application</b>. <a href='https://thingsboard.io/docs/mqtt-broker/user-guide/shared-subscriptions/' target='_blank'>Leer más.</a>",
+        "hint-application-shared-subscription": "<b>Application Shared Subscriptions</b> son entidades TBMQ para gestionar la función de suscripciones compartidas MQTT. Úsalas con clientes <b>Application</b>. <a href='https://tbmq.io/docs/user-guide/shared-subscriptions/' target='_blank'>Leer más.</a>",
         "hint-topic-filter": "El formato es '$share/ShareName/TopicFilter'. Si es '$share/group1/city/+/home/#', establece Topic Filter como 'city/+/home/#'",
         "hint-partitions": "Se recomienda igualar o multiplicar por X el número de particiones según clientes esperados.",
         "hint-shared-subscription-notes": "<li><i>Topic Filter</i> y <i>Partitions</i> no se pueden cambiar tras la creación.</li><li>Funciona con MQTT v5 y v3.x</li>",
@@ -948,7 +948,7 @@
         "delete-retained-messages-text": "Cuidado, tras confirmar se eliminarán los seleccionados y no se podrán recuperar los datos.",
         "clear-empty-retained-message-nodes": "Limpiar nodos vacíos de retained message",
         "clear-empty-retained-message-nodes-title": "¿Limpiar nodos vacíos?",
-        "clear-empty-retained-message-nodes-text": "Cuidado, tras confirmar se limpiarán todos los <a target='_blank' href='https://thingsboard.io/docs/mqtt-broker/user-guide/retained-messages/#clearing-empty-retained-message-nodes'>nodos vacíos</a>.",
+        "clear-empty-retained-message-nodes-text": "Cuidado, tras confirmar se limpiarán todos los <a target='_blank' href='https://tbmq.io/docs/user-guide/retained-messages/#clearing-empty-retained-message-nodes'>nodos vacíos</a>.",
         "details": "Detalles del retained message",
         "search": "Buscar por Topic",
         "selected-retained-messages": "{ count, plural, =1 {1 Retained message} other {# Retained messages} } seleccionados",
@@ -1171,19 +1171,19 @@
             },
             "step-2": {
                 "title": "Añadir Application Credentials",
-                "text": "Vamos a añadir Credentials para conectar el <a target='_blank' href='https://thingsboard.io/docs/mqtt-broker/user-guide/mqtt-client-type/#application-client'>Application</a> Client.\nEstas Credentials se utilizarán para suscribirse a los mensajes publicados por otros MQTT Clients.\n\nPara continuar, haga clic en el botón <b>Add Application Credentials</b> a continuación y confirme la acción haciendo clic en el botón <b>Add</b>.\n"
+                "text": "Vamos a añadir Credentials para conectar el <a target='_blank' href='https://tbmq.io/docs/user-guide/mqtt-client-type/#application-client'>Application</a> Client.\nEstas Credentials se utilizarán para suscribirse a los mensajes publicados por otros MQTT Clients.\n\nPara continuar, haga clic en el botón <b>Add Application Credentials</b> a continuación y confirme la acción haciendo clic en el botón <b>Add</b>.\n"
             },
             "step-3": {
                 "title": "Añadir Device Credentials",
-                "text": "Ahora vamos a añadir Credentials para conectar el <a target='_blank' href='https://thingsboard.io/docs/mqtt-broker/user-guide/mqtt-client-type/#device-client'>Device</a> Client.\nEsto permitirá publicar mensajes en <b>TBMQ</b>.\nPor favor, haga clic en el botón <b>Add Device Credentials</b>.\n"
+                "text": "Ahora vamos a añadir Credentials para conectar el <a target='_blank' href='https://tbmq.io/docs/user-guide/mqtt-client-type/#device-client'>Device</a> Client.\nEsto permitirá publicar mensajes en <b>TBMQ</b>.\nPor favor, haga clic en el botón <b>Add Device Credentials</b>.\n"
             },
             "step-4": {
                 "title": "Suscribirse al Topic",
-                "text": "Para suscribir el <a target='_blank' href='https://thingsboard.io/docs/mqtt-broker/user-guide/mqtt-client-type/#application-client'>Application</a> Client\nal MQTT Topic `tbmq/demo/+`, utilizaremos el MQTT Client <a href='https://mosquitto.org/man/mosquitto_sub-1.html' target=\"_blank\">mosquitto_sub</a>.\nPor favor, copie y pegue el siguiente código en una pestaña de la terminal:"
+                "text": "Para suscribir el <a target='_blank' href='https://tbmq.io/docs/user-guide/mqtt-client-type/#application-client'>Application</a> Client\nal MQTT Topic `tbmq/demo/+`, utilizaremos el MQTT Client <a href='https://mosquitto.org/man/mosquitto_sub-1.html' target=\"_blank\">mosquitto_sub</a>.\nPor favor, copie y pegue el siguiente código en una pestaña de la terminal:"
             },
             "step-5": {
                 "title": "Publicar mensaje",
-                "text": "Para publicar un mensaje desde el <a target='_blank' rel='noopener noreferrer' href='https://thingsboard.io/docs/mqtt-broker/user-guide/mqtt-client-type/#device-client'>Device</a> Client\nal Topic `tbmq/demo/topic`, abra una nueva pestaña en la terminal y pegue el siguiente comando:",
+                "text": "Para publicar un mensaje desde el <a target='_blank' rel='noopener noreferrer' href='https://tbmq.io/docs/user-guide/mqtt-client-type/#device-client'>Device</a> Client\nal Topic `tbmq/demo/topic`, abra una nueva pestaña en la terminal y pegue el siguiente comando:",
                 "after-command": "Una vez ejecute este comando, debería ver el mensaje publicado en la pestaña de la terminal del Client suscrito."
             },
             "step-6": {
@@ -1342,7 +1342,7 @@
     "subscription": {
         "add-subscription": "Agregar suscripción",
         "clear-empty-subscription-nodes": "Limpiar nodos de suscripción vacíos",
-        "clear-empty-subscription-nodes-text": "Cuidado, se limpiarán todos los nodos de <a target='_blank' href='https://thingsboard.io/docs/mqtt-broker/user-guide/ui/subscriptions/#clearing-empty-subscription-nodes'>suscripción</a> vacíos.",
+        "clear-empty-subscription-nodes-text": "Cuidado, se limpiarán todos los nodos de <a target='_blank' href='https://tbmq.io/docs/user-guide/ui/subscriptions/#clearing-empty-subscription-nodes'>suscripción</a> vacíos.",
         "clear-empty-subscription-nodes-title": "¿Limpiar nodos de suscripción vacíos?",
         "color": "Color",
         "copy-topic": "Copiar topic filter",

--- a/ui-ngx/src/assets/locale/locale.constant-hi_IN.json
+++ b/ui-ngx/src/assets/locale/locale.constant-hi_IN.json
@@ -156,7 +156,7 @@
         "authorization-dynamic-hint": "JWT claims से publish/subscribe अधिकार नियम निकाले जा सकते हैं:<ul><li>सेट होने पर broker इन topic पैटर्न से अधिकार नियंत्रित करेगा।</li><li>अनुपस्थित/अमान्य होने पर डिफ़ॉल्ट नियम उपयोग होंगे।</li><li>मान <b>strings के JSON array</b> होना चाहिए, जैसे <code>[\"sensors/.*\", \"updates/.*\"]</code></li></ul>",
         "authorization-default": "डिफ़ॉल्ट अधिकार नियम",
         "client-type": "क्लाइंट प्रकार",
-        "client-type-hint": "JWT claims के आधार पर प्रमाणीकरण के दौरान <a href='https://thingsboard.io/docs/mqtt-broker/user-guide/mqtt-client-type/' target='_blank'>क्लाइंट प्रकार</a> निर्धारित करें:<ul><li>डिफ़ॉल्ट रूप से सभी क्लाइंट चुने गए प्रकार - <b>{{type}}</b> के होते हैं।</li><li>यदि सभी शर्तें मिलें, तो विपरीत प्रकार - <b>{{targetType}}</b> असाइन होता है।</li></ul>उदाहरण: यदि डिफ़ॉल्ट <b>{{type}}</b> है और <code>{your_claim} = {your_value}</code> सेट है, तो claim मौजूद व मेल खाने पर <b>{{targetType}}</b> वर्गीकृत होगा।",
+        "client-type-hint": "JWT claims के आधार पर प्रमाणीकरण के दौरान <a href='https://tbmq.io/docs/user-guide/mqtt-client-type/' target='_blank'>क्लाइंट प्रकार</a> निर्धारित करें:<ul><li>डिफ़ॉल्ट रूप से सभी क्लाइंट चुने गए प्रकार - <b>{{type}}</b> के होते हैं।</li><li>यदि सभी शर्तें मिलें, तो विपरीत प्रकार - <b>{{targetType}}</b> असाइन होता है।</li></ul>उदाहरण: यदि डिफ़ॉल्ट <b>{{type}}</b> है और <code>{your_claim} = {your_value}</code> सेट है, तो claim मौजूद व मेल खाने पर <b>{{targetType}}</b> वर्गीकृत होगा।",
         "claim": "Claim",
         "claims": "प्रमाणीकरण claims",
         "claims-hint": "Claim-आधारित शर्तें अतिरिक्त सुरक्षा जाँच जोड़ती हैं:<ul><li>हस्ताक्षर और अवधि जाँच के बाद, प्रत्येक claim का अपेक्षित मान से मिलान।</li><li><b>${username}</b> और <b>${clientId}</b> placeholders का उपयोग कर सकते हैं।</li><li>कोई भी claim न मिलने पर प्रमाणीकरण विफल।</li></ul>उदाहरण:<ul><li><code>sub = ${clientId}</code> — token subject को client ID से मिलाता है।</li><li><code>env = prod</code> — केवल तब अनुमति जब <code>env</code> <code>prod</code> हो।</li></ul>",
@@ -777,7 +777,7 @@
         "user-name-required": "User Name आवश्यक है।",
         "hint-client-type-application": "'Application' प्रकार उन क्लाइंट्स हेतु जिनके लिए उच्च संदेश दर वाले topics व ऑफ़लाइन persistence आवश्यक हो, जैसे <b>IoT applications</b>।",
         "hint-client-type-device": "'Device' प्रकार उन क्लाइंट्स हेतु जो बहुत संदेश publish करते हैं और कम topics subscribe करते हैं, जैसे <b>IoT devices</b>।",
-        "hint-client-type-read-more": "<a href='https://thingsboard.io/docs/mqtt-broker/user-guide/mqtt-client-type/' target='_blank'>और पढ़ें</a>.",
+        "hint-client-type-read-more": "<a href='https://tbmq.io/docs/user-guide/mqtt-client-type/' target='_blank'>और पढ़ें</a>.",
         "hint-credentials-type-basic": "<b>'Basic'</b> एकतरफ़ा प्रमाणीकरण है जो <b>Client ID, Username और/या Password</b> के संयोजनों पर आधारित है।",
         "hint-credentials-type-ssl": "<b>'X.509 Certificate Chain'</b> TLS पर सुरक्षित द्विपक्षीय प्रमाणीकरण है।",
         "hint-credentials-type-scram": "<b>'SCRAM'</b> MQTT 5 क्लाइंट्स के लिए उन्नत पासवर्ड-आधारित चुनौती-प्रतिक्रिया प्रमाणीकरण है।",
@@ -921,7 +921,7 @@
         "name": "नाम",
         "name-required": "नाम आवश्यक है।",
         "name-max-length": "नाम 256 से कम होना चाहिए",
-        "hint-application-shared-subscription": "<b>Application Shared Subscriptions</b> MQTT shared subscriptions के प्रबंधन हेतु TBMQ entities हैं। <b>Application clients</b> के साथ उपयोग हेतु provisioning करें। <a href='https://thingsboard.io/docs/mqtt-broker/user-guide/shared-subscriptions/' target='_blank'>और पढ़ें।</a>",
+        "hint-application-shared-subscription": "<b>Application Shared Subscriptions</b> MQTT shared subscriptions के प्रबंधन हेतु TBMQ entities हैं। <b>Application clients</b> के साथ उपयोग हेतु provisioning करें। <a href='https://tbmq.io/docs/user-guide/shared-subscriptions/' target='_blank'>और पढ़ें।</a>",
         "hint-topic-filter": "फॉर्मेट: '$share/ShareName/TopicFilter'। जैसे '$share/group1/city/+/home/#' हो तो 'city/+/home/#' सेट करें",
         "hint-partitions": "सुझाव: partitions = अपेक्षित clients की संख्या, या उसका गुणक, ताकि लोड संतुलित रहे।",
         "hint-shared-subscription-notes": "<li><i>Topic Filter</i> और <i>Partitions</i> फ़ील्ड बन जाने के बाद बदल नहीं सकते।</li><li>MQTT v5 और v3.x के साथ काम करता है</li>",
@@ -948,7 +948,7 @@
         "delete-retained-messages-text": "सावधान, पुष्टि के बाद चयनित हट जाएँगे और डेटा पुनर्प्राप्त नहीं होगा।",
         "clear-empty-retained-message-nodes": "खाली retained message नोड्स साफ़ करें",
         "clear-empty-retained-message-nodes-title": "खाली नोड्स साफ़ करें?",
-        "clear-empty-retained-message-nodes-text": "सावधान, पुष्टि के बाद सभी खाली <a target='_blank' href='https://thingsboard.io/docs/mqtt-broker/user-guide/retained-messages/#clearing-empty-retained-message-nodes'>retained message नोड्स</a> साफ़ हो जाएँगे।",
+        "clear-empty-retained-message-nodes-text": "सावधान, पुष्टि के बाद सभी खाली <a target='_blank' href='https://tbmq.io/docs/user-guide/retained-messages/#clearing-empty-retained-message-nodes'>retained message नोड्स</a> साफ़ हो जाएँगे।",
         "details": "Retained Message विवरण",
         "search": "Topic द्वारा खोजें",
         "selected-retained-messages": "{ count, plural, =1 {1 Retained message} other {# Retained messages} } चयनित",
@@ -1171,19 +1171,19 @@
             },
             "step-2": {
                 "title": "Application Credentials जोड़ें",
-                "text": "आइए <a target='_blank' href='https://thingsboard.io/docs/mqtt-broker/user-guide/mqtt-client-type/#application-client'>Application</a> Client को कनेक्ट करने के लिए Credentials जोड़ें।\nइन Credentials का उपयोग अन्य MQTT Clients से प्रकाशित संदेशों को सब्सक्राइब (subscribe) करने के लिए किया जाएगा।\n\nआगे बढ़ने के लिए, कृपया नीचे दिए गए <b>Add Application Credentials</b> बटन पर क्लिक करें और <b>Add</b> बटन पर क्लिक करके कार्रवाई की पुष्टि करें।\n"
+                "text": "आइए <a target='_blank' href='https://tbmq.io/docs/user-guide/mqtt-client-type/#application-client'>Application</a> Client को कनेक्ट करने के लिए Credentials जोड़ें।\nइन Credentials का उपयोग अन्य MQTT Clients से प्रकाशित संदेशों को सब्सक्राइब (subscribe) करने के लिए किया जाएगा।\n\nआगे बढ़ने के लिए, कृपया नीचे दिए गए <b>Add Application Credentials</b> बटन पर क्लिक करें और <b>Add</b> बटन पर क्लिक करके कार्रवाई की पुष्टि करें।\n"
             },
             "step-3": {
                 "title": "Device Credentials जोड़ें",
-                "text": "अब आइए <a target='_blank' href='https://thingsboard.io/docs/mqtt-broker/user-guide/mqtt-client-type/#device-client'>Device</a> Client को कनेक्ट करने के लिए Credentials जोड़ें।\nयह <b>TBMQ</b> पर संदेश प्रकाशित (publish) करने की अनुमति देगा।\nकृपया <b>Add Device Credentials</b> बटन पर क्लिक करें।\n"
+                "text": "अब आइए <a target='_blank' href='https://tbmq.io/docs/user-guide/mqtt-client-type/#device-client'>Device</a> Client को कनेक्ट करने के लिए Credentials जोड़ें।\nयह <b>TBMQ</b> पर संदेश प्रकाशित (publish) करने की अनुमति देगा।\nकृपया <b>Add Device Credentials</b> बटन पर क्लिक करें।\n"
             },
             "step-4": {
                 "title": "Topic को सब्सक्राइब करें",
-                "text": "<a target='_blank' href='https://thingsboard.io/docs/mqtt-broker/user-guide/mqtt-client-type/#application-client'>Application</a> Client को MQTT Topic `tbmq/demo/+` पर सब्सक्राइब करने के लिए हम <a href='https://mosquitto.org/man/mosquitto_sub-1.html' target=\"_blank\">mosquitto_sub</a> MQTT Client का उपयोग करेंगे।\nकृपया निम्नलिखित कोड को कॉपी करें और टर्मिनल टैब में पेस्ट करें:"
+                "text": "<a target='_blank' href='https://tbmq.io/docs/user-guide/mqtt-client-type/#application-client'>Application</a> Client को MQTT Topic `tbmq/demo/+` पर सब्सक्राइब करने के लिए हम <a href='https://mosquitto.org/man/mosquitto_sub-1.html' target=\"_blank\">mosquitto_sub</a> MQTT Client का उपयोग करेंगे।\nकृपया निम्नलिखित कोड को कॉपी करें और टर्मिनल टैब में पेस्ट करें:"
             },
             "step-5": {
                 "title": "संदेश प्रकाशित (Publish) करें",
-                "text": "<a target='_blank' rel='noopener noreferrer' href='https://thingsboard.io/docs/mqtt-broker/user-guide/mqtt-client-type/#device-client'>Device</a> Client से Topic `tbmq/demo/topic` पर संदेश प्रकाशित करने के लिए टर्मिनल में एक नया टैब खोलें और निम्नलिखित कमांड पेस्ट करें:",
+                "text": "<a target='_blank' rel='noopener noreferrer' href='https://tbmq.io/docs/user-guide/mqtt-client-type/#device-client'>Device</a> Client से Topic `tbmq/demo/topic` पर संदेश प्रकाशित करने के लिए टर्मिनल में एक नया टैब खोलें और निम्नलिखित कमांड पेस्ट करें:",
                 "after-command": "एक बार जब आप इस कमांड को चलाएंगे, तो आपको सब्सक्राइब किए गए Client के टर्मिनल टैब में प्रकाशित संदेश दिखाई देना चाहिए।"
             },
             "step-6": {
@@ -1342,7 +1342,7 @@
     "subscription": {
         "add-subscription": "सब्सक्रिप्शन जोड़ें",
         "clear-empty-subscription-nodes": "खाली सब्सक्रिप्शन नोड्स साफ़ करें",
-        "clear-empty-subscription-nodes-text": "सावधान, पुष्टि के बाद सभी खाली <a target='_blank' href='https://thingsboard.io/docs/mqtt-broker/user-guide/ui/subscriptions/#clearing-empty-subscription-nodes'>सब्सक्रिप्शन</a> नोड्स साफ़ हो जाएँगे।",
+        "clear-empty-subscription-nodes-text": "सावधान, पुष्टि के बाद सभी खाली <a target='_blank' href='https://tbmq.io/docs/user-guide/ui/subscriptions/#clearing-empty-subscription-nodes'>सब्सक्रिप्शन</a> नोड्स साफ़ हो जाएँगे।",
         "clear-empty-subscription-nodes-title": "खाली सब्सक्रिप्शन नोड्स साफ़ करें?",
         "color": "रंग",
         "copy-topic": "Topic filter कॉपी करें",

--- a/ui-ngx/src/assets/locale/locale.constant-zh_CN.json
+++ b/ui-ngx/src/assets/locale/locale.constant-zh_CN.json
@@ -156,7 +156,7 @@
         "authorization-dynamic-hint": "可从 JWT claims 中提取发布/订阅规则：<ul><li>若存在，使用其中的 topic 模式进行授权。</li><li>若缺失或无效，则回退到默认规则。</li><li>值必须是<b>字符串数组</b>，如 <code>[\"sensors/.*\", \"updates/.*\"]</code></li></ul>",
         "authorization-default": "默认授权规则",
         "client-type": "客户端类型",
-        "client-type-hint": "根据 JWT claims 确定<a href='https://thingsboard.io/docs/mqtt-broker/user-guide/mqtt-client-type/' target='_blank'>客户端类型</a>：<ul><li>默认将所有客户端设为 <b>{{type}}</b>。</li><li>若匹配所有条件，则指定为相反类型 <b>{{targetType}}</b>。</li></ul>示例：默认 <b>{{type}}</b>，配置 <code>{your_claim} = {your_value}</code>，当 claim 存在且匹配时归类为 <b>{{targetType}}</b>。",
+        "client-type-hint": "根据 JWT claims 确定<a href='https://tbmq.io/docs/user-guide/mqtt-client-type/' target='_blank'>客户端类型</a>：<ul><li>默认将所有客户端设为 <b>{{type}}</b>。</li><li>若匹配所有条件，则指定为相反类型 <b>{{targetType}}</b>。</li></ul>示例：默认 <b>{{type}}</b>，配置 <code>{your_claim} = {your_value}</code>，当 claim 存在且匹配时归类为 <b>{{targetType}}</b>。",
         "claim": "Claim",
         "claims": "认证 claims",
         "claims-hint": "基于 claims 的条件允许额外安全检查：<ul><li>签名和有效期校验后，校验每个 claim 是否匹配预期值。</li><li>可使用 <b>${username}</b> 与 <b>${clientId}</b> 占位符。</li><li>任一 claim 不匹配则认证失败。</li></ul>示例：<ul><li><code>sub = ${clientId}</code> 确保 token subject 等于 client ID。</li><li><code>env = prod</code> 仅当 env 为 prod 时允许。</li></ul>",
@@ -713,7 +713,7 @@
         "user-name-required": "User Name 必填。",
         "hint-client-type-application": "对高消息速率并需离线持久化的订阅客户端使用 'Application' 类型，如<b>IoT 应用</b>。",
         "hint-client-type-device": "对发布量大、订阅少的客户端使用 'Device' 类型，如<b>IoT 设备</b>。",
-        "hint-client-type-read-more": "<a href='https://thingsboard.io/docs/mqtt-broker/user-guide/mqtt-client-type/' target='_blank'>了解更多</a>。",
+        "hint-client-type-read-more": "<a href='https://tbmq.io/docs/user-guide/mqtt-client-type/' target='_blank'>了解更多</a>。",
         "hint-credentials-type-basic": "<b>'Basic'</b> 基于 <b>Client ID、Username 和/或 Password</b> 的单向认证：详见组合列表。",
         "hint-credentials-type-ssl": "<b>'X.509 Certificate Chain'</b> 基于 TLS 的双向安全认证。",
         "hint-credentials-type-scram": "<b>'SCRAM'</b> 适用于 MQTT 5 的增强型基于密码的挑战-响应认证。",
@@ -857,7 +857,7 @@
         "name": "名称",
         "name-required": "名称必填。",
         "name-max-length": "名称长度应小于 256",
-        "hint-application-shared-subscription": "<b>Application Shared Subscriptions</b> 用于高效管理 MQTT 共享订阅功能。计划在 <b>Application 客户端</b>上使用共享订阅时请配置。<a href='https://thingsboard.io/docs/mqtt-broker/user-guide/shared-subscriptions/' target='_blank'>了解更多</a>。",
+        "hint-application-shared-subscription": "<b>Application Shared Subscriptions</b> 用于高效管理 MQTT 共享订阅功能。计划在 <b>Application 客户端</b>上使用共享订阅时请配置。<a href='https://tbmq.io/docs/user-guide/shared-subscriptions/' target='_blank'>了解更多</a>。",
         "hint-topic-filter": "共享订阅 topic filter 格式：'$share/ShareName/TopicFilter'。若为 '$share/group1/city/+/home/#'，则设置为 'city/+/home/#'",
         "hint-partitions": "建议分区数等于或为预期客户端数量的倍数，以保证负载均衡。",
         "hint-shared-subscription-notes": "<li><i>Topic Filter</i> 与 <i>Partitions</i> 创建后不可变更。</li><li>支持 MQTT v5 与 v3.x</li>",
@@ -884,7 +884,7 @@
         "delete-retained-messages-text": "注意，确认后将删除所选且数据不可恢复。",
         "clear-empty-retained-message-nodes": "清理空的 retained message 节点",
         "clear-empty-retained-message-nodes-title": "清理空节点？",
-        "clear-empty-retained-message-nodes-text": "注意，确认后将清理所有空的<a target='_blank' href='https://thingsboard.io/docs/mqtt-broker/user-guide/retained-messages/#clearing-empty-retained-message-nodes'>retained message 节点</a>。",
+        "clear-empty-retained-message-nodes-text": "注意，确认后将清理所有空的<a target='_blank' href='https://tbmq.io/docs/user-guide/retained-messages/#clearing-empty-retained-message-nodes'>retained message 节点</a>。",
         "details": "Retained Message 详情",
         "search": "按 Topic 搜索",
         "selected-retained-messages": "已选择 { count, plural, =1 {1 条 Retained message} other {# 条 Retained messages} }",
@@ -1108,19 +1108,19 @@
             },
             "step-2": {
                 "title": "添加 Application Credentials",
-                "text": "让我们添加 Credentials 以连接 <a target='_blank' href='https://thingsboard.io/docs/mqtt-broker/user-guide/mqtt-client-type/#application-client'>Application</a> Client。\n这些 Credentials 将用于订阅从其他 MQTT Clients 发布的消息。\n\n要继续，请点击下方的 <b>Add Application Credentials</b> 按钮，并通过点击 <b>Add</b> 按钮确认操作。\n"
+                "text": "让我们添加 Credentials 以连接 <a target='_blank' href='https://tbmq.io/docs/user-guide/mqtt-client-type/#application-client'>Application</a> Client。\n这些 Credentials 将用于订阅从其他 MQTT Clients 发布的消息。\n\n要继续，请点击下方的 <b>Add Application Credentials</b> 按钮，并通过点击 <b>Add</b> 按钮确认操作。\n"
             },
             "step-3": {
                 "title": "添加 Device Credentials",
-                "text": "现在让我们添加 Credentials 以连接 <a target='_blank' href='https://thingsboard.io/docs/mqtt-broker/user-guide/mqtt-client-type/#device-client'>Device</a> Client。\n这将允许向 <b>TBMQ</b> 发布消息。\n请点击 <b>Add Device Credentials</b> 按钮。\n"
+                "text": "现在让我们添加 Credentials 以连接 <a target='_blank' href='https://tbmq.io/docs/user-guide/mqtt-client-type/#device-client'>Device</a> Client。\n这将允许向 <b>TBMQ</b> 发布消息。\n请点击 <b>Add Device Credentials</b> 按钮。\n"
             },
             "step-4": {
                 "title": "订阅 Topic",
-                "text": "要将 <a target='_blank' href='https://thingsboard.io/docs/mqtt-broker/user-guide/mqtt-client-type/#application-client'>Application</a> Client\n订阅到 MQTT Topic `tbmq/demo/+`，我们将使用 <a href='https://mosquitto.org/man/mosquitto_sub-1.html' target=\"_blank\">mosquitto_sub</a> MQTT Client。\n请复制并将以下代码粘贴到终端选项卡中："
+                "text": "要将 <a target='_blank' href='https://tbmq.io/docs/user-guide/mqtt-client-type/#application-client'>Application</a> Client\n订阅到 MQTT Topic `tbmq/demo/+`，我们将使用 <a href='https://mosquitto.org/man/mosquitto_sub-1.html' target=\"_blank\">mosquitto_sub</a> MQTT Client。\n请复制并将以下代码粘贴到终端选项卡中："
             },
             "step-5": {
                 "title": "发布消息",
-                "text": "要从 <a target='_blank' rel='noopener noreferrer' href='https://thingsboard.io/docs/mqtt-broker/user-guide/mqtt-client-type/#device-client'>Device</a> Client\n向 Topic `tbmq/demo/topic` 发布消息，请在终端中打开一个新选项卡并粘贴以下命令：",
+                "text": "要从 <a target='_blank' rel='noopener noreferrer' href='https://tbmq.io/docs/user-guide/mqtt-client-type/#device-client'>Device</a> Client\n向 Topic `tbmq/demo/topic` 发布消息，请在终端中打开一个新选项卡并粘贴以下命令：",
                 "after-command": "运行此命令后，您应该会在已订阅 Client 的终端选项卡中看到发布的消息。"
             },
             "step-6": {
@@ -1279,7 +1279,7 @@
     "subscription": {
         "add-subscription": "新增订阅",
         "clear-empty-subscription-nodes": "清理空的订阅节点",
-        "clear-empty-subscription-nodes-text": "注意，确认后将清理所有空的<a target='_blank' href='https://thingsboard.io/docs/mqtt-broker/user-guide/ui/subscriptions/#clearing-empty-subscription-nodes'>订阅</a>节点。",
+        "clear-empty-subscription-nodes-text": "注意，确认后将清理所有空的<a target='_blank' href='https://tbmq.io/docs/user-guide/ui/subscriptions/#clearing-empty-subscription-nodes'>订阅</a>节点。",
         "clear-empty-subscription-nodes-title": "清理空的订阅节点？",
         "color": "颜色",
         "copy-topic": "复制 topic filter",


### PR DESCRIPTION
## Summary

Updates all user-facing links in the UI from `thingsboard.io` to the new `https://tbmq.io` website, remapping paths to the new site structure (`/docs/mqtt-broker/…` → `/docs/…`).

### Changes
- `constants.ts` — `helpBaseUrl` → `https://tbmq.io`, `docsPath` → `/docs`; added `contactUs` and `upgradeInstructions` entries to `HelpLinks.linksMap`; dropped the legacy `?section=tbmq-options` pricing param (the new pricing page honors `?product=tbmq-ce` only).
- Monitoring doc anchors remapped to the restructured page: `#config` → `#broker-settings`; `#kafka-brokers` removed (no such section on the new page — links to the page root).
- `version-card.component` — `gotoDocs` now takes full links from `HelpLinks.linksMap` instead of hardcoded paths; upgrade instructions path fixed (`install` → `installation`), contact-us is now a top-level page.
- `login.component` — logo link bound to `helpBaseUrl` (site root) instead of a hardcoded `/products/mqtt-broker` URL.
- `ws-client.component.html` — reuses the existing `connectionHelpLink` constant instead of a hardcoded URL.
- Locale files (en, de, es, zh, hi) and `guide-javascript.md` — all doc links updated to the new domain/structure.

Every new path and anchor was verified against the tbmq.io site content.

### Left unchanged
- The Sparkplug link in `check-connectivity-dialog.component.html` still points to `thingsboard.io/docs/reference/mqtt-sparkplug-api/` — that page has no equivalent on tbmq.io.