### PR TITLE
QA UI fixes

### DIFF
--- a/ui-ngx/src/app/modules/home/components/home/advanced-settings.component.scss
+++ b/ui-ngx/src/app/modules/home/components/home/advanced-settings.component.scss
@@ -63,6 +63,7 @@
     grid-template-columns: 1fr 1fr;
     align-items: center;
     min-height: 32px;
+    flex-shrink: 0;
 
     &:last-child {
       border-bottom: none;
@@ -97,6 +98,11 @@
     height: 32px;
     padding: 4px;
     color: rgba(0, 0, 0, 0.54);
+
+    ::ng-deep .mat-mdc-button-touch-target {
+      width: 32px;
+      height: 32px;
+    }
   }
 
   .auth-status {

--- a/ui-ngx/src/app/modules/home/components/home/charts.component.ts
+++ b/ui-ngx/src/app/modules/home/components/home/charts.component.ts
@@ -14,7 +14,7 @@
 /// limitations under the License.
 ///
 
-import { Component, ElementRef, OnInit, viewChild } from '@angular/core';
+import { Component, ElementRef, NgZone, OnDestroy, OnInit, viewChild } from '@angular/core';
 import { TranslateModule } from '@ngx-translate/core';
 import { Timewindow } from '@shared/models/time/time.models';
 import { TimeService } from '@core/services/time.service';
@@ -31,7 +31,7 @@ import { ConfigService } from '@core/http/config.service';
   styleUrls: ['./charts.component.scss'],
   imports: [CardTitleButtonComponent, FormsModule, TranslateModule, ChartComponent]
 })
-export class ChartsComponent implements OnInit {
+export class ChartsComponent implements OnInit, OnDestroy {
 
   readonly homeChartsContainer = viewChild<ElementRef>('homeChartsContainer');
   readonly chartsGrid = viewChild<ElementRef>('chartsGrid');
@@ -52,15 +52,22 @@ export class ChartsComponent implements OnInit {
   chartHeight: number;
   timewindow: Timewindow;
 
+  private resizeObserver: ResizeObserver;
+
   constructor(
     private timeService: TimeService,
     private configService: ConfigService,
+    private zone: NgZone,
   ) {
   }
 
   ngOnInit() {
     this.setTimewindow();
     this.onResize();
+  }
+
+  ngOnDestroy() {
+    this.resizeObserver?.disconnect();
   }
 
   private setTimewindow() {
@@ -70,23 +77,25 @@ export class ChartsComponent implements OnInit {
 
   private onResize() {
     const tallLayout = window.matchMedia('screen and (min-width: 1280px)');
-    const resizeObserver = new ResizeObserver(() => {
-      const containerEl = this.homeChartsContainer().nativeElement as HTMLElement;
-      const gridEl = this.chartsGrid().nativeElement as HTMLElement;
-      const w = containerEl.getBoundingClientRect().width;
-      const br = 1700;
-      const correlation = w > br ? ((w - br) / 10000) + 1.4 : 1;
-      const widthBased = Math.round((w / 10) * correlation);
-      if (!tallLayout.matches) {
-        this.chartHeight = widthBased;
-        return;
-      }
-      const chartOverhead = 32;
-      const firstItem = gridEl.firstElementChild as HTMLElement | null;
-      const itemHeight = firstItem?.getBoundingClientRect().height ?? 0;
-      const heightBased = Math.floor(itemHeight) - chartOverhead;
-      this.chartHeight = heightBased > 0 ? heightBased : widthBased;
+    this.resizeObserver = new ResizeObserver(() => {
+      this.zone.run(() => {
+        const containerEl = this.homeChartsContainer().nativeElement as HTMLElement;
+        const gridEl = this.chartsGrid().nativeElement as HTMLElement;
+        const w = containerEl.getBoundingClientRect().width;
+        const br = 1700;
+        const correlation = w > br ? ((w - br) / 10000) + 1.4 : 1;
+        const widthBased = Math.round((w / 10) * correlation);
+        if (!tallLayout.matches) {
+          this.chartHeight = widthBased;
+          return;
+        }
+        const chartOverhead = 32;
+        const firstItem = gridEl.firstElementChild as HTMLElement | null;
+        const itemHeight = firstItem?.getBoundingClientRect().height ?? 0;
+        const heightBased = Math.floor(itemHeight) - chartOverhead;
+        this.chartHeight = heightBased > 0 ? heightBased : widthBased;
+      });
     });
-    resizeObserver.observe(this.homeChartsContainer().nativeElement);
+    this.resizeObserver.observe(this.homeChartsContainer().nativeElement);
   }
 }

--- a/ui-ngx/src/app/shared/adapter/custom-datetime-adapter.ts
+++ b/ui-ngx/src/app/shared/adapter/custom-datetime-adapter.ts
@@ -24,6 +24,9 @@ export class CustomDateAdapter extends NativeDatetimeAdapter {
     if (!this.isValid(date)) {
       return '';
     }
+    if (!displayFormat?.day || !displayFormat?.hour) {
+      return super.format(date, displayFormat);
+    }
     const dtf = new Intl.DateTimeFormat(this.locale, {
       day: '2-digit',
       month: '2-digit',

--- a/ui-ngx/src/app/shared/components/time/timewindow.component.ts
+++ b/ui-ngx/src/app/shared/components/time/timewindow.component.ts
@@ -52,7 +52,7 @@ import { coerceBooleanProperty } from '@angular/cdk/coercion';
 import { Overlay, OverlayConfig, OverlayRef } from '@angular/cdk/overlay';
 import { ComponentPortal } from '@angular/cdk/portal';
 import { coerceBoolean } from '@shared/decorators/coercion';
-import { DEFAULT_OVERLAY_POSITIONS, POSITION_MAP } from '@shared/models/overlay.models';
+import { POSITION_MAP } from '@shared/models/overlay.models';
 import { fromEvent } from 'rxjs';
 import { MatButton } from '@angular/material/button';
 import { MatIcon } from '@angular/material/icon';
@@ -156,10 +156,13 @@ export class TimewindowComponent implements ControlValueAccessor {
 
     const triggerRect = (this.nativeElement.nativeElement as HTMLElement).getBoundingClientRect();
     const preferRight = (triggerRect.left + triggerRect.right) / 2 > window.innerWidth / 2;
-    const positions = preferRight
-      ? [POSITION_MAP.bottomRight, POSITION_MAP.bottomLeft, POSITION_MAP.topRight, POSITION_MAP.topLeft,
-         POSITION_MAP.left, POSITION_MAP.right]
-      : DEFAULT_OVERLAY_POSITIONS;
+    const preferTop = (triggerRect.top + triggerRect.bottom) / 2 > window.innerHeight / 2;
+    const verticalOrder = preferTop ? ['top', 'bottom'] : ['bottom', 'top'];
+    const horizontalOrder = preferRight ? ['Right', 'Left'] : ['Left', 'Right'];
+    const positions = [
+      ...verticalOrder.flatMap(vertical => horizontalOrder.map(horizontal => POSITION_MAP[`${vertical}${horizontal}`])),
+      POSITION_MAP.left, POSITION_MAP.right
+    ];
     config.positionStrategy = this.overlay.position()
       .flexibleConnectedTo(this.nativeElement)
       .withFlexibleDimensions(true)

--- a/ui-ngx/src/app/shared/models/chart.model.ts
+++ b/ui-ngx/src/app/shared/models/chart.model.ts
@@ -301,7 +301,8 @@ export function buildEChartsOption(params: BuildOptionParams): EChartsOption {
           const m = moment(value);
           const text = m.format(xFormat.formatPattern);
           if (compact) {
-            return text;
+            // en-spaces enlarge the label box so hideOverlap keeps a gap between adjacent labels
+            return `\u2002${text}\u2002`;
           }
           let isMajor = false;
           if (xFormat.unit === 'second') {
@@ -332,6 +333,7 @@ export function buildEChartsOption(params: BuildOptionParams): EChartsOption {
       axisLabel: {
         color: tbColors.axisLabel,
         fontSize: compact ? 9 : 11,
+        hideOverlap: true,
         formatter: (value: number) => {
           if (Number.isInteger(value)) {
             return new Intl.NumberFormat('en', { notation: 'compact' }).format(value);


### PR DESCRIPTION
Fixes for QA board cards:

- **#115** — Home monitoring charts: run ResizeObserver height recalculation inside the Angular zone so charts resize correctly after exiting fullscreen (`5ade741c8`)
- **#117** — Home Broker settings card: remove redundant vertical scrollbar caused by the Material icon-button touch target and flex row shrinking (`b3efe3d65`)
- **#72** — Timewindow panel: deterministically open above the trigger when it is in the lower half of the viewport, so the Update button is always reachable (`648a18f26`)
- **#119** — Datetime picker: honor the requested display format in `CustomDateAdapter` so the calendar header no longer duplicates the time label (`f12e12f88`)
- **#116** — Compact monitoring charts: prevent overlapping y-axis labels (`hideOverlap`) and edge-to-edge x-axis timestamps on small screens (`370c7a8b3`)