### PR TITLE
UI fixes for QA-reported issues

### DIFF
--- a/ui-ngx/src/app/core/services/dialog.service.ts
+++ b/ui-ngx/src/app/core/services/dialog.service.ts
@@ -106,7 +106,8 @@ export class DialogService {
       this.dialog.open<GettingStartedGuideDialogComponent>(
         GettingStartedGuideDialogComponent, {
           disableClose: true,
-          panelClass: ['tb-dialog', 'tb-fullscreen-dialog']
+          panelClass: ['tb-dialog', 'tb-fullscreen-dialog'],
+          autoFocus: false
         })
         .afterClosed()
         .subscribe();

--- a/ui-ngx/src/app/modules/home/components/home/advanced-settings.component.scss
+++ b/ui-ngx/src/app/modules/home/components/home/advanced-settings.component.scss
@@ -63,6 +63,7 @@
     grid-template-columns: 1fr 1fr;
     align-items: center;
     min-height: 32px;
+    flex-shrink: 0;
 
     &:last-child {
       border-bottom: none;
@@ -97,6 +98,11 @@
     height: 32px;
     padding: 4px;
     color: rgba(0, 0, 0, 0.54);
+
+    ::ng-deep .mat-mdc-button-touch-target {
+      width: 32px;
+      height: 32px;
+    }
   }
 
   .auth-status {

--- a/ui-ngx/src/app/modules/home/components/home/charts.component.ts
+++ b/ui-ngx/src/app/modules/home/components/home/charts.component.ts
@@ -14,7 +14,7 @@
 /// limitations under the License.
 ///
 
-import { Component, ElementRef, OnInit, viewChild } from '@angular/core';
+import { Component, ElementRef, NgZone, OnDestroy, OnInit, viewChild } from '@angular/core';
 import { TranslateModule } from '@ngx-translate/core';
 import { Timewindow } from '@shared/models/time/time.models';
 import { TimeService } from '@core/services/time.service';
@@ -31,7 +31,7 @@ import { ConfigService } from '@core/http/config.service';
   styleUrls: ['./charts.component.scss'],
   imports: [CardTitleButtonComponent, FormsModule, TranslateModule, ChartComponent]
 })
-export class ChartsComponent implements OnInit {
+export class ChartsComponent implements OnInit, OnDestroy {
 
   readonly homeChartsContainer = viewChild<ElementRef>('homeChartsContainer');
   readonly chartsGrid = viewChild<ElementRef>('chartsGrid');
@@ -52,15 +52,22 @@ export class ChartsComponent implements OnInit {
   chartHeight: number;
   timewindow: Timewindow;
 
+  private resizeObserver: ResizeObserver;
+
   constructor(
     private timeService: TimeService,
     private configService: ConfigService,
+    private zone: NgZone,
   ) {
   }
 
   ngOnInit() {
     this.setTimewindow();
     this.onResize();
+  }
+
+  ngOnDestroy() {
+    this.resizeObserver?.disconnect();
   }
 
   private setTimewindow() {
@@ -70,23 +77,25 @@ export class ChartsComponent implements OnInit {
 
   private onResize() {
     const tallLayout = window.matchMedia('screen and (min-width: 1280px)');
-    const resizeObserver = new ResizeObserver(() => {
-      const containerEl = this.homeChartsContainer().nativeElement as HTMLElement;
-      const gridEl = this.chartsGrid().nativeElement as HTMLElement;
-      const w = containerEl.getBoundingClientRect().width;
-      const br = 1700;
-      const correlation = w > br ? ((w - br) / 10000) + 1.4 : 1;
-      const widthBased = Math.round((w / 10) * correlation);
-      if (!tallLayout.matches) {
-        this.chartHeight = widthBased;
-        return;
-      }
-      const chartOverhead = 32;
-      const firstItem = gridEl.firstElementChild as HTMLElement | null;
-      const itemHeight = firstItem?.getBoundingClientRect().height ?? 0;
-      const heightBased = Math.floor(itemHeight) - chartOverhead;
-      this.chartHeight = heightBased > 0 ? heightBased : widthBased;
+    this.resizeObserver = new ResizeObserver(() => {
+      this.zone.run(() => {
+        const containerEl = this.homeChartsContainer().nativeElement as HTMLElement;
+        const gridEl = this.chartsGrid().nativeElement as HTMLElement;
+        const w = containerEl.getBoundingClientRect().width;
+        const br = 1700;
+        const correlation = w > br ? ((w - br) / 10000) + 1.4 : 1;
+        const widthBased = Math.round((w / 10) * correlation);
+        if (!tallLayout.matches) {
+          this.chartHeight = widthBased;
+          return;
+        }
+        const chartOverhead = 32;
+        const firstItem = gridEl.firstElementChild as HTMLElement | null;
+        const itemHeight = firstItem?.getBoundingClientRect().height ?? 0;
+        const heightBased = Math.floor(itemHeight) - chartOverhead;
+        this.chartHeight = heightBased > 0 ? heightBased : widthBased;
+      });
     });
-    resizeObserver.observe(this.homeChartsContainer().nativeElement);
+    this.resizeObserver.observe(this.homeChartsContainer().nativeElement);
   }
 }

--- a/ui-ngx/src/app/shared/adapter/custom-datetime-adapter.ts
+++ b/ui-ngx/src/app/shared/adapter/custom-datetime-adapter.ts
@@ -24,6 +24,9 @@ export class CustomDateAdapter extends NativeDatetimeAdapter {
     if (!this.isValid(date)) {
       return '';
     }
+    if (!displayFormat?.day || !displayFormat?.hour) {
+      return super.format(date, displayFormat);
+    }
     const dtf = new Intl.DateTimeFormat(this.locale, {
       day: '2-digit',
       month: '2-digit',

--- a/ui-ngx/src/app/shared/components/json-object-edit.component.ts
+++ b/ui-ngx/src/app/shared/components/json-object-edit.component.ts
@@ -133,7 +133,7 @@ export class JsonObjectEditComponent implements OnInit, ControlValueAccessor, Va
         this.jsonEditor = ace.edit(editorElement, editorOptions);
         this.jsonEditor.session.setUseWrapMode(false);
         this.jsonEditor.setValue(this.contentValue ? this.contentValue : '', -1);
-        this.jsonEditor.setReadOnly(this.disabled() || this.readonly());
+        this.updateEditorReadonlyState();
         this.jsonEditor.on('change', () => {
           if (!this.ignoreChange) {
             this.cleanupJsonErrors();
@@ -178,8 +178,30 @@ export class JsonObjectEditComponent implements OnInit, ControlValueAccessor, Va
   setDisabledState(isDisabled: boolean): void {
     this.disabled.set(isDisabled);
     if (this.jsonEditor) {
-      this.jsonEditor.setReadOnly(this.disabled() || this.readonly());
+      this.updateEditorReadonlyState();
     }
+  }
+
+  private updateEditorReadonlyState(): void {
+    const readOnly = this.disabled() || this.readonly();
+    this.jsonEditor.setReadOnly(readOnly);
+    this.jsonEditor.container.style.pointerEvents = readOnly ? 'none' : '';
+    this.jsonEditor.container.style.opacity = readOnly ? '0.6' : '';
+    if (readOnly) {
+      this.jsonEditor.blur();
+      this.clearBracketHighlight();
+    }
+  }
+
+  private clearBracketHighlight(): void {
+    // ace re-adds the matching-bracket markers asynchronously after every cursor change
+    setTimeout(() => {
+      const session = this.jsonEditor?.session as any;
+      if (session?.$bracketHighlight) {
+        session.$bracketHighlight.markerIds.forEach((id: number) => session.removeMarker(id));
+        session.$bracketHighlight = null;
+      }
+    });
   }
 
   public validate(c: UntypedFormControl) {
@@ -236,6 +258,9 @@ export class JsonObjectEditComponent implements OnInit, ControlValueAccessor, Va
       this.ignoreChange = true;
       this.jsonEditor.setValue(this.contentValue ? this.contentValue : '', -1);
       this.ignoreChange = false;
+      if (this.disabled() || this.readonly()) {
+        this.clearBracketHighlight();
+      }
     }
   }
 

--- a/ui-ngx/src/app/shared/components/time/timewindow.component.ts
+++ b/ui-ngx/src/app/shared/components/time/timewindow.component.ts
@@ -52,7 +52,7 @@ import { coerceBooleanProperty } from '@angular/cdk/coercion';
 import { Overlay, OverlayConfig, OverlayRef } from '@angular/cdk/overlay';
 import { ComponentPortal } from '@angular/cdk/portal';
 import { coerceBoolean } from '@shared/decorators/coercion';
-import { DEFAULT_OVERLAY_POSITIONS, POSITION_MAP } from '@shared/models/overlay.models';
+import { POSITION_MAP } from '@shared/models/overlay.models';
 import { fromEvent } from 'rxjs';
 import { MatButton } from '@angular/material/button';
 import { MatIcon } from '@angular/material/icon';
@@ -156,10 +156,13 @@ export class TimewindowComponent implements ControlValueAccessor {
 
     const triggerRect = (this.nativeElement.nativeElement as HTMLElement).getBoundingClientRect();
     const preferRight = (triggerRect.left + triggerRect.right) / 2 > window.innerWidth / 2;
-    const positions = preferRight
-      ? [POSITION_MAP.bottomRight, POSITION_MAP.bottomLeft, POSITION_MAP.topRight, POSITION_MAP.topLeft,
-         POSITION_MAP.left, POSITION_MAP.right]
-      : DEFAULT_OVERLAY_POSITIONS;
+    const preferTop = (triggerRect.top + triggerRect.bottom) / 2 > window.innerHeight / 2;
+    const verticalOrder = preferTop ? ['top', 'bottom'] : ['bottom', 'top'];
+    const horizontalOrder = preferRight ? ['Right', 'Left'] : ['Left', 'Right'];
+    const positions = [
+      ...verticalOrder.flatMap(vertical => horizontalOrder.map(horizontal => POSITION_MAP[`${vertical}${horizontal}`])),
+      POSITION_MAP.left, POSITION_MAP.right
+    ];
     config.positionStrategy = this.overlay.position()
       .flexibleConnectedTo(this.nativeElement)
       .withFlexibleDimensions(true)

--- a/ui-ngx/src/app/shared/models/chart.model.ts
+++ b/ui-ngx/src/app/shared/models/chart.model.ts
@@ -301,7 +301,8 @@ export function buildEChartsOption(params: BuildOptionParams): EChartsOption {
           const m = moment(value);
           const text = m.format(xFormat.formatPattern);
           if (compact) {
-            return text;
+            // en-spaces enlarge the label box so hideOverlap keeps a gap between adjacent labels
+            return `\u2002${text}\u2002`;
           }
           let isMajor = false;
           if (xFormat.unit === 'second') {
@@ -332,6 +333,7 @@ export function buildEChartsOption(params: BuildOptionParams): EChartsOption {
       axisLabel: {
         color: tbColors.axisLabel,
         fontSize: compact ? 9 : 11,
+        hideOverlap: true,
         formatter: (value: number) => {
           if (Number.isInteger(value)) {
             return new Intl.NumberFormat('en', { notation: 'compact' }).format(value);

--- a/ui-ngx/src/app/shared/models/chart.model.ts
+++ b/ui-ngx/src/app/shared/models/chart.model.ts
@@ -406,7 +406,7 @@ export function buildSeries(
     emphasis: {
       lineStyle: { width: 4 },
     },
-    data: (data ?? []).map(d => [d.ts, d.value] as [number, number]),
+    data: (data ?? []).map(d => [d.ts, d.value] as [number, number]).sort((a, b) => a[0] - b[0]),
     z: 2,
     silent: !visible,
   };


### PR DESCRIPTION
Fixes for UI issues reported on the QA board:

- fix: render json editor as non-interactive and visually disabled in view mode
- fix: disable getting started dialog autofocus to prevent scroll on open
- fix: sort chart series data ascending so dataZoom preview matches the main chart
- fix: prevent overlapping axis labels on compact monitoring charts
- fix: remove duplicate time label in datetime picker header
- fix: open timewindow panel above trigger in lower half of viewport
- fix: remove redundant scrollbar in home broker settings card
- fix: run home monitoring charts resize recalculation inside Angular zone