### PR TITLE
fix(startup): keep the session cache live during the subscriptions init load

### DIFF
--- a/application/src/main/java/org/thingsboard/mqtt/broker/actors/client/service/BrokerInitializer.java
+++ b/application/src/main/java/org/thingsboard/mqtt/broker/actors/client/service/BrokerInitializer.java
@@ -99,10 +99,11 @@ public class BrokerInitializer {
         log.info("Initializing Client Sessions and Subscriptions.");
         try {
             initIntegrationLifecycleEventCache();
-            Map<String, ClientSessionInfo> allClientSessions = initClientSessions();
-            initClientSubscriptions(allClientSessions);
 
+            initClientSessions();
             clientSessionService.startListening(clientSessionConsumer);
+
+            initClientSubscriptions();
             clientSubscriptionService.startListening(clientSubscriptionConsumer);
 
             initRetainedMessages();
@@ -205,21 +206,20 @@ public class BrokerInitializer {
         log.info("All client-session-dependent consumers have started.");
     }
 
-    void initClientSubscriptions(Map<String, ClientSessionInfo> allClientSessions) throws QueuePersistenceException {
+    void initClientSubscriptions() throws QueuePersistenceException {
         Map<SubscriptionsSourceKey, Set<TopicSubscription>> allClientSubscriptions = clientSubscriptionConsumer.initLoad();
         log.info("Loaded {} stored client subscriptions from Kafka.", allClientSubscriptions.size());
 
-        removeSubscriptionIfSessionIsAbsent(allClientSessions, allClientSubscriptions);
+        removeSubscriptionIfSessionIsAbsent(allClientSubscriptions);
 
         log.info("Initializing SubscriptionManager with {} client subscriptions.", allClientSubscriptions.size());
         clientSubscriptionService.init(allClientSubscriptions);
     }
 
-    private void removeSubscriptionIfSessionIsAbsent(Map<String, ClientSessionInfo> allClientSessions,
-                                                     Map<SubscriptionsSourceKey, Set<TopicSubscription>> allClientSubscriptions) {
+    private void removeSubscriptionIfSessionIsAbsent(Map<SubscriptionsSourceKey, Set<TopicSubscription>> allClientSubscriptions) {
         for (SubscriptionsSourceKey sourceKey : new HashSet<>(allClientSubscriptions.keySet())) {
             if (MQTT_CLIENT.equals(sourceKey.getSource())) {
-                if (!allClientSessions.containsKey(sourceKey.getId())) {
+                if (clientSessionService.getClientSessionInfo(sourceKey.getId()) == null) {
                     allClientSubscriptions.remove(sourceKey);
                 }
             }

--- a/application/src/test/java/org/thingsboard/mqtt/broker/actors/client/service/BrokerInitializerTest.java
+++ b/application/src/test/java/org/thingsboard/mqtt/broker/actors/client/service/BrokerInitializerTest.java
@@ -21,6 +21,7 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.InOrder;
 import org.springframework.boot.context.event.ApplicationReadyEvent;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
@@ -75,6 +76,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -286,24 +288,33 @@ public class BrokerInitializerTest {
         ));
         when(clientSubscriptionConsumer.initLoad()).thenReturn(map);
 
-        brokerInitializer.initClientSubscriptions(Map.of());
+        brokerInitializer.initClientSubscriptions();
 
         verify(clientSubscriptionConsumer).initLoad();
         verify(clientSubscriptionService).init(eq(Map.of()));
     }
 
+    /**
+     * Sessions are resolved against the live cache, not against the map the sessions init load returned: a client
+     * that connected on another node after that load is in the cache but not in the snapshot, and dropping its
+     * subscription here would lose it for good - the subscriptions consumer resumes past the message that
+     * carried it.
+     */
     @Test
     public void testInitClientSubscriptions() throws QueuePersistenceException {
         Map<SubscriptionsSourceKey, Set<TopicSubscription>> map = new HashMap<>(Map.of(
                 SubscriptionsSourceKey.newInstance("clientId1"), Set.of(new ClientTopicSubscription("#")),
                 SubscriptionsSourceKey.newInstance("clientId2"), Set.of(new ClientTopicSubscription("test/#"), new ClientTopicSubscription("temp/#"))
         ));
+        Map<SubscriptionsSourceKey, Set<TopicSubscription>> expected = Map.copyOf(map);
         when(clientSubscriptionConsumer.initLoad()).thenReturn(map);
+        prepareSessions().forEach((clientId, session) ->
+                when(clientSessionService.getClientSessionInfo(clientId)).thenReturn(session));
 
-        brokerInitializer.initClientSubscriptions(prepareSessions());
+        brokerInitializer.initClientSubscriptions();
 
         verify(clientSubscriptionConsumer).initLoad();
-        verify(clientSubscriptionService).init(eq(map));
+        verify(clientSubscriptionService).init(eq(expected));
     }
 
     @Test
@@ -334,6 +345,20 @@ public class BrokerInitializerTest {
         verify(basicDownLinkConsumer).startConsuming();
         verify(persistentDownLinkConsumer).startConsuming();
         verify(internodeNotificationsConsumer).startConsuming();
+    }
+
+    @Test
+    public void testOnApplicationEventStartsSessionListenerBeforeSubscriptionsInitLoad() throws QueuePersistenceException {
+        ApplicationReadyEvent readyEvent = mock(ApplicationReadyEvent.class);
+        brokerInitializer.onApplicationEvent(readyEvent);
+
+        // The subscriptions init load can run for minutes. If the session cache stays frozen for that long,
+        // subscriptions of clients that connected meanwhile arrive before their sessions do, and
+        // SharedSubscriptionCacheServiceImpl.put() silently drops a subscription whose session it cannot find.
+        InOrder inOrder = inOrder(clientSessionService, clientSubscriptionConsumer);
+        inOrder.verify(clientSessionService).init(anyMap());
+        inOrder.verify(clientSessionService).startListening(any());
+        inOrder.verify(clientSubscriptionConsumer).initLoad();
     }
 
 }


### PR DESCRIPTION
## Pull Request description

Two client subscriptions could be lost at broker startup, both because the node-local session cache is frozen for the whole duration of the subscriptions init load — which can run for minutes at scale.

**1. Shared subscription dropped by the cache (listener path)**

`BrokerInitializer` started the session consumer only after the subscriptions init load had finished, so both consumers began listening at roughly the same moment. At that point the session consumer had a backlog stretching back to before the load, while the subscriptions consumer had none. The subscriptions backlog therefore drained first, and a shared subscription for a client that connected during the load reached the cache before its session did — `SharedSubscriptionCacheServiceImpl.put()` silently returns when it cannot find the client session, so the subscription never made it into `sharedSubscriptionsMap`.

Fix: start `clientSessionService.startListening(clientSessionConsumer)` *before* the subscriptions init load, so the session cache is kept current while the load runs.

**2. Subscription dropped by the orphan filter (init path)**

`removeSubscriptionIfSessionIsAbsent()` filtered against the map returned by the sessions init load. Both init loads stop at a sentinel message the node writes itself, and the sessions sentinel is written first — so the sessions snapshot is cut well before the subscriptions snapshot. A client that connected on another node in between has its subscription inside the subscriptions snapshot but its session outside the sessions snapshot, and the filter removed it. That loss is permanent: the subscriptions consumer resumes past the message that carried the subscription, so it is never replayed and this node routes nothing to that subscriber until it resubscribes.

Fix: resolve sessions against the live session cache (`clientSessionService.getClientSessionInfo(...)`), which fix 1 now keeps current for exactly this window. The per-key lookup is used rather than `getAllClientSessions()`, which copies the largest map in the broker. The filter still does its original job of dropping subscriptions left behind by sessions that are really gone.

**Scope of changes**

- `BrokerInitializer.onApplicationEvent` — session listener starts before `initClientSubscriptions()`.
- `BrokerInitializer.initClientSubscriptions` / `removeSubscriptionIfSessionIsAbsent` — the session-snapshot parameter is dropped; sessions are resolved against the live cache.

Node-local startup ordering only. No API, schema, config or protocol change, so it is backward compatible and needs no upgrade script.

**Documentation**

None needed — no user-facing surface changes.

## General checklist

- [x] You have reviewed the guidelines [document](https://docs.google.com/document/d/1A4Vc3wrHsY_159b9RG5LOtCryoH6VPwgOhrFEzJKwbI/edit?usp=sharing).
- [x] [Labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels#about-labels) that classify your pull request have been added.
- [x] The [milestone](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones) is specified and corresponds to fix version.
- [x] Description references specific [issue](https://github.com/thingsboard/tbmq/issues).
- [x] Description contains human-readable scope of changes.
- [x] Description contains brief notes about what needs to be added to the documentation.
- [x] No merge conflicts, commented blocks of code, code formatting issues.
- [x] Changes are backward compatible or upgrade script is provided.

## Front-End feature checklist

- [x] Screenshots with affected component(s) are added. The best option is to provide 2 screens: before and after changes;
- [x] If you change the widget or other API, ensure it is backward-compatible or upgrade script is present.

## Back-End feature checklist

- [x] Added corresponding unit and/or integration test(s). Provide written explanation in the PR description if you have failed to add tests.
- [x] If new dependency was added: the dependency tree is checked for conflicts.

Tests: `BrokerInitializerTest.testOnApplicationEventStartsSessionListenerBeforeSubscriptionsInitLoad` pins the consumer ordering, and `testInitClientSubscriptions` now asserts retention against the live cache with no snapshot passed in. Both were verified to fail against the previous implementation before the fix was written. Full class: 12/12 green.
